### PR TITLE
improvement - ignore noise triggeres on the minimumViewTime config

### DIFF
--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -226,6 +226,12 @@ class ViewabilityHelper {
     }
     this._viewableIndices = viewableIndices;
     if (this._config.minimumViewTime) {
+      this._timers.forEach(id => {
+        clearTimeout(id);
+        this._timers.delete(id)
+      });
+      this._timers.clear();
+
       const handle: TimeoutID = setTimeout(() => {
         /* $FlowFixMe[incompatible-type] (>=0.63.0 site=react_native_fb) This
          * comment suppresses an error found when Flow v0.63 was deployed. To


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

I have been working on a chat application and dependent on the inView callbacks every time to have certain followup actions, Due to this piled up setTimeout execution there is too much of noise which is already outdated as the timeout never ensure it is resolved immediately after the config

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Clear the previous timers and reply back with the latest inView, the noise and irrelevant reports on the previous state is cleared out

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry. -->

- Improved inView callback reports for the virtualized lists

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

GENERAL - CHANGED 

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
