### PR TITLE
Add accessibilityServiceChanged to AccessibilityChangeEventName def

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
@@ -19,7 +19,8 @@ type AccessibilityChangeEventName =
   | 'highTextContrastChanged' // Android-only Event
   | 'darkerSystemColorsChanged' // iOS-only Event
   | 'screenReaderChanged'
-  | 'reduceTransparencyChanged'; // iOS-only Event
+  | 'reduceTransparencyChanged' // iOS-only Event
+  | 'accessibilityServiceChanged'; // Android-only Event
 
 type AccessibilityChangeEvent = boolean;
 


### PR DESCRIPTION
Add missing type 'accessibilityServiceChanged' to AccessibilityChangeEventName type definition

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I wasn't able to use accessibilityServiceChanged event in our project with TypeScript. I aim to resolve type error by adding it to type definition.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Added missing type accessibilityServiceChanged to AccessibilityChangeEventName type definition

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Added] - Added missing type accessibilityServiceChanged to AccessibilityChangeEventName type definition

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
