### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary to JSRuntimeFactory

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
@@ -10,7 +10,9 @@ package com.facebook.react.runtime
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("rninstance")
 public abstract class JSRuntimeFactory(
     @Suppress("unused", "NoHungarianNotation", "NotAccessedPrivateField")
     @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -18,6 +18,7 @@ import com.facebook.react.devsupport.inspector.TracingStateListener
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTarget
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorUpdateListener
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import java.io.Closeable
 import java.util.concurrent.Executor
 
@@ -82,6 +83,7 @@ internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) :
     return mHybridData.isValid()
   }
 
+  @SoLoaderLibrary("rninstance")
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")


### PR DESCRIPTION
Summary:
Fixed MissingSoLoaderLibrary lint error in JSRuntimeFactory.kt.

Added `SoLoaderLibrary("rninstance")` annotation to document that this class loads
the "rninstance" native library via SoLoader.

changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D92023701


