### PR TITLE
fix: iOS crash when BlobModule is nil in RCTNetworking initialization

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -96,17 +96,25 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDe
           return [@[ [RCTGIFImageDecoder new] ] arrayByAddingObjectsFromArray:imageDataDecoder];
         }];
   } else if (moduleClass == RCTNetworking.class) {
-    return [[moduleClass alloc]
-        initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
+      return [[moduleClass alloc]
+              initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
           NSArray *URLRequestHandlerModules =
-              extractModuleConformingToProtocol(moduleRegistry, @protocol(RCTURLRequestHandler));
-          return [@[
-            [RCTHTTPRequestHandler new],
-            [RCTDataRequestHandler new],
-            [RCTFileRequestHandler new],
-            [moduleRegistry moduleForName:"BlobModule"],
-          ] arrayByAddingObjectsFromArray:URLRequestHandlerModules];
-        }];
+          extractModuleConformingToProtocol(moduleRegistry, @protocol(RCTURLRequestHandler));
+
+          id blobModule = [moduleRegistry moduleForName:"BlobModule"];
+
+          NSMutableArray *handlers = [NSMutableArray arrayWithCapacity:4];
+          [handlers addObject:[RCTHTTPRequestHandler new]];
+          [handlers addObject:[RCTDataRequestHandler new]];
+          [handlers addObject:[RCTFileRequestHandler new]];
+
+          if (blobModule) {
+              [handlers addObject:blobModule];
+          }
+
+          [handlers addObjectsFromArray:URLRequestHandlerModules];
+          return handlers;
+      }];
   }
   // No custom initializer here.
   return [moduleClass new];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

An iOS crash occurs during networking module initialization in uncertain situations. This happens in the `RCTAppSetupUtils.mm` file when setting up URL handlers for the `RCTNetworking` class and `BlobModule` is `nil`.

this PR fixes [this issue #50210](https://github.com/facebook/react-native/issues/50210#issue-2942240981)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Fix app crash in RCTNetworking when BlobModule is nil by adding null check before adding it to handlers array

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Fix app crash in RCTNetworking when BlobModule is nil by adding null check before adding it to handlers array

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

1. Created a test environment where BlobModule is not available/initialized
2. Before the fix, the app crashes when attempting network requests with the error: "Collection element of type 'std::nullptr_t' is not an Objective-C object"
3. After applying the fix, the app successfully initializes the networking module without crashing
4. Verified network requests work properly even when BlobModule is not available
5. Also verified that when BlobModule is properly initialized, it still works as expected with all functionality intact

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
