### PR TITLE
fix(VirtualizedList): sync virtualization logic with local direction style

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -924,11 +924,13 @@ class VirtualizedList extends StateSafePureComponent<
     const {ListEmptyComponent, ListFooterComponent, ListHeaderComponent} =
       this.props;
     const {data, horizontal} = this.props;
+    const isRTL = this._orientation().rtl
     const inversionStyle = this.props.inverted
       ? horizontalOrDefault(this.props.horizontal)
-        ? styles.horizontallyInverted
+        ? [styles.horizontallyInverted]
         : styles.verticallyInverted
       : null;
+    const orientationStyle =  {direction: isRTL ? 'rtl' : 'ltr'}
     const cells: Array<any | React.Node> = [];
     const stickyIndicesFromProps = new Set(this.props.stickyHeaderIndices);
     const stickyHeaderIndices = [];
@@ -1106,8 +1108,8 @@ class VirtualizedList extends StateSafePureComponent<
           : this.props.inverted,
       stickyHeaderIndices,
       style: inversionStyle
-        ? [inversionStyle, this.props.style]
-        : this.props.style,
+        ? [inversionStyle, this.props.style, orientationStyle]
+        : [this.props.style, orientationStyle],
       isInvertedVirtualizedList: this.props.inverted,
       maintainVisibleContentPosition:
         this.props.maintainVisibleContentPosition != null
@@ -1502,7 +1504,7 @@ class VirtualizedList extends StateSafePureComponent<
   }
 
   _selectLength(
-    metrics: Readonly<{
+    metrics: $ReadOnly<{
       height: number,
       width: number,
       ...
@@ -1517,12 +1519,23 @@ class VirtualizedList extends StateSafePureComponent<
     return this._orientation().horizontal ? x : y;
   }
 
-  _orientation(): ListOrientation {
-    return {
-      horizontal: horizontalOrDefault(this.props.horizontal),
-      rtl: I18nManager.isRTL,
-    };
+ _orientation(): ListOrientation {
+  const horizontal = horizontalOrDefault(this.props.horizontal);
+  const flatStyle = StyleSheet.flatten(this.props.style);
+  const localDirection = flatStyle?.direction;
+
+  let isRTL = I18nManager.isRTL;
+  if (localDirection === 'rtl') {
+    isRTL = true;
+  } else if (localDirection === 'ltr') {
+    isRTL = false;
   }
+
+  return {
+    horizontal,
+    rtl: isRTL,
+  };
+}
 
   _maybeCallOnEdgeReached() {
     const {


### PR DESCRIPTION
## Summary:

This commit fixes the blank rendering and behavior issue that occurs when a VirtualizedList is used in an RTL environment but explicitly styled as LTR.

The root cause was a mismatch between the JS-level coordinate normalization and the Native-level layout direction. While the native ScrollView rendered as LTR, the JS logic still applied RTL mirror calculations based on the global I18nManager state. This issue occurs on both iOS and Android.

## Changelog:

[GENERAL] [FIXED] - Synchronize VirtualizedList coordinate logic with local direction style to fix blank rendering in RTL environments.

## Test Plan:

1. Environment: Set device/emulator system language to an RTL language (e.g., Arabic).
2. render this component

```tsx
<FlatList
  horizontal
  data={Array.from({length: 100}, (_, i) => ({id: i}))}
  renderItem={({item}) => (
    <View style={{width: 100, height: 100, backgroundColor: 'red', margin: 5}} />
  )}
  style={{direction: 'ltr'}}
/>
```

### Expected Behavior:

Rendering: All items are rendered correctly during scroll.

Interaction: The scroll origin is at the left, and swiping follows LTR physics, matching the visual layout.

### Actual Behavior (Before Fix):

Only the first few items appear; the rest are blank.

## Related Issue

https://github.com/facebook/react-native/issues/55433
