### PR TITLE
fix(#34627): forward Authorization header from original request on re…

### DIFF
--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -143,6 +143,13 @@ RCT_EXPORT_MODULE()
 
   NSArray<NSHTTPCookie *> *cookies = [[NSHTTPCookieStorage sharedHTTPCookieStorage] cookiesForURL:request.URL];
   nextRequest.allHTTPHeaderFields = [NSHTTPCookie requestHeaderFieldsWithCookies:cookies];
+
+  NSString *originalAuthorizationHeader = [task.originalRequest valueForHTTPHeaderField:@"Authorization"];
+
+  // Forward the original Authorization header if set
+  if (originalAuthorizationHeader) {
+    [nextRequest addValue:originalAuthorizationHeader forHTTPHeaderField:@"Authorization" ];
+  }
   completionHandler(nextRequest);
 }
 


### PR DESCRIPTION
…direct

## Fix https://github.com/facebook/react-native/issues/34627

## Summary:

IOS Specific issue.
HTTP Authorization header is not passed to the sub-request when server responds with a 3xx code

## Changelog:

[IOS] [FIXED] - Forward Authorization header from original request on redirect

## Test Plan
1. Start a bare project
2. Install axios
3. Create a simple http server with 2 endpoints where:
- Both endpoints requires authentication (using jwt for example)
- Endpoint A returns a redirect 307 to endpoint B
4.  Trigger an axios request to endpoint A
- Expected 200 response code from endpoint B
- Actual 401 response code from endpoint B 

## Additional information

It would be nice to have a little bit more control on this rule. Maybe limit header forwarding to urls with the same origin, or it applies if and only if an option is set at request creation (ex: `forwardHeadersOnRedirect: true`) 