### PR TITLE
fix: Android hitSlop prop TalkBack selection

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
@@ -252,7 +252,8 @@ public object TouchTargetHelper {
    * Checks whether a touch at {@code x} and {@code y} are within the bounds of the View. Both
    * {@code x} and {@code y} must be relative to the top-left corner of the view.
    */
-  private fun isTouchPointInView(x: Float, y: Float, view: View): Boolean {
+  @JvmStatic
+  public fun isTouchPointInView(x: Float, y: Float, view: View): Boolean {
     val hitSlopRect = (view as? ReactHitSlopView)?.hitSlopRect
     if (hitSlopRect != null) {
       if (

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -305,8 +305,12 @@ public open class ReactViewGroup public constructor(context: Context?) :
       return false
     }
 
-    // For accessibility (TalkBack), check if hover is within any child's hitSlop area
-    if (ev.isFromSource(android.view.InputDevice.SOURCE_CLASS_POINTER) &&
+    // For accessibility services (TalkBack), check if hover is within any child's hitSlop area.
+    // Only apply this logic when accessibility services are enabled to avoid interfering with
+    // other input methods (VR, mouse, stylus, etc.)
+    val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+    if (accessibilityManager?.isTouchExplorationEnabled == true &&
+        ev.isFromSource(android.view.InputDevice.SOURCE_CLASS_POINTER) &&
         (ev.action == MotionEvent.ACTION_HOVER_ENTER || ev.action == MotionEvent.ACTION_HOVER_MOVE)) {
       val x = ev.x
       val y = ev.y


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/54187 by intercepting TalkBack hover events inside `dispatchGenericMotionEvent` and checking if the tap falls inside the child's hitSlop area. If the tap occurs in the hitSlop zone, the method now requests accessibility focus on that child view. 

## Changelog:

Pick one each for the category and type tags:

[ANDROID] [FIXED] - fix hitSlop prop not providing full hitSlop boundaries to TalkBack

## Test Plan:

You can test this in the "Pressable Hit Slop" segment of the `rn-tester` app on Android.

1. Run install: `yarn install`
2. Open RN tester app: `yarn android`
3. Go to "Pressable"
4. Scroll to "Pressable Hit Slop"
5. Turn on TalkBack
6. Tap in the hitSlop area (not on the pressable itself). With the fix, the pressable should be highlighted. before the fix, it would not be, and would need to be tapped directly.

### Screen recording of fixed behavior in this branch

https://github.com/user-attachments/assets/b97401eb-d941-4e5e-836d-6c3ec7091439

### Screen recording of broken behavior on `main`

https://github.com/user-attachments/assets/435d7463-d53c-473a-bf0a-e001df5a17e3


