### PR TITLE
Fix adjustsFontSizeToFit on new arch

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7390,7 +7390,7 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	public fun setIncludeFontPadding (Z)V
 	public fun setLetterSpacing (F)V
 	public fun setLinkifyMask (I)V
-	public fun setMinimumFontSize (F)V
+	public fun setMinimumFontScale (F)V
 	public fun setNotifyOnInlineViewLayout (Z)V
 	public fun setNumberOfLines (I)V
 	public fun setOverflow (Ljava/lang/String;)V
@@ -7606,7 +7606,7 @@ public class com/facebook/react/views/text/TextLayoutManager {
 	public static final field PA_KEY_INCLUDE_FONT_PADDING S
 	public static final field PA_KEY_MAXIMUM_FONT_SIZE S
 	public static final field PA_KEY_MAX_NUMBER_OF_LINES S
-	public static final field PA_KEY_MINIMUM_FONT_SIZE S
+	public static final field PA_KEY_MINIMUM_FONT_SCALE S
 	public static final field PA_KEY_TEXT_BREAK_STRATEGY S
 	public fun <init> ()V
 	public static fun adjustSpannableFontToFit (Landroid/text/Spannable;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;DIZIILandroid/text/Layout$Alignment;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -63,7 +63,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private TextUtils.TruncateAt mEllipsizeLocation;
   private boolean mAdjustsFontSizeToFit;
   private float mFontSize;
-  private float mMinimumFontSize;
+  private float mMinimumFontScale;
   private float mLetterSpacing;
   private int mLinkifyMaskType;
   private boolean mNotifyOnInlineViewLayout;
@@ -99,7 +99,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mShouldAdjustSpannableFontSize = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
     mFontSize = Float.NaN;
-    mMinimumFontSize = Float.NaN;
+    mMinimumFontScale = 0.f;
     mLetterSpacing = 0.f;
 
     mSpanned = null;
@@ -371,7 +371,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
           YogaMeasureMode.EXACTLY,
           getHeight(),
           YogaMeasureMode.EXACTLY,
-          mMinimumFontSize,
+          mMinimumFontScale,
           mNumberOfLines,
           getIncludeFontPadding(),
           getBreakStrategy(),
@@ -623,8 +623,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     applyTextAttributes();
   }
 
-  public void setMinimumFontSize(float minimumFontSize) {
-    mMinimumFontSize = minimumFontSize;
+  public void setMinimumFontScale(float minimumFontScale) {
+    mMinimumFontScale = minimumFontScale;
     mShouldAdjustSpannableFontSize = true;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -154,11 +154,11 @@ public class ReactTextViewManager
     view.setSpanned(spanned);
 
     try {
-      float minimumFontSize =
-          (float) paragraphAttributes.getDouble(TextLayoutManager.PA_KEY_MINIMUM_FONT_SIZE);
-      view.setMinimumFontSize(minimumFontSize);
+      float minimumFontScale =
+          (float) paragraphAttributes.getDouble(TextLayoutManager.PA_KEY_MINIMUM_FONT_SCALE);
+      view.setMinimumFontScale(minimumFontScale);
     } catch (IllegalArgumentException e) {
-      // T190482857: We see rare crash with MapBuffer without PA_KEY_MINIMUM_FONT_SIZE entry
+      // T190482857: We see rare crash with MapBuffer without PA_KEY_MINIMUM_FONT_SCALE entry
       FLog.e(
           TAG,
           "Paragraph Attributes: %s",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -77,8 +77,7 @@ public class TextLayoutManager {
   public static final short PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
   public static final short PA_KEY_INCLUDE_FONT_PADDING = 4;
   public static final short PA_KEY_HYPHENATION_FREQUENCY = 5;
-  public static final short PA_KEY_MINIMUM_FONT_SIZE = 6;
-  public static final short PA_KEY_MAXIMUM_FONT_SIZE = 7;
+  public static final short PA_KEY_MINIMUM_FONT_SCALE = 6;
 
   private static final boolean ENABLE_MEASURE_LOGGING = ReactBuildConfig.DEBUG && false;
 
@@ -428,7 +427,7 @@ public class TextLayoutManager {
       YogaMeasureMode widthYogaMeasureMode,
       float height,
       YogaMeasureMode heightYogaMeasureMode,
-      double minimumFontSizeAttr,
+      double minimumFontScaleAttr,
       int maximumNumberOfLines,
       boolean includeFontPadding,
       int textBreakStrategy,
@@ -446,18 +445,15 @@ public class TextLayoutManager {
             hyphenationFrequency,
             alignment);
 
-    // Minimum font size is 4pts to match the iOS implementation.
-    int minimumFontSize =
-        (int)
-            (Double.isNaN(minimumFontSizeAttr) ? PixelUtil.toPixelFromDIP(4) : minimumFontSizeAttr);
-
-    // Find the largest font size used in the spannable to use as a starting point.
-    int currentFontSize = minimumFontSize;
+    // Find the largest font size used in the spanable to use as a starting point.
+    int currentFontSize = 0;
     ReactAbsoluteSizeSpan[] spans = text.getSpans(0, text.length(), ReactAbsoluteSizeSpan.class);
     for (ReactAbsoluteSizeSpan span : spans) {
       currentFontSize = Math.max(currentFontSize, span.getSize());
     }
 
+    // Minimum font size is 4pts to match the iOS implementation.
+    int minimumFontSize = (int) Math.max(minimumFontScaleAttr * currentFontSize, PixelUtil.toPixelFromDIP(4));
     int initialFontSize = currentFontSize;
     while (currentFontSize > minimumFontSize
         && ((maximumNumberOfLines != ReactConstants.UNSET
@@ -534,10 +530,10 @@ public class TextLayoutManager {
     Layout.Alignment alignment = getTextAlignment(attributedString, text);
 
     if (adjustFontSizeToFit) {
-      double minimumFontSize =
-          paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
-              ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
-              : Double.NaN;
+      double minimumFontScale =
+          paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SCALE)
+              ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SCALE)
+              : 0.0;
 
       adjustSpannableFontToFit(
           text,
@@ -545,7 +541,7 @@ public class TextLayoutManager {
           widthYogaMeasureMode,
           height,
           heightYogaMeasureMode,
-          minimumFontSize,
+          minimumFontScale,
           maximumNumberOfLines,
           includeFontPadding,
           textBreakStrategy,
@@ -743,10 +739,10 @@ public class TextLayoutManager {
     Layout.Alignment alignment = getTextAlignment(attributedString, text);
 
     if (adjustFontSizeToFit) {
-      double minimumFontSize =
-          paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE)
-              ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE)
-              : Double.NaN;
+      double minimumFontScale =
+          paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SCALE)
+              ? paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SCALE)
+              : 0.0;
 
       adjustSpannableFontToFit(
           text,
@@ -754,7 +750,7 @@ public class TextLayoutManager {
           YogaMeasureMode.EXACTLY,
           height,
           YogaMeasureMode.UNDEFINED,
-          minimumFontSize,
+          minimumFontScale,
           maximumNumberOfLines,
           includeFontPadding,
           textBreakStrategy,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -29,8 +29,7 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              rhs.adjustsFontSizeToFit,
              rhs.includeFontPadding,
              rhs.android_hyphenationFrequency) &&
-      floatEquality(minimumFontSize, rhs.minimumFontSize) &&
-      floatEquality(maximumFontSize, rhs.maximumFontSize);
+      floatEquality(minimumFontScale, rhs.minimumFontScale);
 }
 
 bool ParagraphAttributes::operator!=(const ParagraphAttributes& rhs) const {
@@ -46,8 +45,7 @@ SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
       debugStringConvertibleItem("ellipsizeMode", ellipsizeMode),
       debugStringConvertibleItem("textBreakStrategy", textBreakStrategy),
       debugStringConvertibleItem("adjustsFontSizeToFit", adjustsFontSizeToFit),
-      debugStringConvertibleItem("minimumFontSize", minimumFontSize),
-      debugStringConvertibleItem("maximumFontSize", maximumFontSize),
+      debugStringConvertibleItem("minimumFontScale", minimumFontScale),
       debugStringConvertibleItem("includeFontPadding", includeFontPadding),
       debugStringConvertibleItem(
           "android_hyphenationFrequency", android_hyphenationFrequency)};

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -64,11 +64,10 @@ class ParagraphAttributes : public DebugStringConvertible {
   HyphenationFrequency android_hyphenationFrequency{};
 
   /*
-   * In case of font size adjustment enabled, defines minimum and maximum
-   * font sizes.
+   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit
+   * is enabled. (values 0.01-1.0).
    */
-  Float minimumFontSize{std::numeric_limits<Float>::quiet_NaN()};
-  Float maximumFontSize{std::numeric_limits<Float>::quiet_NaN()};
+  Float minimumFontScale{0.0};
 
   bool operator==(const ParagraphAttributes&) const;
   bool operator!=(const ParagraphAttributes&) const;
@@ -93,8 +92,7 @@ struct hash<facebook::react::ParagraphAttributes> {
         attributes.ellipsizeMode,
         attributes.textBreakStrategy,
         attributes.adjustsFontSizeToFit,
-        attributes.minimumFontSize,
-        attributes.maximumFontSize,
+        attributes.minimumFontScale,
         attributes.includeFontPadding,
         attributes.android_hyphenationFrequency);
   }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -858,8 +858,7 @@ constexpr static MapBuffer::Key PA_KEY_TEXT_BREAK_STRATEGY = 2;
 constexpr static MapBuffer::Key PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
 constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
-constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
-constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
+constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SCALE = 6;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
   auto builder = MapBufferBuilder();
@@ -878,9 +877,7 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
       PA_KEY_HYPHENATION_FREQUENCY,
       toString(paragraphAttributes.android_hyphenationFrequency));
   builder.putDouble(
-      PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
-  builder.putDouble(
-      PA_KEY_MAXIMUM_FONT_SIZE, paragraphAttributes.maximumFontSize);
+      PA_KEY_MINIMUM_FONT_SCALE, paragraphAttributes.minimumFontScale);
 
   return builder.build();
 }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -762,18 +762,12 @@ inline ParagraphAttributes convertRawProp(
       "adjustsFontSizeToFit",
       sourceParagraphAttributes.adjustsFontSizeToFit,
       defaultParagraphAttributes.adjustsFontSizeToFit);
-  paragraphAttributes.minimumFontSize = convertRawProp(
+  paragraphAttributes.minimumFontScale = convertRawProp(
       context,
       rawProps,
-      "minimumFontSize",
-      sourceParagraphAttributes.minimumFontSize,
-      defaultParagraphAttributes.minimumFontSize);
-  paragraphAttributes.maximumFontSize = convertRawProp(
-      context,
-      rawProps,
-      "maximumFontSize",
-      sourceParagraphAttributes.maximumFontSize,
-      defaultParagraphAttributes.maximumFontSize);
+      "minimumFontScale",
+      sourceParagraphAttributes.minimumFontScale,
+      defaultParagraphAttributes.minimumFontScale);
   paragraphAttributes.includeFontPadding = convertRawProp(
       context,
       rawProps,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -98,14 +98,8 @@ void ParagraphProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
+        minimumFontScale,
+        "minimumFontScale");
     REBUILD_FIELD_SWITCH_CASE(
         paDefaults,
         value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -145,14 +145,8 @@ void BaseTextInputProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
+        minimumFontScale,
+        "minimumFontScale");
     REBUILD_FIELD_SWITCH_CASE(
         paDefaults,
         value,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -167,6 +167,22 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return paragraphLines;
 }
 
+- (CGFloat)_maximumFontSizeInAttributedString:(NSAttributedString *)attributedString
+{
+  __block CGFloat maximumFontSize = 0.0;
+  [attributedString enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedString.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(id _Nullable value, NSRange range, BOOL *_Nonnull stop) {
+                              CGFloat fontSize = ((UIFont *)value).pointSize;
+                              if (fontSize > maximumFontSize) {
+                                maximumFontSize = fontSize;
+                              }
+                            }];
+
+  return maximumFontSize;
+}
+
 - (NSTextStorage *)_textStorageAndLayoutManagerWithAttributesString:(NSAttributedString *)attributedString
                                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                                size:(CGSize)size
@@ -188,8 +204,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   [textStorage addLayoutManager:layoutManager];
 
   if (paragraphAttributes.adjustsFontSizeToFit) {
-    CGFloat minimumFontSize = !isnan(paragraphAttributes.minimumFontSize) ? paragraphAttributes.minimumFontSize : 4.0;
-    CGFloat maximumFontSize = !isnan(paragraphAttributes.maximumFontSize) ? paragraphAttributes.maximumFontSize : 96.0;
+    CGFloat maximumFontSize = [self _maximumFontSizeInAttributedString:attributedString];
+    CGFloat minimumFontSize = MAX(paragraphAttributes.minimumFontScale * maximumFontSize, 4.0);
     [textStorage scaleFontSizeToFitSize:size minimumFontSize:minimumFontSize maximumFontSize:maximumFontSize];
   }
 

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -134,6 +134,22 @@ class AdjustingFontSize extends React.Component<
           style={{fontSize: 36, marginVertical: 6}}>
           Truncated text is baaaaad.
         </Text>
+
+        <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          style={{fontSize: 16, marginVertical: 6}}>
+          It doesn't grow
+        </Text>
+
+        <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.5}
+          style={{fontSize: 40, marginVertical: 6}}>
+          Can limit how small the text becomes with minimumFontScale
+        </Text>
+
         <Text
           numberOfLines={1}
           adjustsFontSizeToFit={true}

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -211,11 +211,27 @@ class AdjustingFontSize extends React.Component<
           style={{fontSize: 36, marginVertical: 6}}>
           Truncated text is baaaaad.
         </Text>
+
         <Text
           numberOfLines={1}
           adjustsFontSizeToFit={true}
           style={{fontSize: 40, marginVertical: 6}}>
           Shrinking to fit available space is much better!
+        </Text>
+
+        <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          style={{fontSize: 16, marginVertical: 6}}>
+          It doesn't grow
+        </Text>
+
+        <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.5}
+          style={{fontSize: 40, marginVertical: 6}}>
+          Can limit how small the text becomes with minimumFontScale
         </Text>
 
         <Text


### PR DESCRIPTION
## Summary:

When using adjustsFontSizeToFit on Fabric the behavior is different from the old renderer. The text will grow bigger than the current font size while on the old renderer it won't. The `minimumFontScale` is also not implemented. The code currently uses `minimumFontSize` and `maximumFontSize` but those props do not actually exist.

This brings the behavior closer to the old renderer by removing the wrong props and implementing `minimumFontScale` instead. From what I understand in the old renderer it would use the font size of the outermost text, but since we don't easily have access to that in Fabric I use the maximum font size of the attributed string.

## Changelog:

[IOS] [FIXED] - Fix adjustsFontSizeToFit on iOS Fabric

## Test Plan:

This adds some example of the different behavior in RNTester

- You can see that on iOS fabric the line `It doesn't grow` grows bigger than its original font size
- You can see that on iOS and Android fabric the line `Can limit how small the text becomes with minimumFontScale` does not respect the minimumFontScale.

### Before

Old renderer iOS:

<img width="324" alt="image" src="https://github.com/facebook/react-native/assets/2677334/b40fcd40-a50e-4f51-a4f8-6bb4a5e66504">

Old renderer Android

<img width="409" alt="image" src="https://github.com/facebook/react-native/assets/2677334/a1cbcfe4-effb-4bc3-83b0-6723e3a655c9">

Fabric iOS:

<img width="324" alt="image" src="https://github.com/facebook/react-native/assets/2677334/d0d42be4-091c-42e2-b7e7-d3a1d0b88aa8">

Fabric Android

<img width="416" alt="image" src="https://github.com/facebook/react-native/assets/2677334/d86364eb-14d5-481f-852d-05f083fb593e">

### After

Fabric iOS:

<img width="325" alt="image" src="https://github.com/facebook/react-native/assets/2677334/f267fc8e-4676-45ef-98d1-b07e7e3f25c5">

Fabric Android:

<img width="410" alt="image" src="https://github.com/facebook/react-native/assets/2677334/edeb7273-15eb-4d9d-9980-0bddde351d37">



