### PR TITLE
Fixes  CSS transform styles applied directly to <Text> components are silently ignored on iOS when using the new architecture

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
@@ -7,6 +7,8 @@
 
 #include "TextProps.h"
 
+#include <react/renderer/core/propsConversions.h>
+
 namespace facebook::react {
 
 TextProps::TextProps(
@@ -14,7 +16,19 @@ TextProps::TextProps(
     const TextProps& sourceProps,
     const RawProps& rawProps)
     : Props(context, sourceProps, rawProps),
-      BaseTextProps::BaseTextProps(context, sourceProps, rawProps) {};
+      BaseTextProps::BaseTextProps(context, sourceProps, rawProps),
+      transform(convertRawProp(
+          context,
+          rawProps,
+          "transform",
+          sourceProps.transform,
+          {})),
+      transformOrigin(convertRawProp(
+          context,
+          rawProps,
+          "transformOrigin",
+          sourceProps.transformOrigin,
+          {})) {};
 
 void TextProps::setProp(
     const PropsParserContext& context,
@@ -23,6 +37,12 @@ void TextProps::setProp(
     const RawValue& value) {
   BaseTextProps::setProp(context, hash, propName, value);
   Props::setProp(context, hash, propName, value);
+
+  static auto defaults = TextProps{};
+  switch (hash) {
+    RAW_SET_PROP_SWITCH_CASE_BASIC(transform);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(transformOrigin);
+  }
 }
 
 #pragma mark - DebugStringConvertible

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -12,6 +12,7 @@
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/Transform.h>
 
 namespace facebook::react {
 
@@ -22,6 +23,10 @@ class TextProps : public Props, public BaseTextProps {
 
   void
   setProp(const PropsParserContext &context, RawPropsPropNameHash hash, const char *propName, const RawValue &value);
+
+  // View-level props that affect whether this text node needs a backing view
+  Transform transform{};
+  TransformOrigin transformOrigin{};
 
 #pragma mark - DebugStringConvertible
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -42,6 +42,21 @@ class TextShadowNode : public ConcreteShadowNode<TextComponentName, ShadowNode, 
   {
     orderIndex_ = std::numeric_limits<decltype(orderIndex_)>::max();
   }
+  using BaseShadowNode = ConcreteShadowNode<TextComponentName, ShadowNode, TextProps, TextEventEmitter>;
+
+  static ShadowNodeTraits getModifiedTraitsForText(const ShadowNodeFragment &fragment, ShadowNodeTraits traits)
+  {
+    auto textProps = std::static_pointer_cast<const TextProps>(fragment.props);
+    if (textProps && !textProps->transform.operations.empty()) {
+      traits.set(ShadowNodeTraits::Trait::FormsView);
+    }
+    return traits;
+  }
+
+  TextShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits)
+      : BaseShadowNode(fragment, family, getModifiedTraitsForText(fragment, traits)), BaseTextShadowNode()
+  {
+  }
 #endif
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -42,19 +42,21 @@ class TextShadowNode : public ConcreteShadowNode<TextComponentName, ShadowNode, 
   {
     orderIndex_ = std::numeric_limits<decltype(orderIndex_)>::max();
   }
+#else
   using BaseShadowNode = ConcreteShadowNode<TextComponentName, ShadowNode, TextProps, TextEventEmitter>;
 
-  static ShadowNodeTraits getModifiedTraitsForText(const ShadowNodeFragment &fragment, ShadowNodeTraits traits)
-  {
-    auto textProps = std::static_pointer_cast<const TextProps>(fragment.props);
-    if (textProps && !textProps->transform.operations.empty()) {
-      traits.set(ShadowNodeTraits::Trait::FormsView);
-    }
-    return traits;
-  }
-
   TextShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits)
-      : BaseShadowNode(fragment, family, getModifiedTraitsForText(fragment, traits)), BaseTextShadowNode()
+      : BaseShadowNode(
+            fragment,
+            family,
+            [&] {
+              auto textProps = std::static_pointer_cast<const TextProps>(fragment.props);
+              if (textProps && !textProps->transform.operations.empty()) {
+                traits.set(ShadowNodeTraits::Trait::FormsView);
+              }
+              return traits;
+            }()),
+        BaseTextShadowNode()
   {
   }
 #endif


### PR DESCRIPTION
Fixes #55306
Root Cause
On iOS, a <Text> node does not form a dedicated UIView by default. It is "flattened" into its parent <Paragraph> component as an NSAttributedString fragment, controlled by the ShadowNodeTraits::Trait::FormsView flag. Since there is no backing UIView or CALayer, any transform prop applied to <Text> has nothing to act on and is silently ignored.

On Android, all <Text> nodes always set FormsView (unconditionally), which is why the transform works there — this asymmetry was the root cause.

cpp
// Before fix: FormsView only ever set on Android
static ShadowNodeTraits BaseTraits() {
  auto traits = ConcreteShadowNode::BaseTraits();
#ifdef ANDROID
  traits.set(ShadowNodeTraits::Trait::FormsView);  // ← iOS never reaches here!
#endif
  return traits;
}
Fix
Three files were changed:

TextProps.h
 — Added Transform transform and TransformOrigin transformOrigin fields. Previously 
TextProps
 only inherited from 
Props
 + 
BaseTextProps
 (not 
BaseViewProps
), so it had no transform field at all.

TextProps.cpp
 — Parse transform and transformOrigin from raw JS props in the constructor and in 
setProp
, mirroring 
BaseViewProps
.

TextShadowNode.h
 — On iOS, added a custom constructor that checks textProps->transform.operations.empty(). If the user supplied a transform, it sets ShadowNodeTraits::Trait::FormsView before delegating to BaseShadowNode, forcing Fabric to generate a real UIView for that text node so the transform can be applied.

This is zero-cost for non-transformed <Text> nodes — they continue to be flattened as before with no performance regression.

Changelog:
[IOS] [FIXED] - CSS transform styles applied to <Text> components are now correctly applied on iOS in the new architecture (Fabric), matching Android behavior.

Test Plan:
Repro steps (iOS Simulator, macOS + Xcode required)
Clone and build the RNTester app with this fix on an iOS Simulator.
Create a component with a directly-transformed <Text>:
jsx
<Text style={{ transform: [{ translateY: 50 }] }}>
  Transformed text
</Text>
Before fix: Text is not translated — it renders at its default position.
After fix: Text is translated 50pt downward, matching Android behavior.