### PR TITLE
Fix LogBox parsing for cross-runtime jsi::JSErrors

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -170,7 +170,7 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
-    onTaskError_(runtime, error);
+    reportError(runtime, error);
   } catch (std::exception& ex) {
     jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
@@ -242,7 +242,7 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
-    onTaskError_(runtime, error);
+    reportError(runtime, error);
   } catch (std::exception& ex) {
     jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
@@ -250,6 +250,33 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
 
   currentPriority_ = previousPriority;
   isPerformingWork_ = false;
+}
+
+void RuntimeScheduler_Legacy::reportError(
+    jsi::Runtime& runtime,
+    jsi::JSError& error) const {
+  try {
+    auto errorCtor =
+        runtime.global().getPropertyAsFunction(runtime, "Error");
+    auto errorObj =
+        errorCtor
+            .callAsConstructor(
+                runtime,
+                jsi::String::createFromUtf8(runtime, error.getMessage()))
+            .getObject(runtime);
+    errorObj.setProperty(
+        runtime,
+        "stack",
+        jsi::String::createFromUtf8(runtime, error.getStack()));
+    jsi::JSError localError(
+        jsi::Value(std::move(errorObj)),
+        error.getMessage(),
+        error.getStack());
+    onTaskError_(runtime, localError);
+  } catch (...) {
+    jsi::JSError fallbackError(runtime, error.getMessage());
+    onTaskError_(runtime, fallbackError);
+  }
 }
 
 void RuntimeScheduler_Legacy::executeTask(

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -149,6 +149,8 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
 
   void executeTask(jsi::Runtime &runtime, const std::shared_ptr<Task> &task, bool didUserCallbackTimeout);
 
+  void reportError(jsi::Runtime &runtime, jsi::JSError &error) const;
+
   /*
    * Returns a time point representing the current point in time. May be called
    * from multiple threads.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -380,10 +380,37 @@ void RuntimeScheduler_Modern::executeTask(
       task.callback = result.getObject(runtime).getFunction(runtime);
     }
   } catch (jsi::JSError& error) {
-    onTaskError_(runtime, error);
+    reportError(runtime, error);
   } catch (std::exception& ex) {
     jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
+  }
+}
+
+void RuntimeScheduler_Modern::reportError(
+    jsi::Runtime& runtime,
+    jsi::JSError& error) const {
+  try {
+    auto errorCtor =
+        runtime.global().getPropertyAsFunction(runtime, "Error");
+    auto errorObj =
+        errorCtor
+            .callAsConstructor(
+                runtime,
+                jsi::String::createFromUtf8(runtime, error.getMessage()))
+            .getObject(runtime);
+    errorObj.setProperty(
+        runtime,
+        "stack",
+        jsi::String::createFromUtf8(runtime, error.getStack()));
+    jsi::JSError localError(
+        jsi::Value(std::move(errorObj)),
+        error.getMessage(),
+        error.getStack());
+    onTaskError_(runtime, localError);
+  } catch (...) {
+    jsi::JSError fallbackError(runtime, error.getMessage());
+    onTaskError_(runtime, fallbackError);
   }
 }
 
@@ -419,7 +446,7 @@ void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
         break;
       }
     } catch (jsi::JSError& error) {
-      onTaskError_(runtime, error);
+      reportError(runtime, error);
     } catch (std::exception& ex) {
       jsi::JSError error(
           runtime, std::string("Non-js exception: ") + ex.what());

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -179,6 +179,16 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   void executeTask(jsi::Runtime &runtime, Task &task, bool didUserCallbackTimeout) const;
 
+  /*
+   * Re-creates a jsi::JSError as a proper Error instance in the given runtime
+   * and forwards it to onTaskError_. This is necessary because the caught
+   * error's jsi::Value may belong to a different jsi::Runtime (e.g. when the
+   * error originates from a background Hermes instance). Using a cross-runtime
+   * Value is undefined behavior and causes LogBox to show "Unknown".
+   * getMessage() and getStack() are plain C++ strings and always safe to use.
+   */
+  void reportError(jsi::Runtime &runtime, jsi::JSError &error) const;
+
   void updateRendering(HighResTimeStamp taskEndTime);
 
   bool performingMicrotaskCheckpoint_{false};

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -1206,6 +1206,55 @@ TEST_P(RuntimeSchedulerTest, errorInTaskShouldNotStopMicrotasks) {
   EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
 }
 
+TEST_P(RuntimeSchedulerTest, handlingCrossRuntimeError) {
+  auto secondRuntime = facebook::hermes::makeHermesRuntime();
+
+  bool didRunTask = false;
+  auto callback = createHostFunctionFromLambda(
+      [&didRunTask, &secondRuntime](bool /*unused*/) {
+        didRunTask = true;
+        throw jsi::JSError(*secondRuntime, "Cross-runtime error");
+        return jsi::Value::undefined();
+      });
+
+  runtimeScheduler_->scheduleTask(
+      SchedulerPriority::NormalPriority, std::move(callback));
+
+  EXPECT_FALSE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 1);
+
+  stubQueue_->tick();
+
+  EXPECT_TRUE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 0);
+  EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
+  EXPECT_EQ(stubErrorUtils_->getLastReportedMessage(), "Cross-runtime error");
+}
+
+TEST_P(RuntimeSchedulerTest, handlingErrorPreservesMessage) {
+  bool didRunTask = false;
+  auto callback =
+      createHostFunctionFromLambda([this, &didRunTask](bool /*unused*/) {
+        didRunTask = true;
+        throw jsi::JSError(*runtime_, "Same-runtime error");
+        return jsi::Value::undefined();
+      });
+
+  runtimeScheduler_->scheduleTask(
+      SchedulerPriority::NormalPriority, std::move(callback));
+
+  EXPECT_FALSE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 1);
+
+  stubQueue_->tick();
+
+  EXPECT_TRUE(didRunTask);
+  EXPECT_EQ(stubQueue_->size(), 0);
+  EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
+  EXPECT_EQ(
+      stubErrorUtils_->getLastReportedMessage(), "Same-runtime error");
+}
+
 TEST_P(RuntimeSchedulerTest, reportsLongTasks) {
   // Only for event loop
   if (!GetParam()) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/StubErrorUtils.h
@@ -46,8 +46,15 @@ class StubErrorUtils : public jsi::HostObject {
           name,
           1,
           [this](
-              jsi::Runtime &runtime, const jsi::Value &, const jsi::Value *arguments, size_t) noexcept -> jsi::Value {
+              jsi::Runtime &runtime, const jsi::Value &, const jsi::Value *arguments, size_t count) noexcept -> jsi::Value {
             reportFatalCallCount_++;
+            if (count > 0 && arguments[0].isObject()) {
+              auto obj = arguments[0].getObject(runtime);
+              auto msgVal = obj.getProperty(runtime, "message");
+              if (msgVal.isString()) {
+                lastReportedMessage_ = msgVal.getString(runtime).utf8(runtime);
+              }
+            }
             return jsi::Value::undefined();
           });
     }
@@ -60,8 +67,14 @@ class StubErrorUtils : public jsi::HostObject {
     return reportFatalCallCount_;
   }
 
+  const std::string &getLastReportedMessage() const
+  {
+    return lastReportedMessage_;
+  }
+
  private:
   int reportFatalCallCount_;
+  std::string lastReportedMessage_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary

When a `jsi::JSError` is thrown from a background Hermes runtime and caught in the RuntimeScheduler, the error's `jsi::Value` belongs to a different `jsi::Runtime`. Forwarding this cross-runtime value to `onTaskError_` is undefined behavior and causes LogBox to display "Unknown" instead of the actual error message.

This PR introduces a `reportError()` helper in both `RuntimeScheduler_Legacy` and `RuntimeScheduler_Modern` that:
- Re-creates the error as a proper `Error` instance in the **current** runtime using the safe C++ string accessors (`getMessage()` / `getStack()`)
- Preserves the original message and stack trace
- Falls back to a simple `jsi::JSError` if reconstruction fails

## Changelog:

[GENERAL] [FIXED] - Fix LogBox showing "Unknown" for errors originating from background Hermes runtimes

## Test plan:

- Added `handlingCrossRuntimeError` test: throws a `jsi::JSError` from a second Hermes runtime and verifies the error message is correctly forwarded
- Added `handlingErrorPreservesMessage` test: verifies same-runtime errors still work correctly with the new code path
- Updated `StubErrorUtils` to capture and expose the last reported error message for assertion


🤖 Generated with [Claude Code](https://claude.com/claude-code)