### PR TITLE
Add workflow to backfill assets for a manual/incomplete GitHub release

### DIFF
--- a/.github/workflows/backfill-release-assets.yml
+++ b/.github/workflows/backfill-release-assets.yml
@@ -1,0 +1,83 @@
+name: Backfill Release Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of React Native we want to backfill assets for. For example 0.75.0-rc.0"
+        required: true
+        type: string
+      dry-run:
+        description: "Whether the job should be executed in dry-run mode or not"
+        type: boolean
+        default: true
+      force:
+        description: "Whether to reupload assets even if they already exist"
+        type: boolean
+        default: false
+
+jobs:
+  backfill-release-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Check if on stable branch
+        id: check_stable_branch
+        run: |
+          BRANCH="$(git branch --show-current)"
+          PATTERN='^0\.[0-9]+-stable$'
+          if [[ $BRANCH =~ $PATTERN ]]; then
+            echo "On a stable branch"
+            echo "ON_STABLE_BRANCH=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Configure Git
+        shell: bash
+        run: |
+          git config --local user.email "bot@reactnative.dev"
+          git config --local user.name "React Native Bot"
+      - name: Resolve release ID
+        uses: actions/github-script@v6
+        env:
+          VERSION: ${{ inputs.version }}
+        id: resolve-release-id
+        with:
+          github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
+          script: |
+            const tag = 'v' + process.env.VERSION;
+            const releaseId = await github.rest.repos.getReleaseByTag({
+              owner: 'facebook',
+              repo: 'react-native',
+              tag,
+            }).then(({data}) => data.id);
+            console.log(`Resolved release ID: ${releaseId}`);
+            return releaseId;
+          result-encoding: string
+      - name: Upload release assets for DotSlash
+        if: ${{ steps.check_stable_branch.outputs.ON_STABLE_BRANCH }}
+        uses: actions/github-script@v6
+        env:
+          RELEASE_ID: ${{ steps.resolve-release-id.outputs.result }}
+          REACT_NATIVE_VERSION: ${{ inputs.version }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          FORCE: ${{ inputs.force }}
+        with:
+          github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
+          script: |
+            const {uploadReleaseAssetsForDotSlashFiles} = require('./scripts/releases/upload-release-assets-for-dotslash.js');
+            await uploadReleaseAssetsForDotSlashFiles({
+              version: process.env.REACT_NATIVE_VERSION,
+              token: github.token,
+              releaseId: process.env.RELEASE_ID,
+              dryRun: process.env.DRY_RUN === 'true',
+              force: process.env.FORCE === 'true',
+            });
+
+  validate-dotslash-artifacts:
+    uses: ./.github/workflows/validate-dotslash-artifacts
+    needs: backfill-release-assets

--- a/.github/workflows/validate-dotslash-artifacts.yml
+++ b/.github/workflows/validate-dotslash-artifacts.yml
@@ -1,6 +1,7 @@
 name: Validate DotSlash Artifacts
 
 on:
+  workflow_call:
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
## Summary:

When we create a GitHub release manually (like we had to do for 0.82.0-rc.1 because of an unrelated [workflow failure](https://github.com/facebook/react-native/actions/runs/17579028647)), we don't currently have a way to manually backfill the missing assets that would have been uploaded as part of an automated release (since https://github.com/facebook/react-native/pull/52930).

This PR adds a workflow that the release crew can use to securely upload the missing assets for a release that has already been drafted/published.

**NOTE:**  The workflow uses the *current* state of the branch as its input, so it's only useful for uploading assets for the latest release (it will not roll back to a previous release commit before running the upload script). However, it's *safe* to run the script on an older tag - it will just noop, since the release asset URLs will not match the (thanks to https://github.com/facebook/react-native/blob/main/scripts/releases/upload-release-assets-for-dotslash.js#L261-L284).

## Changelog:

[Internal]

## Test Plan:

eyes - to be tested after picking to 0.82-stable branch.