### PR TITLE
add failing test for ItemSeparatorComponent state bug

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -12,27 +12,111 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {useState} from 'react';
+import {
+  Button,
+  SectionList,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+const INITIAL_SECTIONS = [
+  {title: 'Section', data: [{key: 'a'}, {key: 'b'}, {key: 'c'}]},
+];
+const REORDERED_SECTIONS = [
+  {title: 'Section', data: [{key: 'b'}, {key: 'a'}, {key: 'c'}]},
+];
+
+function ItemSeparatorReproducer({leadingItem, trailingItem}: any) {
+  const leading = leadingItem?.key ?? 'undefined';
+  const trailing = trailingItem?.key ?? 'undefined';
+  return (
+    <View style={styles.separator}>
+      <Text style={styles.separatorText}>
+        leading: {leading} | trailing: {trailing}
+      </Text>
+    </View>
+  );
+}
+
+function ItemSeparatorComponentBugPlayground() {
+  const [sections, setSections] = useState(INITIAL_SECTIONS);
+  const [reordered, setReordered] = useState(false);
+
+  return (
+    <View style={styles.container}>
+      <RNTesterText>
+        Bug: ItemSeparatorComponent receives stale leadingItem/trailingItem after
+        reorder. Tap "Reorder" to swap first two items. The separator between
+        "b" and "a" should show "leading: b | trailing: a". If it shows
+        "leading: a | trailing: c" or "undefined", the bug is present.
+      </RNTesterText>
+      <Button
+        title={reordered ? 'Reset' : 'Reorder (swap first two)'}
+        onPress={() => {
+          setReordered(r => !r);
+          setSections(reordered ? INITIAL_SECTIONS : REORDERED_SECTIONS);
+        }}
+      />
+      <SectionList
+        style={styles.list}
+        sections={sections}
+        keyExtractor={item => item.key}
+        renderItem={({item}) => (
+          <View style={styles.item}>
+            <Text>{item.key}</Text>
+          </View>
+        )}
+        renderSectionHeader={({section: {title}}) => (
+          <Text style={styles.sectionHeader}>{title}</Text>
+        )}
+        ItemSeparatorComponent={ItemSeparatorReproducer}
+      />
+    </View>
+  );
+}
 
 function Playground() {
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <ItemSeparatorComponentBugPlayground />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
     padding: 10,
+  },
+  item: {
+    padding: 12,
+    backgroundColor: '#f0f0f0',
+  },
+  list: {
+    flex: 1,
+  },
+  sectionHeader: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    paddingVertical: 8,
+  },
+  separator: {
+    height: 24,
+    backgroundColor: '#e0e0ff',
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+  },
+  separatorText: {
+    fontSize: 12,
   },
 });
 
 export default ({
   title: 'Playground',
   name: 'playground',
-  description: 'Test out new features and ideas.',
+  description:
+    'Test out new features and ideas. Includes reproducer for ItemSeparatorComponent leadingItem/trailingItem state bug.',
   render: (): React.Node => <Playground />,
 }: RNTesterModuleExample);

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
@@ -202,6 +202,64 @@ describe('VirtualizedSectionList', () => {
     expect(component).toMatchSnapshot();
   });
 
+  it('syncs ItemWithSeparator separator props when list re-renders with new leadingItem/trailingItem', async () => {
+    // Reproduces: When ItemWithSeparator re-renders with new props (e.g. after reorder),
+    // leadingItem/trailingItem can become stale (e.g. undefined when the row was previously at a boundary).
+    const separatorPropsReceived = [];
+    const ItemSeparatorWithCapture = props => {
+      separatorPropsReceived.push({
+        leadingItem: props.leadingItem?.key,
+        trailingItem: props.trailingItem?.key,
+      });
+      return <separator {...props} />;
+    };
+
+    let setSections;
+    const initialSections = [
+      {title: 's0', data: [{key: 'a'}, {key: 'b'}, {key: 'c'}]},
+    ];
+    const reorderedSections = [
+      {title: 's0', data: [{key: 'b'}, {key: 'a'}, {key: 'c'}]},
+    ];
+
+    function ListWithState() {
+      const [sections, setSectionsState] = React.useState(initialSections);
+      setSections = setSectionsState;
+      return (
+        <VirtualizedSectionList
+          ItemSeparatorComponent={ItemSeparatorWithCapture}
+          sections={sections}
+          renderItem={({item}) => <item title={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+          keyExtractor={(item, index) => item.key}
+        />
+      );
+    }
+
+    let component;
+    await ReactTestRenderer.act(() => {
+      component = ReactTestRenderer.create(<ListWithState />);
+    });
+
+    separatorPropsReceived.length = 0;
+
+    await ReactTestRenderer.act(() => {
+      setSections(reorderedSections);
+    });
+
+    // After reorder: row "b" moved from index 1 to 0. Its trailing separator
+    // (between b and a) should show leadingItem: b, trailingItem: a.
+    // But buggy ItemWithSeparator keeps the initial
+    // state from when "b" was at index 1 (leadingItem: a, trailingItem: c), so
+    // the separator receives stale props and this assertion fails.
+    expect(separatorPropsReceived).toEqual(
+      expect.arrayContaining([
+        {leadingItem: 'b', trailingItem: 'a'},
+      ]),
+    );
+  });
+
   describe('scrollToLocation', () => {
     const ITEM_HEIGHT = 100;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

**Bug: VirtualizedSectionList passes incorrect leading/trailingItem to ItemSeparatorComponent**

Our app has a `<SectionList>` which was intermittently rendering `ItemSeparatorComponent`s with wildly incorrect `leadingItem`/`trailingItem` props, including `undefined`, which as far as I can tell should never happen.

(While I’m here, I would also like to complain that the type definition for this prop is `React.ComponentType<any>` so I also spent a bit of time trying to work out if `undefined` was even an expected value.)

After investigation, it turns out that `ItemWithSeparator` keeps these values in state, so when the same cell happens to re-render with new props (for example when the virtualized list renders a different region), the separator keeps the previous `leadingItem`/`trailingItem`, which can be undefined if that previous row was at a section boundary.

I attach here a failing unit test which reproduces this behavior.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[General] [Fixed] - VirtualizedSectionList passes correct leading/trailingItem to ItemSeparatorComponent

## Test Plan:

Run the test and observe it failing. I looked into fixing it, but was stymied by the highlighting and updateProps features: they also store state on `ItemWithSeparator`, which presumably is equally incorrect when it moves, but I don’t understand what the intended behavior is here or where that state ought to live instead. (For example, if you highlight the separator between items B and C, and item B is removed, should the highlight be transferred to the now A-C separator?)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
