### PR TITLE
[Android] Add Kotlin collection factory functions for Maps and Arrays

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CollectionFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CollectionFactory.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+/**
+ * Creates a [WritableMap] with the given key-value pairs.
+ *
+ * Example:
+ * ```
+ * val map = writableMapOf(
+ *     "name" to "Alice",
+ *     "age" to 30,
+ *     "active" to true
+ * )
+ * ```
+ *
+ * Supported value types: null, Boolean, Int, Long, Float, Double, String, ReadableMap,
+ * ReadableArray, WritableMap, WritableArray.
+ *
+ * @throws IllegalArgumentException if a value is of unsupported type
+ */
+public fun writableMapOf(vararg pairs: Pair<String, Any?>): WritableMap {
+  val map = Arguments.createMap()
+  for ((key, value) in pairs) {
+    putValue(map, key, value)
+  }
+  return map
+}
+
+private fun putValue(map: WritableMap, key: String, value: Any?) {
+  when (value) {
+    null -> map.putNull(key)
+    is Boolean -> map.putBoolean(key, value)
+    is Int -> map.putInt(key, value)
+    is Long -> map.putDouble(key, value.toDouble())
+    is Float -> map.putDouble(key, value.toDouble())
+    is Double -> map.putDouble(key, value)
+    is String -> map.putString(key, value)
+    is ReadableMap -> map.putMap(key, value)
+    is ReadableArray -> map.putArray(key, value)
+    else -> {
+      throw IllegalArgumentException(
+        "Unsupported value type: ${value.javaClass.name} for key '$key'"
+      )
+    }
+  }
+}
+
+/**
+ * Creates a [WritableArray] with the given elements.
+ *
+ * Example:
+ * ```
+ * val array = writableArrayOf("apple", "banana", "cherry")
+ * val mixed = writableArrayOf(1, "two", true, 4.0)
+ * ```
+ *
+ * Supported element types: null, Boolean, Int, Long, Float, Double, String, ReadableMap,
+ * ReadableArray, WritableMap, WritableArray.
+ *
+ * @throws IllegalArgumentException if an element is of unsupported type
+ */
+public fun writableArrayOf(vararg elements: Any?): WritableArray {
+  val array = Arguments.createArray()
+  for (element in elements) {
+    pushValue(array, element)
+  }
+  return array
+}
+
+private fun pushValue(array: WritableArray, value: Any?) {
+  when (value) {
+    null -> array.pushNull()
+    is Boolean -> array.pushBoolean(value)
+    is Int -> array.pushInt(value)
+    is Long -> array.pushDouble(value.toDouble())
+    is Float -> array.pushDouble(value.toDouble())
+    is Double -> array.pushDouble(value)
+    is String -> array.pushString(value)
+    is ReadableMap -> array.pushMap(value)
+    is ReadableArray -> array.pushArray(value)
+    else -> {
+      throw IllegalArgumentException("Unsupported element type: ${value.javaClass.name}")
+    }
+  }
+}
+
+/**
+ * Creates a [ReadableMap] with the given key-value pairs. Returns an immutable view - mutations are
+ * not possible through the returned interface.
+ *
+ * Example:
+ * ```
+ * val map = readableMapOf("key" to "value", "count" to 42)
+ * ```
+ */
+public fun readableMapOf(vararg pairs: Pair<String, Any?>): ReadableMap = writableMapOf(*pairs)
+
+/**
+ * Creates a [ReadableArray] with the given elements. Returns an immutable view - mutations are not
+ * possible through the returned interface.
+ *
+ * Example:
+ * ```
+ * val array = readableArrayOf(1, 2, 3)
+ * ```
+ */
+public fun readableArrayOf(vararg elements: Any?): ReadableArray = writableArrayOf(*elements)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/CollectionFactoryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/CollectionFactoryTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import com.facebook.testutils.shadows.ShadowArguments
+import com.facebook.testutils.shadows.ShadowNativeArray
+import com.facebook.testutils.shadows.ShadowNativeLoader
+import com.facebook.testutils.shadows.ShadowNativeMap
+import com.facebook.testutils.shadows.ShadowReadableNativeArray
+import com.facebook.testutils.shadows.ShadowReadableNativeMap
+import com.facebook.testutils.shadows.ShadowSoLoader
+import com.facebook.testutils.shadows.ShadowWritableNativeArray
+import com.facebook.testutils.shadows.ShadowWritableNativeMap
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+  shadows =
+    [
+      ShadowArguments::class,
+      ShadowSoLoader::class,
+      ShadowNativeLoader::class,
+      ShadowNativeArray::class,
+      ShadowNativeMap::class,
+      ShadowWritableNativeMap::class,
+      ShadowWritableNativeArray::class,
+      ShadowReadableNativeMap::class,
+      ShadowReadableNativeArray::class,
+    ]
+)
+class CollectionFactoryTest {
+  @Test
+  fun `writableMapOf creates empty map`() {
+    val map = writableMapOf()
+    assertThat(map.toHashMap()).isEmpty()
+  }
+
+  @Test
+  fun `writableArrayOf creates empty array`() {
+    val array = writableArrayOf()
+    assertThat(array.toArrayList()).isEmpty()
+  }
+
+  @Test
+  fun `writableMapOf creates map with primitive values`() {
+    val map = writableMapOf(
+      "stringKey" to "stringValue",
+      "intKey" to 42,
+      "boolKey" to true,
+      "doubleKey" to 3.14
+    )
+
+    assertThat(map.toHashMap())
+      .hasSize(4)
+      .containsEntry("stringKey", "stringValue")
+      .containsEntry("intKey", 42.0)
+      .containsEntry("boolKey", true)
+      .containsEntry("doubleKey", 3.14)
+  }
+
+  @Test
+  fun `writableArrayOf creates array with mixed types`() {
+    val array = writableArrayOf("one", 2, true, 4.0)
+
+    assertThat(array.toArrayList()).hasSize(4).containsExactly("one", 2.0, true, 4.0)
+  }
+
+  @Test
+  fun `writableMapOf handles null values correctly`() {
+    val map = writableMapOf("nullKey" to null)
+    assertThat(map.toHashMap()).containsEntry("nullKey", null)
+  }
+
+  @Test
+  fun `writableArrayOf handles null elements correctly`() {
+    val array = writableArrayOf("first", null, "third")
+    assertThat(array.toArrayList()).hasSize(3).containsExactly("first", null, "third")
+  }
+
+  @Test
+  fun `writableMapOf converts Long and Float to Double`() {
+    val map = writableMapOf("longKey" to 123L, "floatKey" to 4.5f)
+
+    assertThat(map.toHashMap()).containsEntry("longKey", 123.0).containsEntry("floatKey", 4.5)
+  }
+
+  @Test
+  fun `writableArrayOf converts Long and Float to Double`() {
+    val array = writableArrayOf(123L, 4.5f)
+
+    assertThat(array.toArrayList()).containsExactly(123.0, 4.5)
+  }
+
+  @Test
+  fun `writableMapOf supports nested maps`() {
+    val map = writableMapOf("nested" to writableMapOf("inner" to "value"))
+
+    val nested = map.getMap("nested")
+    checkNotNull(nested)
+    assertThat(nested.toHashMap()).containsEntry("inner", "value")
+  }
+
+  @Test
+  fun `writableMapOf supports nested arrays`() {
+    val map = writableMapOf("items" to writableArrayOf(1, 2, 3))
+
+    val items = map.getArray("items")
+    checkNotNull(items)
+    assertThat(items.toArrayList()).containsExactly(1.0, 2.0, 3.0)
+  }
+
+  @Test
+  fun `writableArrayOf supports nested maps`() {
+    val array = writableArrayOf(writableMapOf("key" to "value"))
+
+    val nested = array.getMap(0)
+    checkNotNull(nested)
+    assertThat(nested.toHashMap()).containsEntry("key", "value")
+  }
+
+  @Test
+  fun `writableArrayOf supports nested arrays`() {
+    val array = writableArrayOf(writableArrayOf(1, 2))
+
+    val nested = array.getArray(0)
+    assertThat(nested?.toArrayList()).containsExactly(1.0, 2.0)
+  }
+
+  @Test
+  fun `readableMapOf returns ReadableMap with correct content`() {
+    val map: ReadableMap = readableMapOf("key" to "value", "count" to 42)
+
+    assertThat(map.getString("key")).isEqualTo("value")
+    assertThat(map.getInt("count")).isEqualTo(42)
+  }
+
+  @Test
+  fun `readableArrayOf returns ReadableArray with correct content`() {
+    val array: ReadableArray = readableArrayOf(1, 2, 3)
+
+    assertThat(array.toArrayList()).containsExactly(1.0, 2.0, 3.0)
+  }
+
+  @Test
+  fun `writableMapOf throws on unsupported type`() {
+    assertThatThrownBy { writableMapOf("date" to java.util.Date()) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Unsupported value type")
+      .hasMessageContaining("date")
+  }
+
+  @Test
+  fun `writableArrayOf throws on unsupported type`() {
+    assertThatThrownBy { writableArrayOf(java.util.Date()) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessageContaining("Unsupported element type")
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR is based on the proposal: https://github.com/react-native-community/discussions-and-proposals/issues/966

Add Kotlin collection factory functions for maps (WritableMap, ReadableMap) and arrays (WritableArray, ReadableArray)

Introduce idiomatic Kotlin factory functions for creating React Native bridge collection types:

- `writableMapOf()`: Creates WritableMap with vararg key-value pairs
- `writableArrayOf()`: Creates WritableArray with vararg elements
- `readableMapOf()`: Returns ReadableMap
- `readableArrayOf()`: Returns ReadableArray                                                                                                                                       
                                                                                                                                                                                     
These functions mirror Kotlin's standard library conventions (mapOf/mutableMapOf) and provide a more concise alternative to the builder DSL pattern when constructing small, static collections.                                                                                                                                                                      
                                                                                                                                                                                     
Supported types: null, Boolean, Int, Long, Float, Double, String, ReadableMap, ReadableArray. 

> Long and Float are converted to Double for JavaScript compatibility.

## Changelog:

[ANDROID] [ADDED] - Add Kotlin collection factory functions: writableMapOf, writableArrayOf, readableMapOf, readableArrayOf

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Unit tests added in `CollectionFactoryTest.kt` covering:
- Empty collections 
- Primitive values (String, Int, Boolean, Double)
- Null handling 
- Long/Float to Double conversion
- Nested maps and arrays
- Error handling for unsupported types

<img width="1425" height="476" alt="스크린샷 2025-12-19 오전 10 40 31" src="https://github.com/user-attachments/assets/bca29e17-2c23-4130-8946-a79378f129bb" />
