### PR TITLE
feat(yoga): Add cache miss tracking to LayoutData for hit rate metrics

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2266,6 +2266,10 @@ bool calculateLayoutInternal(
     (performLayout ? layoutMarkerData.cachedLayouts
                    : layoutMarkerData.cachedMeasures) += 1;
   } else {
+    // Track cache misses for computing hit rates
+    (performLayout ? layoutMarkerData.layoutCacheMisses
+                   : layoutMarkerData.measureCacheMisses) += 1;
+
     calculateLayoutImpl(
         node,
         availableWidth,

--- a/packages/react-native/ReactCommon/yoga/yoga/event/event.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/event/event.h
@@ -41,6 +41,10 @@ struct LayoutData {
   uint32_t maxMeasureCache = 0;
   int cachedLayouts = 0;
   int cachedMeasures = 0;
+  // Cache misses occur when a cached result is not found and layout must be
+  // recalculated. Track these to compute cache hit rates.
+  int layoutCacheMisses = 0;
+  int measureCacheMisses = 0;
   int measureCallbacks = 0;
   std::array<int, static_cast<uint8_t>(LayoutPassReason::COUNT)>
       measureCallbackReasonsCount;


### PR DESCRIPTION
# PR: feat(yoga): Add cache miss tracking to LayoutData for hit rate metrics

## Summary

Add `layoutCacheMisses` and `measureCacheMisses` fields to Yoga's `LayoutData` struct to enable cache hit rate calculation in layout performance analysis.

Currently, Yoga tracks cache hits (`cachedLayouts`, `cachedMeasures`) but not cache misses. This makes it impossible to calculate cache efficiency metrics like hit rate percentage.

With this change, consumers of the `LayoutPassEnd` event can now compute:

```cpp
float layoutHitRate = (float)cachedLayouts / (cachedLayouts + layoutCacheMisses);
float measureHitRate = (float)cachedMeasures / (cachedMeasures + measureCacheMisses);
```

This enables better performance profiling and optimization insights for React Native apps.

Changelog: [INTERNAL] [ADDED] - Add cache miss tracking to Yoga LayoutData for hit rate metrics

## Test Plan

- Built Yoga library successfully with `cmake` and `make`
- Verified first layout produces cache misses (2 misses for root + child nodes)
- Verified second layout with same dimensions produces cache hits (1 hit)
- Verified cache hit rate is calculable (100% on second pass with same dimensions)

```
Testing cache hit/miss metrics...
After first layout:
  cachedLayouts: 0
  layoutCacheMisses: 2
  ✓ First layout has expected cache misses

After second layout (same dimensions):
  cachedLayouts: 1
  layoutCacheMisses: 0
  ✓ Second layout has expected cache hits

Layout Cache Hit Rate: 100%
✅ All cache metrics tests passed!
```

## Impact

- No breaking changes
- Backward compatible (new fields default to 0)
- Minimal performance overhead (single integer increment per layout operation)
