### PR TITLE
Invert iOS scroll-to-top gesture scroll so it also scrolls to the top when using inverted ScrollViews

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -754,6 +754,13 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 - (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView
 {
   _isUserTriggeredScrolling = YES;
+
+  if ([self isInverted]) {
+    _isUserTriggeredScrolling = NO;
+    [self scrollToEnd:YES];
+    return NO;
+  }
+
   return YES;
 }
 


### PR DESCRIPTION
## Summary:

When using `inverted` in a component that uses UIKit's `ScrollView` under the hood and tapping the status bar (scroll-to-top gesture), instead of scrolling to the top, we end up going to the bottom because of the -1 transform invert.

I think this fix has 1 (likely inevitable) bug that seems to be unfixable without upstream changes on iOS or a hacky workaround. It won't trigger the scroll when at `y = 0` (the absolute bottom), it thinks we are at the top of the list because of the -1 transform, thus it doesn't scroll:

<img width="909" height="84" alt="image" src="https://github.com/user-attachments/assets/00fda8c4-f24d-4c6c-80f6-def8f2ef9ad2" />

You can see this behavior here (this is from my branch), notice that the gesture only works when I scroll up a bit:

https://github.com/user-attachments/assets/dd47d8f2-d7ca-451c-b905-eba94c344fa7

I'm opening this PR because of an issue in another repo (Expensify) I'm working on, there, I came to the conclusion that we had two options for working around this:

> 1. Workaround this by limiting the minimum scroll rest point to y = 1, instead of y = 0. (we'll let it bounce below 0 to maintain current behavior, but it'll always land at 1). This is what I just pushed a fix for. The downside is that all scrollviews will always be offset by 1 pixel, but it's barely possible to even notice that.
> 2. Revert the 1-pixel workaround I just pushed. This has the downside that users will never be able to click status bar to scroll after opening a list, they'd have to scroll at least 1 pixel before doing that, and if scrolling to the absolute bottom of the list (y = 0), they also wouldn't be able to click the status bar.

You can see more details [here](https://github.com/Expensify/App/pull/76174).

I think there might be another way of working around this which would be using an invisible `ScrollView` to catch the gesture, but this would likely be even worse than the other 2 options.

I also remember reading that this has been attempted before in a PR on the old arch and it had the same exact bug. I'll try to link it here if I find it later.

I think I could implement a prop that activates the 1-pixel workaround described above, and another that disables this PR entirely (scrolls to the bottom, like it's being done now) so that developers can choose.

Obviously, everything I described above is not ideal, and simply a workaround, I would love to hear if anyone has any other ideas on how to tackle this.

## Changelog:

[iOS] [CHANGED] - Fix scroll-to-top gesture on inverted lists

## Test Plan:

This is a simple change but there is 1 known bug that I'd like to address before writing this section (more details above).
