### PR TITLE
[iOS] Fix `minimumFontScale` in New Architecture

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -31,8 +31,6 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              rhs.includeFontPadding,
              rhs.android_hyphenationFrequency,
              rhs.textAlignVertical) &&
-      floatEquality(minimumFontSize, rhs.minimumFontSize) &&
-      floatEquality(maximumFontSize, rhs.maximumFontSize) &&
       floatEquality(minimumFontScale, rhs.minimumFontScale);
 }
 
@@ -61,13 +59,9 @@ SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
           adjustsFontSizeToFit,
           paragraphAttributes.adjustsFontSizeToFit),
       debugStringConvertibleItem(
-          "minimumFontSize",
-          minimumFontSize,
-          paragraphAttributes.minimumFontSize),
-      debugStringConvertibleItem(
-          "maximumFontSize",
-          maximumFontSize,
-          paragraphAttributes.maximumFontSize),
+          "minimumFontScale",
+          minimumFontScale,
+          paragraphAttributes.minimumFontScale),
       debugStringConvertibleItem(
           "includeFontPadding",
           includeFontPadding,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -64,17 +64,10 @@ class ParagraphAttributes : public DebugStringConvertible {
   HyphenationFrequency android_hyphenationFrequency{};
 
   /*
-   * In case of font size adjustment enabled, defines minimum and maximum
-   * font sizes.
-   */
-  Float minimumFontSize{std::numeric_limits<Float>::quiet_NaN()};
-  Float maximumFontSize{std::numeric_limits<Float>::quiet_NaN()};
-
-  /*
    * Specifies the smallest possible scale a font can reach when
    * adjustsFontSizeToFit is enabled. (values 0.01-1.0).
    */
-  Float minimumFontScale{std::numeric_limits<Float>::quiet_NaN()};
+  Float minimumFontScale{0.0};
 
   /*
    * The vertical alignment of the text, causing the glyphs to be vertically
@@ -105,8 +98,7 @@ struct hash<facebook::react::ParagraphAttributes> {
         attributes.ellipsizeMode,
         attributes.textBreakStrategy,
         attributes.adjustsFontSizeToFit,
-        attributes.minimumFontSize,
-        attributes.maximumFontSize,
+        attributes.minimumFontScale,
         attributes.includeFontPadding,
         attributes.android_hyphenationFrequency,
         attributes.minimumFontScale,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -952,18 +952,6 @@ inline ParagraphAttributes convertRawProp(
       "minimumFontScale",
       sourceParagraphAttributes.minimumFontScale,
       defaultParagraphAttributes.minimumFontScale);
-  paragraphAttributes.minimumFontSize = convertRawProp(
-      context,
-      rawProps,
-      "minimumFontSize",
-      sourceParagraphAttributes.minimumFontSize,
-      defaultParagraphAttributes.minimumFontSize);
-  paragraphAttributes.maximumFontSize = convertRawProp(
-      context,
-      rawProps,
-      "maximumFontSize",
-      sourceParagraphAttributes.maximumFontSize,
-      defaultParagraphAttributes.maximumFontSize);
   paragraphAttributes.includeFontPadding = convertRawProp(
       context,
       rawProps,
@@ -1062,8 +1050,7 @@ constexpr static MapBuffer::Key PA_KEY_TEXT_BREAK_STRATEGY = 2;
 constexpr static MapBuffer::Key PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
 constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
-constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
-constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
+constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SCALE = 6;
 constexpr static MapBuffer::Key PA_KEY_TEXT_ALIGN_VERTICAL = 8;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
@@ -1088,9 +1075,7 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
         toString(*paragraphAttributes.textAlignVertical));
   }
   builder.putDouble(
-      PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
-  builder.putDouble(
-      PA_KEY_MAXIMUM_FONT_SIZE, paragraphAttributes.maximumFontSize);
+      PA_KEY_MINIMUM_FONT_SCALE, paragraphAttributes.minimumFontScale);
 
   return builder.build();
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
@@ -106,18 +106,6 @@ void BaseParagraphProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
         includeFontPadding,
         "includeFontPadding");
     REBUILD_FIELD_SWITCH_CASE(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
@@ -132,18 +132,6 @@ folly::dynamic HostPlatformParagraphProps::getDiffProps(
     result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
   }
 
-  if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
-  }
-
   if (paragraphAttributes.includeFontPadding !=
       oldProps->paragraphAttributes.includeFontPadding) {
     result["includeFontPadding"] = paragraphAttributes.includeFontPadding;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -177,14 +177,8 @@ void BaseTextInputProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
+        minimumFontScale,
+        "minimumFontScale");
     REBUILD_FIELD_SWITCH_CASE(
         paDefaults,
         value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -394,15 +394,9 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
+          paragraphAttributes.minimumFontScale,
+          oldProps->paragraphAttributes.minimumFontScale)) {
+    result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
   }
 
   if (paragraphAttributes.includeFontPadding !=

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -220,6 +220,22 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return paragraphLines;
 }
 
+- (CGFloat)_maximumFontSizeInAttributedString:(NSAttributedString *)attributedString
+{
+  __block CGFloat maximumFontSize = 0.0;
+  [attributedString enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedString.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(id _Nullable value, NSRange range, BOOL *_Nonnull stop) {
+                              CGFloat fontSize = ((UIFont *)value).pointSize;
+                              if (fontSize > maximumFontSize) {
+                                maximumFontSize = fontSize;
+                              }
+                            }];
+
+  return maximumFontSize;
+}
+
 - (NSTextStorage *)_textStorageAndLayoutManagerWithAttributesString:(NSAttributedString *)attributedString
                                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                                size:(CGSize)size
@@ -243,8 +259,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   [textStorage addLayoutManager:layoutManager];
 
   if (paragraphAttributes.adjustsFontSizeToFit) {
-    CGFloat minimumFontSize = !isnan(paragraphAttributes.minimumFontSize) ? paragraphAttributes.minimumFontSize : 4.0;
-    CGFloat maximumFontSize = !isnan(paragraphAttributes.maximumFontSize) ? paragraphAttributes.maximumFontSize : 96.0;
+    CGFloat maximumFontSize = [self _maximumFontSizeInAttributedString:attributedString];
+    CGFloat minimumFontSize = MAX(paragraphAttributes.minimumFontScale * maximumFontSize, 4.0);
     [textStorage scaleFontSizeToFitSize:size minimumFontSize:minimumFontSize maximumFontSize:maximumFontSize];
   }
 

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -212,6 +212,21 @@ class AdjustingFontSize extends React.Component<
         </Text>
 
         <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          style={{fontSize: 16, marginVertical: 6}}>
+          It doesn't grow
+        </Text>
+
+        <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.5}
+          style={{fontSize: 40, marginVertical: 6}}>
+          Can limit how small the text becomes with minimumFontScale
+        </Text>
+
+        <Text
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{fontSize: 30, marginVertical: 6}}>

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -214,13 +214,6 @@ class AdjustingFontSize extends React.Component<
         <Text
           numberOfLines={1}
           adjustsFontSizeToFit={true}
-          style={{fontSize: 16, marginVertical: 6}}>
-          It doesn't grow
-        </Text>
-
-        <Text
-          numberOfLines={1}
-          adjustsFontSizeToFit={true}
           minimumFontScale={0.5}
           style={{fontSize: 40, marginVertical: 6}}>
           Can limit how small the text becomes with minimumFontScale


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR is meant to replace #43543 and attempts to address the issue of `minimumFontScale` not being respected on iOS when used with `adjustsFontSizeToFit`.

When using `adjustsFontSizeToFit` on Fabric, the behavior differs from the old renderer, as `minimumFontScale` is not respected. The code currently uses `minimumFontSize` and `maximumFontSize`, but those props do not actually exist. This brings the behavior closer to the old renderer by removing the unused props and implementing `minimumFontScale` instead. 

From #43543: 

> From what I understand, in the old renderer, it would use the font size of the outermost text, but since we don't easily have access to that in Fabric, I use the maximum font size of the attributed string.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Fix `minimumFontScale` on iOS Fabric

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

This adds one example of the new iOS behavior in RNTester. You can see that, on iOS, the line "Can limit how small the text becomes with minimumFontScale" does not respect the `minimumFontScale` prop in the before screenshot, but does in the after screenshot:


| **Before** | **After** |
| - | - |
| <img width="827" height="760" alt="image" src="https://github.com/user-attachments/assets/1f6503a2-9134-4dc9-a816-54108287a99e" /> | <img width="826" height="784" alt="image" src="https://github.com/user-attachments/assets/901c798d-57bb-4c76-917d-d7c5c5d8d6e2" /> |

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
