### PR TITLE
Fix `accessibilityState={{expanded: false}}` ignored on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1525,11 +1525,15 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
         addObject:RCTLocalizedString(
                       "mixed", "a checkbox, radio button, or other widget which is both checked and unchecked")];
   }
-  if (accessibilityState.expanded.value_or(false)) {
-    [valueComponents
-        addObject:RCTLocalizedString("expanded", "a menu, dialog, accordian panel, or other widget which is expanded")];
+  if (accessibilityState.expanded.has_value()) {
+    if (accessibilityState.expanded.value()) {
+      [valueComponents
+          addObject:RCTLocalizedString("expanded", "a menu, dialog, accordian panel, or other widget which is expanded")];
+    } else {
+      [valueComponents
+          addObject:RCTLocalizedString("collapsed", "a menu, dialog, accordian panel, or other widget which is collapsed")];
+    }
   }
-
   if (accessibilityState.busy) {
     [valueComponents addObject:RCTLocalizedString("busy", "an element currently being updated or modified")];
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

On iOS, `accessibilityState={{ expanded: true }}` works as expected, but `accessibilityState={{ expanded: false }}` is ignored. That means the collapsed state is not announced by VoiceOver, so users may not know the element can be expanded.

Fixes https://github.com/facebook/react-native/issues/56296

## Changelog:

[IOS] [FIXED] - `accessibilityState={{expanded: false}}` ignored on iOS

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
```TSX
import type {RNTesterModuleExample} from '../../types/RNTesterTypes';

import * as React from 'react';
import {Pressable, Text, View} from 'react-native';

function Playground() {
  return (
    <View style={{flex: 1, alignItems: 'center', justifyContent: 'center'}}>
      <Text>1. accessibilityState=&#123;"expanded": true&#125;</Text>
      <Pressable
        accessibilityState={{expanded: true}}
        style={{
          backgroundColor: 'lightgrey',
          margin: 16,
          marginBottom: 64,
          padding: 8,
        }}>
        <Text>Element 1</Text>
      </Pressable>
      <Text>2. accessibilityState=&#123;"expanded": false&#125;</Text>
      <Pressable
        accessibilityState={{expanded: false}}
        style={{
          backgroundColor: 'lightgrey',
          margin: 16,
          padding: 8,
        }}>
        <Text>Element 2</Text>
      </Pressable>
    </View>
  );
}

export default {
  title: 'Playground',
  name: 'playground',
  description: 'Test out new features and ideas.',
  render: (): React.Node => <Playground />,
} as RNTesterModuleExample;
```

1. Put the code into packages/rn-tester/js/examples/Playground/RNTesterPlayground.js.
2. Build and run RNTester on the iOS Simulator.
3. Open **Xcode** > **Open Developer Tool** > **Accessibility Inspector**.
4. Click **Select an element to inspect** and choose **Element 1**.
5. Verify **Value** is _expanded_.
6. Click **Select an element to inspect** and choose **Element 2**.
7. Verify **Value** is _collapsed_.

<img width="1095" height="965" alt="Screenshot 2026-04-14 at 1 16 03 PM" src="https://github.com/user-attachments/assets/718121c3-1f9c-4757-933a-a96910f063f5" />
<img width="1095" height="965" alt="Screenshot 2026-04-14 at 1 16 09 PM" src="https://github.com/user-attachments/assets/8a365c62-524c-49e6-a235-b06b0ef43b94" />