### PR TITLE
SectionList: fix separators position when list is inverted

### DIFF
--- a/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
@@ -10,7 +10,7 @@
 
 import SectionListBaseExample from './SectionListBaseExample';
 import * as React from 'react';
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
 const Separator =
@@ -34,21 +34,42 @@ const Separator =
   };
 
 export function SectionList_withSeparators(): React.Node {
+  const [isInverted, setInverted] = useState(false);
+
   const exampleProps = {
+    inverted: isInverted,
     ItemSeparatorComponent: Separator('lightgreen', 'green', false),
     SectionSeparatorComponent: Separator('lightblue', 'blue', true),
   };
   const ref = useRef<any>(null);
 
-  return <SectionListBaseExample ref={ref} exampleProps={exampleProps} />;
+  function onTest() {
+    setInverted(!isInverted);
+  }
+
+  return (
+    <SectionListBaseExample
+      ref={ref}
+      exampleProps={exampleProps}
+      itemStyle={styles.item}
+      onTest={onTest}
+      testOutput={`Inverted: ${isInverted.toString()}`}
+      testLabel={isInverted ? 'Toggle false' : 'Toggle true'}
+    />
+  );
 }
 
 const styles = StyleSheet.create({
   separator: {
-    height: 12,
+    height: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   separatorText: {
     fontSize: 10,
+  },
+  item: {
+    marginVertical: 0,
   },
 });
 

--- a/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
@@ -16,6 +16,7 @@ import {
   StyleSheet,
   Text,
   View,
+  type ViewStyle,
 } from 'react-native';
 
 const DATA = [
@@ -39,7 +40,7 @@ const DATA = [
 
 /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
  * LTI update could not be added via codemod */
-const Item = ({item, section, separators}) => {
+const Item = ({item, separators, style}) => {
   return (
     <Pressable
       onPressIn={() => {
@@ -54,6 +55,7 @@ const Item = ({item, section, separators}) => {
       }}
       style={({pressed}) => [
         styles.item,
+        style,
         {
           backgroundColor: pressed ? 'red' : 'pink',
         },
@@ -71,6 +73,7 @@ type Props = $ReadOnly<{
   testLabel?: ?string,
   testOutput?: ?string,
   children?: ?React.Node,
+  itemStyle?: ViewStyle,
 }>;
 
 const SectionListBaseExample: component(
@@ -109,7 +112,9 @@ const SectionListBaseExample: component(
         sections={DATA}
         keyExtractor={(item, index) => item + index}
         style={styles.list}
-        renderItem={Item}
+        renderItem={({item, separators}) => (
+          <Item style={props.itemStyle} item={item} separators={separators} />
+        )}
         /* $FlowFixMe[prop-missing] Error revealed after improved builtin React
          * utility types */
         renderSectionHeader={({section: {title}}) => (

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -378,8 +378,12 @@ class VirtualizedSectionList<
         }
       } else {
         const renderItem = info.section.renderItem || this.props.renderItem;
+        const displayIndex =
+          !!this.props.inverted && info.section.data.length
+            ? info.section.data.length - 1 - infoIndex
+            : infoIndex;
         const SeparatorComponent = this._getSeparatorComponent(
-          index,
+          displayIndex,
           info,
           listItemCount,
         );
@@ -388,7 +392,9 @@ class VirtualizedSectionList<
           <ItemWithSeparator
             SeparatorComponent={SeparatorComponent}
             LeadingSeparatorComponent={
-              infoIndex === 0 ? this.props.SectionSeparatorComponent : undefined
+              displayIndex === 0
+                ? this.props.SectionSeparatorComponent
+                : undefined
             }
             cellKey={info.key}
             index={infoIndex}
@@ -460,7 +466,7 @@ class VirtualizedSectionList<
     const {SectionSeparatorComponent} = this.props;
     const isLastItemInList = index === listItemCount - 1;
     const isLastItemInSection =
-      info.index === this.props.getItemCount(info.section.data) - 1;
+      index === this.props.getItemCount(info.section.data) - 1;
     if (SectionSeparatorComponent && isLastItemInSection) {
       return SectionSeparatorComponent;
     }

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
@@ -94,6 +94,7 @@ describe('VirtualizedSectionList', () => {
       component = ReactTestRenderer.create(
         <VirtualizedSectionList
           ItemSeparatorComponent={() => <separator />}
+          SectionSeparatorComponent={() => <sectionSeparator />}
           ListEmptyComponent={() => <empty />}
           ListFooterComponent={() => <footer />}
           ListHeaderComponent={() => <header />}

--- a/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
+++ b/packages/virtualized-lists/Lists/__tests__/__snapshots__/VirtualizedSectionList-test.js.snap
@@ -863,7 +863,7 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
         ]
       }
     >
-      <separator />
+      <sectionSeparator />
       <item
         value="0"
       />
@@ -951,9 +951,11 @@ exports[`VirtualizedSectionList renders all the bells and whistles 1`] = `
         ]
       }
     >
+      <separator />
       <item
         value="4"
       />
+      <sectionSeparator />
     </View>
     <View
       onFocusCapture={[Function]}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes:
* #53749

Before:

<table>
<tr><th>Android</th><th>iOS</th><tr/>
<tr><td><img width="550" alt="Screenshot (16 Sept 2025 14_20_06)" src="https://github.com/user-attachments/assets/46a795e3-e47c-4604-aab8-9601ec0dd533" /></td><td><img width="585" height="1266" alt="IMG_2891" src="https://github.com/user-attachments/assets/090f6eff-9a3f-470a-8d4d-d2e9c2aa6e0e" /></td>
</tr>
</table>

If `inverted` prop is used, update section index calculation to return correct value in `VirtualizedSectionList`.

I have also altered the RNTester example styling slightly to make it easier to debug and test the issue (removed applied by default items margin).

## Changelog:

[GENERAL] [FIXED] - SectionList: fix separators position when list is inverted

## Test Plan:

Modify the RNTester "SectionList with separators" to include invert option. Make sure that Flow checks are passing, test the changes on real devices on both platforms.

I have also make sure that non-inverted lists are not affected by the changes.

# Preview:

<table>
<tr><th>Android</th><th>iOS</th><tr/>
<tr><td><img width="550" alt="Screenshot (16 Sept 2025 13_56_21)" src="https://github.com/user-attachments/assets/234da8e2-7e5a-4692-81e2-5a19ab3a05dd" /></td><td><img width="585" height="1266" alt="IMG_2890" src="https://github.com/user-attachments/assets/28396f00-5bc7-4d77-8865-026137ff3dd4" /></td>
</tr>
</table>


