### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary to BlobCollector

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobCollector.kt
@@ -10,7 +10,9 @@ package com.facebook.react.modules.blob
 import com.facebook.react.bridge.JavaScriptContextHolder
 import com.facebook.react.bridge.ReactContext
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("reactnativeblob")
 internal object BlobCollector {
   init {
     SoLoader.loadLibrary("reactnativeblob")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
@@ -10,7 +10,9 @@ package com.facebook.react.runtime
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("rninstance")
 public abstract class JSRuntimeFactory(
     @Suppress("unused", "NoHungarianNotation", "NotAccessedPrivateField")
     @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
@@ -13,8 +13,10 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.modules.core.JavaScriptTimerExecutor
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
 @DoNotStrip
+@SoLoaderLibrary("rninstance")
 internal class JSTimerExecutor() : HybridClassBase(), JavaScriptTimerExecutor {
   init {
     initHybrid()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -18,6 +18,7 @@ import com.facebook.react.devsupport.inspector.TracingStateListener
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTarget
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorUpdateListener
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import java.io.Closeable
 import java.util.concurrent.Executor
 
@@ -82,6 +83,7 @@ internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) :
     return mHybridData.isValid()
   }
 
+  @SoLoaderLibrary("rninstance")
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -11,7 +11,9 @@ import com.facebook.jni.HybridData
 import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("hermesinstancejni")
 public class HermesInstance(allocInOldGenBeforeTTI: Boolean) :
     JSRuntimeFactory(initHybrid(allocInOldGenBeforeTTI)) {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolverBinding.kt
@@ -10,6 +10,7 @@ package com.facebook.react.uimanager
 import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import kotlin.jvm.JvmStatic
 
 /**
@@ -19,6 +20,7 @@ import kotlin.jvm.JvmStatic
  * JavaScript runtime, making component name information available to the native side.
  */
 @DoNotStripAny
+@SoLoaderLibrary("uimanagerjni")
 internal object ComponentNameResolverBinding {
   init {
     SoLoader.loadLibrary("uimanagerjni")


### PR DESCRIPTION
Summary:
Fixed MissingSoLoaderLibrary lint error in BlobCollector.kt.

Added `SoLoaderLibrary("reactnativeblob")` annotation to document that this class
loads the "reactnativeblob" native library via SoLoader.

Also added the required soloader annotation dependency to the BUCK file.

changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D92024489


