### PR TITLE
Fix Headers with prebuilt

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" "),
                           }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
     s.module_name             = 'React_FabricComponents'
   end

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
                           }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
     s.module_name             = 'React_FabricImage'
   end

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
     s.module_name             = 'React_Mapbuffer'
   end


### PR DESCRIPTION
## Summary:

This is to continue the work of this lovely PR https://github.com/facebook/react-native/pull/52489
unfortunately currently prebuilt is not working well with USE_FRAMEWORKS.
I am honestly still not able to get a successful build in a complicated project due to how this change touches a lot of core stuff.

but one of the things I noticed is that Headers directories are not correct due to the "header_mappings_dir" so I am adding the same check here to make sure this is not included when we don't use source build.

## Changelog:

[IOS] [FIXED] - React-FabricImage and React-Mapbuffer Headers

## Test Plan:

You can build before this change, and go to Pods/Headers/Public and see how React-FabricImage has "react/renderer/components/image/react/renderer/components/image" instead of just "react/renderer/components/image"
build after this patch and it will be fixed
