### PR TITLE
Preload Yarn PnP and add autolinking fallback in Podfile

### DIFF
--- a/private/helloworld/ios/Podfile
+++ b/private/helloworld/ios/Podfile
@@ -19,17 +19,28 @@ end
 
 target 'HelloWorld' do
   require 'pathname'
-config = nil
-begin
-  config = use_native_modules!(['sh', '../scripts/config.sh'])
-rescue => e
-  Pod::UI.warn "use_native_modules! failed: #{e}. Falling back to minimal config (no native module autolinking)."
-  rn_pkg_json = Pod::Executable.execute_command('node', ['-e', "process.stdout.write(require.resolve('react-native/package.json'))"]).strip
-  rn_dir = File.dirname(rn_pkg_json)
-  ios_project_root = Pod::Config.instance.installation_root
-  rn_rel = Pathname.new(rn_dir).relative_path_from(Pathname.new(ios_project_root)).to_s
-  config = { :reactNativePath => rn_rel }
-end
+  config = nil
+
+  # Preflight the autolinking config command to avoid hard exit inside autolinking.rb
+  begin
+    _json, _err, status = Pod::Executable.capture_command('bash', ['../scripts/config.sh'], capture: :both)
+    if status.success?
+      config = use_native_modules!(['bash', '../scripts/config.sh'])
+    else
+      raise "config command failed with status #{status.exitstatus}"
+    end
+  rescue => e
+    Pod::UI.warn "Autolinking preflight failed: #{e}. Falling back to minimal config (no native module autolinking)."
+    rn_pkg_json = Pod::Executable.execute_command('node', ['-e', "process.stdout.write(require.resolve('react-native/package.json'))"]).strip
+    rn_dir = File.dirname(rn_pkg_json)
+    ios_project_root = Pod::Config.instance.installation_root
+    rn_rel = Pathname.new(rn_dir).relative_path_from(Pathname.new(ios_project_root)).to_s
+    config = { :reactNativePath => rn_rel }
+  end
+
+  # Allow Yarn v1 to ignore engines during codegen to accommodate local Node versions
+  # CI should already use a compliant Node version, so this only aids local validation.
+  ENV['YARN_IGNORE_ENGINES'] = '1'
 
   use_react_native!(
     :path => "../../../packages/react-native",

--- a/private/helloworld/ios/Podfile
+++ b/private/helloworld/ios/Podfile
@@ -38,10 +38,6 @@ target 'HelloWorld' do
     config = { :reactNativePath => rn_rel }
   end
 
-  # Allow Yarn v1 to ignore engines during codegen to accommodate local Node versions
-  # CI should already use a compliant Node version, so this only aids local validation.
-  ENV['YARN_IGNORE_ENGINES'] = '1'
-
   use_react_native!(
     :path => "../../../packages/react-native",
     # An absolute path to your application root.

--- a/private/helloworld/ios/Podfile
+++ b/private/helloworld/ios/Podfile
@@ -1,3 +1,11 @@
+# Ensure Yarn PnP is loaded when resolving RN scripts
+pnp_path = File.expand_path('../.pnp.cjs', __dir__)
+if File.exist?(pnp_path)
+  existing_opts = ENV['NODE_OPTIONS']
+  pnp_opt = "--require #{pnp_path}"
+  ENV['NODE_OPTIONS'] = [pnp_opt, existing_opts].compact.join(' ')
+end
+
 require "../../../packages/react-native/scripts/cocoapods/autolinking.rb"
 
 platform :ios, min_ios_version_supported
@@ -10,7 +18,18 @@ if linkage != nil
 end
 
 target 'HelloWorld' do
+  require 'pathname'
+config = nil
+begin
   config = use_native_modules!(['sh', '../scripts/config.sh'])
+rescue => e
+  Pod::UI.warn "use_native_modules! failed: #{e}. Falling back to minimal config (no native module autolinking)."
+  rn_pkg_json = Pod::Executable.execute_command('node', ['-e', "process.stdout.write(require.resolve('react-native/package.json'))"]).strip
+  rn_dir = File.dirname(rn_pkg_json)
+  ios_project_root = Pod::Config.instance.installation_root
+  rn_rel = Pathname.new(rn_dir).relative_path_from(Pathname.new(ios_project_root)).to_s
+  config = { :reactNativePath => rn_rel }
+end
 
   use_react_native!(
     :path => "../../../packages/react-native",


### PR DESCRIPTION
## Changelog:
[iOS] [Fixed] - Fix autolinking under Yarn PnP in the HelloWorld Podfile.

## Summary
Make the HelloWorld iOS Podfile robust under Yarn 3 Plug’n’Play by preloading PnP and adding a safe fallback.

## Test Plan
- PnP: init new app → set Yarn Berry + nodeLinker pnp → `yarn install` → `npx pod-install` → codegen runs, Pods generated, no "react_native_pods.rb" error, iOS build OK.
- Non-PnP: init new app → `yarn install` (or `npm i`) → `npx pod-install` → behavior unchanged.

