### PR TITLE
Skip set-rn-artifacts-version for PRs targeting stable branches

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -26,7 +26,9 @@ runs:
       # already set from the 'create release' commits on the release branch.
       # For testing RC.0, though, the version has not been set yet. In that case, we are on Stable branch and
       # it is the only case when the version is still 1000.0.0
-      if: ${{ !endsWith(github.ref_name, '-stable') || endsWith(github.ref_name, '-stable') && steps.read-rn-version.outputs.rn-version == '1000.0.0' }}
+      # We also skip this when the PR targets a stable branch (github.base_ref ends with '-stable'),
+      # since the version is already set on the stable branch.
+      if: ${{ !endsWith(github.ref_name, '-stable') && !endsWith(github.base_ref || '', '-stable') || endsWith(github.ref_name, '-stable') && steps.read-rn-version.outputs.rn-version == '1000.0.0' }}
       shell: bash
       run: node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ inputs.release-type }}
     - name: Setup gradle


### PR DESCRIPTION
## Summary
When a PR targets a `-stable` branch, `github.ref_name` is the PR branch (not ending in `-stable`), so the version script was incorrectly running. Added a check for `github.base_ref` to also skip the script when the PR target branch is a stable branch.

## Changelog:
[Internal] - Skip set-rn-artifacts-version for PRs targeting stable branches

## Test plan
CI should pass without running the artifacts version script on PRs targeting stable branches.