### PR TITLE
fix: maintainVisibleContentPosition not compensating for height changes of first visible view

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -1090,6 +1090,14 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   // TODO: detect and handle/ignore re-ordering
   if (horizontal) {
     CGFloat deltaX = _firstVisibleView.frame.origin.x - _prevFirstVisibleFrame.origin.x;
+    // If the first visible view didn't move but grew in width,
+    // content after it still shifted. Use width change as delta.
+    if (ABS(deltaX) <= 0.5) {
+      CGFloat widthDelta = _firstVisibleView.frame.size.width - _prevFirstVisibleFrame.size.width;
+      if (widthDelta > 0.5) {
+        deltaX = widthDelta;
+      }
+    }
     if (ABS(deltaX) > 0.5) {
       CGFloat x = _scrollView.contentOffset.x;
       [self _forceDispatchNextScrollEvent];
@@ -1104,6 +1112,14 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   } else {
     CGRect newFrame = _firstVisibleView.frame;
     CGFloat deltaY = newFrame.origin.y - _prevFirstVisibleFrame.origin.y;
+    // If the first visible view didn't move but grew in height,
+    // content below it still shifted. Use height change as delta.
+    if (ABS(deltaY) <= 0.5) {
+      CGFloat heightDelta = newFrame.size.height - _prevFirstVisibleFrame.size.height;
+      if (heightDelta > 0.5) {
+        deltaY = heightDelta;
+      }
+    }
     if (ABS(deltaY) > 0.5) {
       CGFloat y = _scrollView.contentOffset.y;
       [self _forceDispatchNextScrollEvent];

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
@@ -106,7 +106,15 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
     firstVisibleView.getHitRect(newFrame)
 
     if (horizontal) {
-      val deltaX = newFrame.left - prevFirstVisibleFrame.left
+      var deltaX = newFrame.left - prevFirstVisibleFrame.left
+      // If the first visible view didn't move but grew in width,
+      // content after it still shifted. Use width change as delta.
+      if (deltaX == 0) {
+        val widthDelta = newFrame.width() - prevFirstVisibleFrame.width()
+        if (widthDelta > 0) {
+          deltaX = widthDelta
+        }
+      }
       if (deltaX != 0) {
         val scrollX = scrollView.scrollX
         scrollView.scrollToPreservingMomentum(scrollX + deltaX, scrollView.scrollY)
@@ -116,7 +124,15 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
         }
       }
     } else {
-      val deltaY = newFrame.top - prevFirstVisibleFrame.top
+      var deltaY = newFrame.top - prevFirstVisibleFrame.top
+      // If the first visible view didn't move but grew in height,
+      // content below it still shifted. Use height change as delta.
+      if (deltaY == 0) {
+        val heightDelta = newFrame.height() - prevFirstVisibleFrame.height()
+        if (heightDelta > 0) {
+          deltaY = heightDelta
+        }
+      }
       if (deltaY != 0) {
         val scrollY = scrollView.scrollY
         scrollView.scrollToPreservingMomentum(scrollView.scrollX, scrollY + deltaY)


### PR DESCRIPTION
The algorithm only compared the first visible view's origin before and after a mounting transaction. When the first visible view grows in size without changing its origin, content after it shifts but no scroll compensation was applied. This adds a size-change check that fires only when the origin delta is negligible, covering scenarios like streaming chat messages in inverted FlatLists, lazy-loaded images, and expandable content.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[General] [Fixed] - maintainVisibleContentPosition now compensates for size changes of the
   first visible view, not just origin changes

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
