### PR TITLE
fix: don't update text input text directly in setTextAndSelection

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -484,7 +484,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
         [[NSAttributedString alloc] initWithString:value attributes:_backedTextInputView.defaultTextAttributes];
     [self _updateStateWithString:attributedString];
   }
-  
+
   UITextPosition *startPosition = [_backedTextInputView positionFromPosition:_backedTextInputView.beginningOfDocument
                                                                       offset:start];
   UITextPosition *endPosition = [_backedTextInputView positionFromPosition:_backedTextInputView.beginningOfDocument
@@ -495,7 +495,6 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     // _updateStateWithString executes any state updates sync, so its safe to update the selection as the attributedString is already updated!
     [_backedTextInputView setSelectedTextRange:range notifyDelegate:NO];
   }
-  
   _comingFromJS = NO;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is one possible solution to fix the flickering issue described here:

- https://github.com/facebook/react-native/issues/46838

The main fix is that when we receive the view command call `setTextAndSelection` we don't want to update the attributedString on the backing TextField immediately, but update the state of the shadow node.
This way the layout for the view will be calculated with the updated state, and the updated text + updated layout will be applied at once.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Flicker when changing text in a dynamic sized TextInput

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run the tester app and make sure that every TextInput example still works as before

I added another PR which adds an explicit example case to the RNTester app:

- https://github.com/facebook/react-native/pull/46976


| Before changes | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/7571b80b-7035-47df-b840-4218ab0802b5" /> | <video src="https://github.com/user-attachments/assets/60ae35b8-9f34-467f-a24e-af80648316bc" /> | 




