### PR TITLE
Fix KotlinNullableVariableCastToNonnullType: Use safe casts in InterpolationAnimatedNode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
@@ -76,29 +76,34 @@ internal class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNod
     val parentValue = parent?.getValue() ?: return
     when (outputType) {
       OutputType.Number ->
-          nodeValue =
-              interpolate(
-                  parentValue,
-                  inputRange,
-                  outputRange as DoubleArray,
-                  extrapolateLeft,
-                  extrapolateRight,
-              )
-      OutputType.Color ->
-          objectValue =
-              Integer.valueOf(interpolateColor(parentValue, inputRange, outputRange as IntArray))
-      OutputType.String ->
-          pattern?.let {
-            @Suppress("UNCHECKED_CAST")
-            objectValue =
-                interpolateString(
-                    it,
+          (outputRange as? DoubleArray)?.let { range ->
+            nodeValue =
+                interpolate(
                     parentValue,
                     inputRange,
-                    outputRange as Array<DoubleArray>,
+                    range,
                     extrapolateLeft,
                     extrapolateRight,
                 )
+          }
+      OutputType.Color ->
+          (outputRange as? IntArray)?.let { range ->
+            objectValue = Integer.valueOf(interpolateColor(parentValue, inputRange, range))
+          }
+      OutputType.String ->
+          pattern?.let { pat ->
+            @Suppress("UNCHECKED_CAST")
+            (outputRange as? Array<DoubleArray>)?.let { range ->
+              objectValue =
+                  interpolateString(
+                      pat,
+                      parentValue,
+                      inputRange,
+                      range,
+                      extrapolateLeft,
+                      extrapolateRight,
+                  )
+            }
           }
 
       else -> {}


### PR DESCRIPTION
Summary:
Fixed KotlinNullableVariableCastToNonnullType lint errors in InterpolationAnimatedNode.kt.

The `outputRange` field is nullable (`Any?`) but was being cast directly to non-null types
(`DoubleArray`, `IntArray`, `Array<DoubleArray>`) in the `update()` method. Changed to use
safe casts (`as?`) with `?.let` blocks to handle the null case gracefully.

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D92133946


