### PR TITLE
Add E2E test for Console.log Measure and Interop Layer Measurements

### DIFF
--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -19,12 +19,12 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 - assertVisible:
     text: "measure x: 0, y: 0, width: 0, height: 0"
 - tapOn: "Console.log Measure"
-- assertNotVisible:
-    text: "measure x: 0, y: 0, width: 0, height: 0"
-- assertNotVisible:
-    text: "InWindow x: 0, y: 0, width: 0, height: 0"
-- assertNotVisible:
-    text: "InLayout x: 0, y: 0, width: 0, height: 0"
+- assertVisible:
+    text: "measure x: 0, y: 134, width: 393, height: 99.67"
+- assertVisible:
+    text: "InWindow x: 0, y: 287.67, width: 393, height: 99.67"
+- assertVisible:
+    text: "InLayout x: 0, y: 134, width: 393, height: 99.67"
 - assertVisible: "Legacy Style Event Fired 0 times"
 - tapOn:
     text: "Fire Legacy Style Event"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
   - hermes-engine/inspector (1000.0.0)
   - hermes-engine/inspector_chrome (1000.0.0)
   - hermes-engine/Public (1000.0.0)
-  - MyNativeView (0.76.0-main):
+  - MyNativeView (0.77.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -36,7 +36,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NativeCxxModuleExample (0.76.0-main):
+  - NativeCxxModuleExample (0.77.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -58,7 +58,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - OCMock (3.9.4)
-  - OSSLibraryExample (0.76.0-main):
+  - OSSLibraryExample (0.77.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1277,6 +1277,7 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-jsi
+    - ReactCommon/turbomodule/bridging
   - React-jsi (1000.0.0):
     - boost
     - DoubleConversion
@@ -1349,6 +1350,7 @@ PODS:
   - React-performancetimeline (1000.0.0):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
+    - React-featureflags
     - React-timing
   - React-RCTActionSheet (1000.0.0):
     - React-Core/RCTActionSheetHeaders (= 1000.0.0)
@@ -1622,7 +1624,7 @@ PODS:
     - React-logger (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - React-utils (= 1000.0.0)
-  - ScreenshotManager (0.76.0-main):
+  - ScreenshotManager (0.77.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1870,79 +1872,79 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  FBLazyVector: c8715bd426ed93c57bb679b549e92f79a823212a
-  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
-  hermes-engine: 18648a751649d9b6ac408579511554a4fbaaccc2
-  MyNativeView: 32eb899a4fc31dbe7e93f356935a7fe56d42d74e
-  NativeCxxModuleExample: 9621f63e90acef88ac37beac4fb841132ad18d86
+  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
+  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  FBLazyVector: d702dba5e761443db760c4cebfa04bc8b5016672
+  fmt: 9020cae7652ac67569a4107a84070539cc62e041
+  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
+  hermes-engine: 1f6b2390b77be58d40ba2011ae2c245d61b95f8a
+  MyNativeView: b7595ccf55431fc4dda10efdb79a8b17d206f4ed
+  NativeCxxModuleExample: 5287f423741538771b120c3e10369006748b5a14
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  OSSLibraryExample: 44a44517ba2b7e99be1ac345942e5c98e3f8d8da
-  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
+  OSSLibraryExample: 35a30a9b326431b9b91b38544c993cffcf8acc6e
+  RCT-Folly: f36a458e49b85ad0f14c37027d3fc83aeb929909
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: 7a8e6a2c361700f9c645216e9991604757b1025c
-  RCTTypeSafety: 27891ddab793e9f45bd427e0063985fa9d1a745c
-  React: 0a852eb3a4778fa382bd4bec1d1102dc95c492ce
-  React-callinvoker: 4857665c23ce7406d949bb95ce3a579620cd35f5
-  React-Core: dab3d3b3713c207cf555cc54f613d72e5dda65dc
-  React-CoreModules: 5d48f1d3a5f01341d5e34b401cf7b099a6834941
-  React-cxxreact: cfad872bd295947124e9d3635b5dc2395037875f
-  React-debug: 8cf17cbbe4db4489da08583fa1219292ab3add3b
-  React-defaultsnativemodule: 8f585662fc9ea76ad1a6f2df50f245e126ea2c1f
-  React-domnativemodule: 6d3248be46d2b94fa9b09e09a5981adb35ec135e
-  React-Fabric: ea21b602bbfe90f63aadf01c069b7f1759d5e2c7
-  React-FabricComponents: c69ec63ffe8b1bf773f85695939d8c21e77b3423
-  React-FabricImage: fcbed58676da40e43f50970d4a3abf7014d4c97c
-  React-featureflags: b8a4c60827c52e3e6b3d331c47964b91226da452
-  React-featureflagsnativemodule: 12af419af8e7cc6e2212fa10d450ec6cc78e3c93
-  React-graphics: c385ac155868a23b0dd4dace94228a0812dd3587
-  React-hermes: bf8bec9c40d4756e74be3bb642dcc636ee0a3376
-  React-idlecallbacksnativemodule: 01b2c90be61e39ea57c5ec8fb40223402f0408a3
-  React-ImageManager: d09977cf41a8af909d776b92150d00066610253e
-  React-jserrorhandler: bf2e4e3e6ea6c903c0dac85d6ef069bdf010073c
-  React-jsi: ca82ba79ab3b28553f3c7cae5d3e6bd61bd0615c
-  React-jsiexecutor: 0bce63803bd83219aa6f5d64ffdd504a407f8f76
-  React-jsinspector: 51698143244af04db8fff1968b6eae92dbc29ef6
-  React-jsitracing: 00126dc737136e1359deabbd064ad3e8d17e30a7
-  React-logger: 7c9f94c18cab8076ed5ab70f4aeeeb1668c44c7d
-  React-Mapbuffer: 5dcd028f06ec61a76e3d2e823033a9d33c948f9d
-  React-microtasksnativemodule: d34bab40ed40aa735326940cfb4d5b1206761431
-  React-nativeconfig: ede29a5b5c88ce9f6e6dfd41b5e6cab57059ebb5
-  React-NativeModulesApple: 36bd93a8e4aded2cc32355a8f3df92b7e97d8edd
-  React-perflogger: 932cd803362f3d58552daafd62bc9ff51ba58021
-  React-performancetimeline: 0b4298173f00277c86e4cb5ee5a7c05d7bc8d4aa
-  React-RCTActionSheet: 036a8aefa14fc19675e9e9f5006dc714bcb46684
-  React-RCTAnimation: 0053c157cbbea286bc2db8835ef4f44b30508cc4
-  React-RCTAppDelegate: 71c4f386c437618dcd5208ce6e8c754293594ad4
-  React-RCTBlob: 037dd4857df7cee67f8f888a7bc50d2b4a92bca5
-  React-RCTFabric: 02213d7cec2c67a050743a23892810e9c0c3f2fd
-  React-RCTImage: 66449efc872f237ccb44a6a3bfd356989a587fe4
-  React-RCTLinking: 16741487b0dc6801cfaa708e64c038a74e9a847d
-  React-RCTNetwork: ff9babb55e055cff13673f16f3d4d538c64df90d
-  React-RCTPushNotification: 03d115747b28a77ae375e0f63e188bf9a1d1d4be
-  React-RCTSettings: 48fc69ff93298efee6611f6983180aafa438b47a
-  React-RCTTest: 5f5e3cd632066b2b798917bd076ba539a30fe415
-  React-RCTText: 11944100c500f4d315616c05ac547535c4dad9aa
-  React-RCTVibration: 9fd4ce9cc2b7dd827dcec09eb502d07a1b076b76
-  React-rendererconsistency: 546e5e6e2cd2452dceae8a1f649a8729459e1ef7
-  React-rendererdebug: ba5a20926f8e0d8de547bad92c88e63910bce590
-  React-rncore: 3a67b832671a341bb3418a8b89a8dc4425b62310
-  React-RuntimeApple: 71457481a74e06a296448a8ac4a9700167a2d241
-  React-RuntimeCore: bf9c9c863e710e4d2938d9bc542501b3cd07fc03
-  React-runtimeexecutor: 5a4b1736b547811ebbf2f5db9e58c9184d6514cd
-  React-RuntimeHermes: 3d83f329b54d2d6accaf7c9d28d6f519857b83b9
-  React-runtimescheduler: 8786b1927836380c443d0fb39af3f10cf80ffd18
-  React-timing: ff1ffa083a1901bf161f7d50950f08c7e07dca90
-  React-utils: 31bd4a7e3141994194048105b704669d2190818c
+  RCTRequired: df81ecde64969eba946394da03ca0fb52cb6b83e
+  RCTTypeSafety: cf332fa814d1ad3f0a5f9c1d92c820305e55fd22
+  React: 0e05b6b2840dc4ca272a7e4656057b8dab5c9f41
+  React-callinvoker: 09811cbc76a7efc8766b5cc6f0ceed582e5998d7
+  React-Core: 9051ce3de858d5f0055e18ba1830c431c80ab476
+  React-CoreModules: 736e4499780d03a54b3d12bf925feb46920a3421
+  React-cxxreact: 7d0adc488f9d17cd87ae5f8c1f2107cc951e977f
+  React-debug: c3532c4b107ef7396b3ace156699709c4502a76c
+  React-defaultsnativemodule: 1887081a8a64e818a7a46e8b9883bab781b8fc1b
+  React-domnativemodule: db8c202c3e27e2dc15ab76a6c090fc63c0ea3f8f
+  React-Fabric: 60b510f33724f45135f8ef952694d88fd837a667
+  React-FabricComponents: 63573ed04c38cc31f230efbf34a265558524518d
+  React-FabricImage: 056d39f63c91eca0d1f3096e7908ccfc3b9a19e3
+  React-featureflags: d24f40bf958bbfdcdcab466d42eda4e3b74a5ce0
+  React-featureflagsnativemodule: bfde5023791d64e78fcffa8ca0c6a163756b1884
+  React-graphics: 891c7fb1b8d3a71a451fa89f89b522bd5c6c9fee
+  React-hermes: c6c57092feee21f0099f069af336e13d16183c5c
+  React-idlecallbacksnativemodule: a114dc3658d8a340b22b6448d0f2583c3520d22a
+  React-ImageManager: 7e2e1ea939b5185a3d6c85231a7d1c48276cb184
+  React-jserrorhandler: 95fce0af5bc5c49676d3c97b0ac9b9cdd8a5cf01
+  React-jsi: 43421f37efe2376a6db2dd6f4df844cc8ddeff8d
+  React-jsiexecutor: ee474e59eb0cd9e1bc493dfa20d27841e364ad00
+  React-jsinspector: c6a90cefcd6fe4579b4379a02807331b4ea911f6
+  React-jsitracing: d4753cdb011382aec5b25d3382cca8ce3c861dba
+  React-logger: 7a2e5b8688eb11e88a972b6bcf719bd4b5842ddf
+  React-Mapbuffer: 9f17c5a9f2d25503e4032b346ee97ffc693fafa6
+  React-microtasksnativemodule: bf36ef555e900e895a22cea73628a954d910b10c
+  React-nativeconfig: 990a1920f0ba104e78fe00fc83f07d787b6b8457
+  React-NativeModulesApple: 37c3de786a69a420b768014f4b7aabbc317f73d2
+  React-perflogger: 7b72a3cc21c6f9e1a49a8817c22a7c18619e4577
+  React-performancetimeline: 6d5171a24d367efb44ac5b1b27b4420091ad1433
+  React-RCTActionSheet: aac8d9ea035e600846c962adb9b5add7868a0672
+  React-RCTAnimation: 9eee6aa9c1de74292801db46b4822c7260ac389e
+  React-RCTAppDelegate: 6055b6e3726152ee0775b3c0ec9ec5159e1d78c0
+  React-RCTBlob: 89394043708b4aafdd604bd29eaf4a9bcc0a2e2c
+  React-RCTFabric: 3c01037fde6fa87af39e17f5881d19f67038076e
+  React-RCTImage: e1d8c2bd0819565d0c473149f99be9520ae3143c
+  React-RCTLinking: 598ea361da9d2e70e809eef7707a3873d845cc82
+  React-RCTNetwork: d4acabb11841ff7c2500fae3f5d0ff7af77b95fe
+  React-RCTPushNotification: 58a30ad99254d039d1e808ab999b407b9e721082
+  React-RCTSettings: 06cb7802c256928f714e19f37ad5e97a8dadd4f0
+  React-RCTTest: 88a71f1b830e5583681f397a681cf10b965e82e7
+  React-RCTText: b1f692ebaa1fa8e5b275d08e7ec659eee2f84f96
+  React-RCTVibration: f537cb5be8f089132cde1ed3c7f0de313fec102b
+  React-rendererconsistency: 6b02b067ffabb9128ed8ecabd8768f8907411fd7
+  React-rendererdebug: 152338bf31075577f06aad782e5fe2c19f5ef7a7
+  React-rncore: 470d3e23e889804797cddee161867481fe99677b
+  React-RuntimeApple: eca4a7ab5f4671362de1258a5f89c115b8d5a7b4
+  React-RuntimeCore: ee4139a9ae5a8305b8f073a4ed3ef43b73953e7c
+  React-runtimeexecutor: eefeb4c5e21f969cf0cce5dff1c034ad0c21403e
+  React-RuntimeHermes: de56f230af33aaee96923d6f1c19709cf802615b
+  React-runtimescheduler: 2655b27d850a8281019bcca5bca86446dfd112cc
+  React-timing: df2de49ce911b6a82f3df48e480af11d1ce75353
+  React-utils: 8c9f9288fb3c0a4eef4494cc9600b33c635c5fe7
   ReactCodegen: 65ce3f3e2bb238505f943941b1cf30b4f5ea9698
-  ReactCommon: 2f7f1a6ac3607b43f524dd6997813075ac06dcfa
-  ReactCommon-Samples: cb52d135304897c4aab596d514d6a44ab1e25b21
-  ScreenshotManager: a3d9db14cd056df5e4a57c3fedee795393246790
+  ReactCommon: ea7cc0a62c1c75c1905f9efc4792683b5e2d0bfb
+  ReactCommon-Samples: 5daa2e701a0dfac587517b02c378bc09752544bb
+  ScreenshotManager: 6385c57a6af8b4474021a51f651ec486d299d191
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: dcc37de9ded9760f3d5dc18865cc15a62bb4884b
+  Yoga: 93aa6d6f28497dd63acaf64d32554ebaa396979e
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2


### PR DESCRIPTION
This PR adds a new end-to-end test in new-arch-example.yml. It taps on the "Console.log Measure" button and verifies that the Interop Layer Measurements are correctly updated. 
Ensures the measurements are correctly reflected in the app's UI.