### PR TITLE
Bugfix/rootview leak

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -145,7 +145,6 @@ public class ReactDelegate {
   }
 
   public void onHostDestroy() {
-    unloadApp();
     if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onHostDestroy(mActivity);
     } else {
@@ -153,6 +152,7 @@ public class ReactDelegate {
         getReactNativeHost().getReactInstanceManager().onHostDestroy(mActivity);
       }
     }
+    unloadApp();
   }
 
   public boolean onBackPressed() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -172,6 +172,7 @@ public class UIImplementation {
   public void removeRootView(int rootViewTag) {
     removeRootShadowNode(rootViewTag);
     mOperationsQueue.enqueueRemoveRootView(rootViewTag);
+    //if container is destroyed, we need make RemoveRootView Operation do in UIThread
     if (isDestroy) {
       dispatchViewUpdates(-1);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -52,6 +52,8 @@ public class UIImplementation {
   private long mLastCalculateLayoutTime = 0;
   protected @Nullable LayoutUpdateListener mLayoutUpdateListener;
 
+  private boolean isDestroy = false;
+
   /**
    * When react instance is being shutdown, there could be some pending operations queued in the JS
    * thread. This flag ensures view related operations are not triggered if the Catalyst instance
@@ -170,6 +172,9 @@ public class UIImplementation {
   public void removeRootView(int rootViewTag) {
     removeRootShadowNode(rootViewTag);
     mOperationsQueue.enqueueRemoveRootView(rootViewTag);
+    if (isDestroy) {
+      dispatchViewUpdates(-1);
+    }
   }
 
   /**
@@ -760,14 +765,18 @@ public class UIImplementation {
   }
 
   public void onHostResume() {
+    isDestroy = false;
     mOperationsQueue.resumeFrameCallback();
   }
 
   public void onHostPause() {
+    isDestroy = false;
     mOperationsQueue.pauseFrameCallback();
   }
 
-  public void onHostDestroy() {}
+  public void onHostDestroy() {
+    isDestroy = true;
+  }
 
   public void onCatalystInstanceDestroyed() {
     mViewOperationsEnabled = false;


### PR DESCRIPTION
## Summary:

when we use react-native in our hybrid app, we make more then one ReactInstanceManager instance and every RN page is in new Activity Container. if we reuse the ReactInstanceManager in same business, when Activity Container is destroy, we found the ReactRootView is not removed, so it is leaked.  the key point is previous page is not use this ReactInstanceManager instance.

## Changelog:

[ANDROID][FIXED] - Fix ReactRootView Memory Leak。

## Test Plan:

follow the steps:
1. write a log in `RemoveRootViewOperation.execute()` method 

`Log.i("RN", "RemoveRootViewOperation removeRootView");`

2. install RNTester app
3. open RN page
4. close RN page
5. see the log 

Expect： print `RemoveRootViewOperation removeRootView`.