### PR TITLE
fix(android): props 2.0 image tintColor=transparent broken

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -63,7 +63,11 @@ using namespace facebook::react;
 
   // `tintColor`
   if (oldImageProps.tintColor != newImageProps.tintColor) {
-    _imageView.tintColor = RCTUIColorFromSharedColor(newImageProps.tintColor);
+    if (newImageProps.tintColor.has_value()) {
+      _imageView.tintColor = RCTUIColorFromSharedColor(newImageProps.tintColor.value());
+    } else {
+      _imageView.tintColor = nil;
+    }
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -247,7 +247,11 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
   }
 
   if (tintColor != oldProps->tintColor) {
-    result["tintColor"] = *tintColor;
+      if (tintColor.has_value()) {
+        result["tintColor"] = *tintColor.value();
+      } else {
+        result["tintColor"] = folly::dynamic(nullptr);
+      }
   }
 
   if (internal_analyticTag != oldProps->internal_analyticTag) {

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -31,7 +31,7 @@ class ImageProps final : public ViewProps {
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};
-  SharedColor tintColor{};
+  std::optional<SharedColor> tintColor{};
   std::string internal_analyticTag{};
   std::string resizeMethod{"auto"};
   Float resizeMultiplier{1.f};

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -26,7 +26,7 @@ class ImageRequestParams {
       Float resizeMultiplier,
       bool shouldNotifyLoadEvents,
       SharedColor overlayColor,
-      SharedColor tintColor,
+      std::optional<SharedColor> tintColor,
       Float fadeDuration,
       bool progressiveRenderingEnabled,
       ImageSource loadingIndicatorSource,
@@ -55,7 +55,7 @@ class ImageRequestParams {
   Float resizeMultiplier{};
   bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
-  SharedColor tintColor{};
+  std::optional<SharedColor> tintColor{};
   Float fadeDuration{};
   bool progressiveRenderingEnabled{};
   ImageSource loadingIndicatorSource{};

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -58,8 +58,12 @@ inline void serializeImageRequestParams(MapBufferBuilder &builder, const ImageRe
   if (isColorMeaningful(imageRequestParams.overlayColor)) {
     builder.putInt(IS_KEY_OVERLAY_COLOR, toAndroidRepr(imageRequestParams.overlayColor));
   }
-  if (isColorMeaningful(imageRequestParams.tintColor)) {
-    builder.putInt(IS_KEY_TINT_COLOR, toAndroidRepr(imageRequestParams.tintColor));
+  if (imageRequestParams.tintColor.has_value()) {
+    auto tintColor = imageRequestParams.tintColor.value();
+    if (isColorMeaningful(tintColor)) {
+      builder.putInt(
+          IS_KEY_TINT_COLOR, toAndroidRepr(tintColor));
+    }
   }
   builder.putInt(IS_KEY_FADE_DURATION, static_cast<int32_t>(imageRequestParams.fadeDuration));
   builder.putBool(IS_KEY_PROGRESSIVE_RENDERING_ENABLED, imageRequestParams.progressiveRenderingEnabled);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When enabling the props 2.0 feature flags I noticed that for an `<Image source={...} style={{ tintColor: 'transparent' }} />` the image is actually still showing, instead of becoming transparent.

### The underlying issue

All color props are defined as `SharedColor`, where a `SharedColor` has a default value of `0`:

https://github.com/facebook/react-native/blob/f3678f51d9873cb19602d7e36a4d8ed71562b9d0/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h#L15-L18

https://github.com/facebook/react-native/blob/f3678f51d9873cb19602d7e36a4d8ed71562b9d0/packages/react-native/ReactCommon/react/renderer/graphics/Color.h#L30-L32

> [!NOTE] 
> This is a bit confusing to me. `0` is not really an "undefined" color, but its actually "transparent". What we are really saying this way is that all color props have a default value of "transparent". The naming makes me unsure whether this has been intentional.

For other use cases, this seems to make sense. Ie. a user expects their text to have a background color of transparent/"nothing". However, we do not expect our image's tint color to have a default color of "transparent". This would hide all our images.

With props 2.0 we use the `getDiffProp` function, and when we pass `tintColor: 'transparent'` it will be passed to native as `tintColor: 0`. When we then compare the passed prop's value vs the default value here, it will not include the `tintColor`:

https://github.com/facebook/react-native/blob/f3678f51d9873cb19602d7e36a4d8ed71562b9d0/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp#L249-L251

`tintColor` really is an optional color prop, and should be treated as such. The best fix I found was therefor making it really an `std::optional`. Let me know if you think otherwise!

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - ImageProps make `tintColor` an `std::optional` to support color `transparent` (`0`) with props 2.0

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- In the RNTester app change one of the Tint Color image examples to use tintColor of "transparent"
- The image should be invisible now as all visible pixels turned transparent
- Enable the props 2.0 feature flags
- Run the same example, notice that the tintColor has not been applied