### PR TITLE
Update types for `require` and `require.context`

### DIFF
--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -171,7 +171,7 @@ declare global {
      * @see https://github.com/facebook/metro/pull/822
      * @see https://webpack.js.org/guides/dependency-management/#requirecontext
      */
-    context(
+    context?(
       directory: string,
       useSubdirectories?: boolean,
       regExp?: RegExp,

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -161,11 +161,38 @@ export * from './public/ReactNativeTypes';
 import type {ErrorUtils} from '../Libraries/vendor/core/ErrorUtils';
 
 declare global {
-  interface NodeRequire {
+  interface ReactNativeRequire {
     (id: string): any;
+    /**
+     * Instructs Metro to generate a virtual module in the dependency graph,
+     * with dependencies on every file in the file map that matches the context params.
+     * This can be used to perform dynamic imports from files on disk at build time.
+     * @note Metro parses for `require.context()` calls in the code while building.
+     * @see https://github.com/facebook/metro/pull/822
+     * @see https://webpack.js.org/guides/dependency-management/#requirecontext
+     */
+    context(
+      directory: string,
+      useSubdirectories?: boolean,
+      regExp?: RegExp,
+      mode?: 'sync' | 'lazy',
+    ): MetroRequireContext;
   }
 
-  var require: NodeRequire;
+  /**
+   * Returned from `require.context` provided by Metro.
+   * @see https://github.com/facebook/metro/pull/822
+   * @see https://webpack.js.org/guides/dependency-management/#requirecontext
+   */
+  interface MetroRequireContext {
+    (id: string): any;
+    /**
+     * @return an array of all possible requests that the context module can handle.
+     */
+    keys(): string[];
+  }
+
+  var require: ReactNativeRequire;
 
   /**
    * Console polyfill


### PR DESCRIPTION
## Summary:

It's been 1½ years since the merge of https://github.com/facebook/metro/pull/822 and my hope is that this feature is ready to be documented and made available through types.

## Changelog:

[GENERAL] [ADDED] - Added types for `require.context`, which is provided by Metro at build time.

## Test Plan:

I've tested this manually in a project.
