### PR TITLE
[iOS] Fix paragraph styling of TextInput

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -291,6 +291,14 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
         RCTNSTextAttributesFromTextAttributes(newTextInputProps.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
     defaultAttributes[RCTAttributedStringEventEmitterKey] =
         _backedTextInputView.defaultTextAttributes[RCTAttributedStringEventEmitterKey];
+
+    NSMutableParagraphStyle *paragraphStyle = defaultAttributes[NSParagraphStyleAttributeName];
+
+    if (!newTextInputProps.multiline) {
+        paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
+        defaultAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
+    }
+
     _backedTextInputView.defaultTextAttributes = defaultAttributes;
   }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -292,12 +292,11 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     defaultAttributes[RCTAttributedStringEventEmitterKey] =
         _backedTextInputView.defaultTextAttributes[RCTAttributedStringEventEmitterKey];
 
-    NSMutableParagraphStyle *paragraphStyle = defaultAttributes[NSParagraphStyleAttributeName];
-
-    if (!newTextInputProps.multiline) {
+      if (!newTextInputProps.multiline) {
+        NSMutableParagraphStyle *paragraphStyle = defaultAttributes[NSParagraphStyleAttributeName];
         paragraphStyle.lineBreakMode = NSLineBreakByTruncatingTail;
         defaultAttributes[NSParagraphStyleAttributeName] = paragraphStyle;
-    }
+      }
 
     _backedTextInputView.defaultTextAttributes = defaultAttributes;
   }

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -699,6 +699,27 @@ const textInputExamples: Array<RNTesterModuleExample> = [
               placeholder="Placeholder defines intrinsic size"
             />
           </View>
+          <RNTesterText>Singleline TextInput with text styles</RNTesterText>
+          <View style={{height: 130}}>
+            <ExampleTextInput
+              style={{
+                position: 'absolute',
+                fontSize: 16,
+                backgroundColor: '#eeeeee',
+                borderColor: '#666666',
+                borderWidth: 5,
+                borderTopWidth: 20,
+                borderRadius: 10,
+                borderBottomRightRadius: 20,
+                padding: 10,
+                paddingTop: 20,
+                lineHeight: 18,
+                height: '100%',
+              }}
+              testID="singleline_textinput_with_text_styling"
+              placeholder="Placeholder defines intrinsic size & text styling"
+            />
+          </View>
           <RNTesterText>Multiline TextInput</RNTesterText>
           <View style={{height: 80}}>
             <ExampleTextInput


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Hi, I noticed that on iOS TextInput's value overflows out of the input if we set specific styling. In my case it were `lineHeight` and `height`.  I did a little research and it turned out that we can break TextInput when we set styling related to `ParagraphStyles` , because in that case within `RCTNSTextAttributesFromTextAttributes`  new instance of `NSMutableParagraphStyle` is created with some default values, which includes `lineBreakMode` set to `NSLineBreakByWordWrapping` what is totally fine for multiline TextInput, but it's not for single one.

I decided to add an extra check that  overrides default value of `lineBreakMode`  to make it working correctly even though when paragraph styling props were passed.

This is how it looked like before:
<img width="429" alt="Screenshot 2024-12-03 at 11 31 52" src="https://github.com/user-attachments/assets/795b4507-0b5f-4d77-a67e-5b2acb32d4a0">

After:
<img width="429" alt="Screenshot 2024-12-03 at 12 11 53" src="https://github.com/user-attachments/assets/f04aaab8-6970-4ac4-b775-254ee9f710bd">


## Changelog:

[IOS][FIXED] - all changes that take care of overriding `lineBreakMode` default value are added to `packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm` 

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message



For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

I added an extra example to tester app that is breaks if we set input's value to something long like `This is a very long text value of an input that will overflow the input container if we set specific height and text styling` 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
