### PR TITLE
fix: use stringifySafe for serializing messages in FuseboxReactDevToolsDispatcher

### DIFF
--- a/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import stringifySafe from '../../../Libraries/Utilities/stringifySafe';
+
 type JSONValue =
   | string
   | number
@@ -53,7 +55,7 @@ export class Domain {
 
   sendMessage(message: JSONValue) {
     const messageWithDomain = {domain: this.name, message};
-    const serializedMessageWithDomain = JSON.stringify(messageWithDomain);
+    const serializedMessageWithDomain = stringifySafe(messageWithDomain);
 
     global[FuseboxReactDevToolsDispatcher.BINDING_NAME](
       serializedMessageWithDomain,

--- a/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import stringifySafe from '../../../Libraries/Utilities/stringifySafe';
+import stringifySafe from '../../../../Libraries/Utilities/stringifySafe';
 
 type JSONValue =
   | string


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Replace JSON.stringify with stringifySafe in FuseboxReactDevToolsDispatcher to safely serialize messages that may contain circular refs. This prevents errors observed when some plugins (e.g., on rozenite.dev) emit circular structures and hardens the dispatcher for other callers.

## Changelog:

[GENERAL] [FIXED] - Prevent errors when serializing messages with circular references in FuseboxReactDevToolsDispatcher by using stringifySafe.

## Test Plan:

Repro before: use a plugin that emits a circular structure (e.g., via rozenite.dev) → app crashes with “Converting circular structure to JSON”.

After change: no crash; messages are delivered; receiving side still JSON.parses and emits as expected.

