### PR TITLE
Fix KeyboardAvoidingView not recognizing the keyboard is dismissed after it was opened on Android

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -208,7 +208,7 @@ class KeyboardAvoidingView extends React.Component<
       ];
     } else {
       this._subscriptions = [
-        Keyboard.addListener('keyboardDidHide', this._onKeyboardChange),
+        Keyboard.addListener('keyboardDidHide', this._onKeyboardHide),
         Keyboard.addListener('keyboardDidShow', this._onKeyboardChange),
       ];
     }


### PR DESCRIPTION
## Summary:
Fix a problem on Android where `KeyboardAvoidingView` does not recognize that the keyboard is dismissed after it was opened.

Root Cause:
`KeyboardAvoidingView` subscribes to keyboard change events (show, hide). However, it binds the wrong event handler for `keyboardDidHide`. This causes `_updateBottomIfNecessary` to wrongfully calculate `state.bottom` because it relies on whether `this._keyboardEvent` is `null` or not. 

## Changelog:

[ANDROID] [FIXED] - Fix a problem on Android where `KeyboardAvoidingView` does not recognize that the keyboard is dismissed after it was opened.

## Test Plan:

1. Wrap your app view tree by `KeyboardAvoidingView`
2. Run on android
3. open keyboard
4. observe `KeyboardAvoidingView` `behavior` which is normal
5. dismiss the keyboard
6. `KeyboardAvoidingView` shows a gap on the bottom of the screen as "avoiding view". But this is incorrect behaviour since the keyboard is already dismissed.
