### PR TITLE
Fix: Fabric Native Measure

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -6,6 +6,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <cstdint>
 #import <memory>
 
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
@@ -43,6 +44,12 @@ NS_ASSUME_NONNULL_BEGIN
                        forShadowView:(const facebook::react::ShadowView &)shadowView;
 
 - (void)schedulerDidSynchronouslyUpdateViewOnUIThread:(facebook::react::Tag)reactTag props:(folly::dynamic)props;
+
+// Measure APIs (used by Fabric `measure` / `measureInWindow`).
+- (void)schedulerMeasure:(ReactTag)surfaceId
+                reactTag:(ReactTag)reactTag
+                inWindow:(BOOL)inWindow
+              callbackId:(int64_t)callbackId;
 @end
 
 /**
@@ -74,6 +81,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addEventListener:(const std::shared_ptr<facebook::react::EventListener> &)listener;
 
 - (void)removeEventListener:(const std::shared_ptr<facebook::react::EventListener> &)listener;
+
+- (void)onMeasureResultWithCallbackId:(int64_t)callbackId
+                             inWindow:(BOOL)inWindow
+                              success:(BOOL)success
+                                    x:(double)x
+                                    y:(double)y
+                                width:(double)width
+                               height:(double)height;
 
 @end
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -83,6 +83,17 @@ internal class FabricUIManagerBinding : HybridClassBase() {
 
   external fun reportMount(surfaceId: Int)
 
+  @DoNotStrip
+  external fun onMeasureResult(
+      callbackId: Long,
+      inWindow: Boolean,
+      success: Boolean,
+      x: Int,
+      y: Int,
+      width: Int,
+      height: Int,
+  )
+
   fun register(
       runtimeExecutor: RuntimeExecutor,
       runtimeScheduler: RuntimeScheduler,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -52,6 +52,7 @@ import com.facebook.react.uimanager.RootView;
 import com.facebook.react.uimanager.RootViewManager;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewMeasureUtil;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.uimanager.ViewManagerRegistry;
 import com.facebook.react.uimanager.events.EventCategoryDef;
@@ -1241,6 +1242,18 @@ public class SurfaceMountingManager {
           "Trying to resolve view with tag " + reactTag + " which doesn't exist");
     }
     return view;
+  }
+
+  @UiThread
+  public void measure(int reactTag, int[] outputBuffer) {
+    UiThreadUtil.assertOnUiThread();
+    ViewMeasureUtil.measureViewRelativeToRoot(getView(reactTag), outputBuffer);
+  }
+
+  @UiThread
+  public void measureInWindow(int reactTag, int[] outputBuffer) {
+    UiThreadUtil.assertOnUiThread();
+    ViewMeasureUtil.measureViewInWindow(getView(reactTag), outputBuffer);
   }
 
   private @NonNull ViewState getViewState(int tag) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewMeasureUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewMeasureUtil.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+package com.facebook.react.uimanager
+
+import android.graphics.Matrix
+import android.graphics.Rect
+import android.graphics.RectF
+import android.view.View
+import android.view.ViewParent
+import androidx.annotation.UiThread
+import com.facebook.react.bridge.UiThreadUtil
+
+/** Utility for measuring a View's bounding box accounting for view transforms. */
+public object ViewMeasureUtil {
+  /**
+   * Populates outputBuffer with `[x, y, width, height]` measured relative to the surface RootView.
+   *
+   * The resulting `x` and `y` are relative to the RootView's coordinate space (same space as
+   * `pageX/pageY` in touch events).
+   */
+  @UiThread
+  @JvmStatic
+  public fun measureViewRelativeToRoot(view: View, outputBuffer: IntArray) {
+    UiThreadUtil.assertOnUiThread()
+
+    val rootView = RootViewUtil.getRootView(view) as? View
+        ?: throw IllegalViewOperationException("Native view ${view.id} is no longer on screen")
+
+    val rootBuffer = IntArray(4)
+    computeBoundingBox(rootView, rootBuffer)
+    val rootX = rootBuffer[0]
+    val rootY = rootBuffer[1]
+
+    computeBoundingBox(view, outputBuffer)
+    outputBuffer[0] -= rootX
+    outputBuffer[1] -= rootY
+  }
+
+  /**
+   * Populates outputBuffer with `[x, y, width, height]` measured relative to the visible window.
+   */
+  @UiThread
+  @JvmStatic
+  public fun measureViewInWindow(view: View, outputBuffer: IntArray) {
+    UiThreadUtil.assertOnUiThread()
+
+    computeBoundingBox(view, outputBuffer)
+
+    // Subtract window insets / split-screen offsets, matching Paper semantics.
+    val visibleWindowFrame = Rect()
+    view.getWindowVisibleDisplayFrame(visibleWindowFrame)
+    outputBuffer[0] -= visibleWindowFrame.left
+    outputBuffer[1] -= visibleWindowFrame.top
+  }
+
+  private fun computeBoundingBox(view: View, outputBuffer: IntArray) {
+    val rect = RectF(0f, 0f, view.width.toFloat(), view.height.toFloat())
+    mapRectFromViewToWindowCoords(view, rect)
+
+    outputBuffer[0] = Math.round(rect.left)
+    outputBuffer[1] = Math.round(rect.top)
+    outputBuffer[2] = Math.round(rect.right - rect.left)
+    outputBuffer[3] = Math.round(rect.bottom - rect.top)
+  }
+
+  private fun mapRectFromViewToWindowCoords(view: View, rect: RectF) {
+    var matrix: Matrix = view.matrix
+    if (!matrix.isIdentity) {
+      matrix.mapRect(rect)
+    }
+
+    rect.offset(view.left.toFloat(), view.top.toFloat())
+
+    var parent: ViewParent? = view.parent
+    while (parent is View) {
+      val parentView = parent
+
+      rect.offset(-parentView.scrollX.toFloat(), -parentView.scrollY.toFloat())
+
+      matrix = parentView.matrix
+      if (!matrix.isIdentity) {
+        matrix.mapRect(rect)
+      }
+
+      rect.offset(parentView.left.toFloat(), parentView.top.toFloat())
+
+      parent = parentView.parent
+    }
+  }
+}
+

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -1206,4 +1206,16 @@ void FabricMountingManager::synchronouslyUpdateViewOnUIThread(
   synchronouslyUpdateViewOnUIThreadJNI(javaUIManager_, viewTag, propsMap);
 }
 
+void FabricMountingManager::measure(Tag viewTag, int64_t callbackId, bool inWindow) {
+  static auto measureJNI =
+      JFabricUIManager::javaClassStatic()->getMethod<void(jint, jlong, jboolean)>(
+          "measure");
+
+  measureJNI(
+      javaUIManager_,
+      static_cast<jint>(viewTag),
+      static_cast<jlong>(callbackId),
+      static_cast<jboolean>(inWindow));
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -54,6 +54,8 @@ class FabricMountingManager final {
 
   void synchronouslyUpdateViewOnUIThread(Tag viewTag, const folly::dynamic &props);
 
+  void measure(Tag viewTag, int64_t callbackId, bool inWindow);
+
  private:
   bool isOnMainThread();
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
+#include <optional>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/MountingCoordinator.h>
@@ -20,6 +22,24 @@ namespace facebook::react {
  */
 class SchedulerDelegate {
  public:
+  struct MeasureResult {
+    double pageX{0};
+    double pageY{0};
+    double width{0};
+    double height{0};
+  };
+
+  struct MeasureInWindowResult {
+    double x{0};
+    double y{0};
+    double width{0};
+    double height{0};
+  };
+
+  using MeasureCallback = std::function<void(std::optional<MeasureResult>)>;
+  using MeasureInWindowCallback =
+      std::function<void(std::optional<MeasureInWindowResult>)>;
+
   /*
    * Called right after Scheduler computed (and laid out) a new updated version
    * of the tree and calculated a set of mutations which are sufficient
@@ -59,6 +79,29 @@ class SchedulerDelegate {
   virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic &props) = 0;
 
   virtual void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) = 0;
+
+  /*
+   * Request measuring a mounted native view (if present). Implementations may
+   * call `callback` on any thread. Default implementation reports failure.
+   */
+  virtual void schedulerMeasure(
+      SurfaceId /*surfaceId*/,
+      Tag /*tag*/,
+      MeasureCallback callback) {
+    callback(std::nullopt);
+  }
+
+  /*
+   * Request measuring a mounted native view (if present) in window coordinates.
+   * Implementations may call `callback` on any thread. Default implementation
+   * reports failure.
+   */
+  virtual void schedulerMeasureInWindow(
+      SurfaceId /*surfaceId*/,
+      Tag /*tag*/,
+      MeasureInWindowCallback callback) {
+    callback(std::nullopt);
+  }
 
   virtual ~SchedulerDelegate() noexcept = default;
 };

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -173,6 +173,66 @@ function PressableDelayEvents() {
   );
 }
 
+function PressableDuringNativeDriverAnimation() {
+  const [pressCount, setPressCount] = useState(0);
+  const translateX = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(translateX, {
+          toValue: 1,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateX, {
+          toValue: 0,
+          duration: 1200,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [translateX]);
+
+  const tx = translateX.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, 160],
+  });
+
+  return (
+    <View>
+      <View style={styles.logBox}>
+        <Text>
+          Try pressing the moving button while it animates (native driver). If
+          hit testing is broken, the press count won’t increment reliably.
+        </Text>
+        <Text testID="pressable_native_driver_press_count">
+          Press count: {pressCount}
+        </Text>
+      </View>
+
+      <View style={[styles.row, {height: 72}]}>
+        <Animated.View style={{transform: [{translateX: tx}]}}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={() => setPressCount(c => c + 1)}
+            style={({pressed}) => [
+              styles.wrapperCustom,
+              {backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white'},
+            ]}>
+            <Text style={styles.text}>Tap me while moving</Text>
+          </Pressable>
+        </Animated.View>
+      </View>
+    </View>
+  );
+}
+
 function ForceTouchExample() {
   const [force, setForce] = useState(0);
 
@@ -403,6 +463,15 @@ const examples = [
       'onPressOut, and onLongPress as props.': string),
     render: function (): React.Node {
       return <PressableFeedbackEvents />;
+    },
+  },
+  {
+    title: 'Press during native-driver transform animation (Android)',
+    description:
+      ('Repro for pressability regressions during native-driven transforms. Try tapping while it moves.': string),
+    platform: 'android',
+    render(): React.Node {
+      return <PressableDuringNativeDriverAnimation />;
     },
   },
   {


### PR DESCRIPTION
## Summary:
Fix Fabric `UIManager.measure` / `measureInWindow` returning **shadow-tree** coordinates on Android (and iOS), which breaks `Pressability` hit regions when the native view is moving (e.g. native-driven animations).

- **Issue**: [facebook/react-native#51621](https://github.com/facebook/react-native/issues/51621)
- **Related attempts**: [discord/react-native#44](https://github.com/discord/react-native/pull/44), [facebook/react-native#51835](https://github.com/facebook/react-native/pull/51835)

This fix is inspired by a potential solution proposed in [#51621](https://github.com/facebook/react-native/issues/51621).

## What changed
- Route Fabric `measure` / `measureInWindow` through `SchedulerDelegate` so the platform can optionally measure the **mounted native view** on the UI thread.
- Android: measure mounted `View` bounds (incl. transforms) and report back to C++/JS.
- iOS: measure mounted `UIView` via `convertRect` and report back to C++/JS.
- Keep existing DOM/shadow-tree measurement as a fallback.

## Changelog:
[ANDROID] [FIXED] - Fabric `measure` / `measureInWindow` use mounted native view coordinates (fixes Pressable `onPress` during native-driven animations).
[IOS] [FIXED] - Fabric `measure` / `measureInWindow` use mounted native view coordinates.

## Test Plan:
- `yarn test packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js`
- RNTester:
  - Pressable → “Pressable with Animated Transform”
  - Verify `onPress` works while the view is animating (Android + iOS)