### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary annotation to ReactHostInspectorTarget

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -18,6 +18,7 @@ import com.facebook.react.devsupport.inspector.TracingStateListener
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTarget
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorUpdateListener
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import java.io.Closeable
 import java.util.concurrent.Executor
 
@@ -82,6 +83,7 @@ internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) :
     return mHybridData.isValid()
   }
 
+  @SoLoaderLibrary("rninstance")
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")


### PR DESCRIPTION
Summary:
This fixes the MissingSoLoaderLibrary lint warning in ReactHostInspectorTarget.kt by
adding the SoLoaderLibrary("rninstance") annotation to the companion object that
loads the native library via SoLoader.loadLibrary(). This annotation helps with static
analysis and proper tracking of native library dependencies.

Also adds the required soloader annotation dependency to the BUCK file.

Reviewed By: alanleedev

Differential Revision: D92022954


