### PR TITLE
Fix skewX/skewY transforms on Android Q+ (#27649)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4110,6 +4110,13 @@ public abstract class com/facebook/react/uimanager/SimpleViewManager : com/faceb
 	public fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
 }
 
+public final class com/facebook/react/uimanager/SkewMatrixHelper {
+	public static final field INSTANCE Lcom/facebook/react/uimanager/SkewMatrixHelper;
+	public static final fun buildAffine2DMatrix (Lcom/facebook/react/bridge/ReadableArray;FFLcom/facebook/react/bridge/ReadableArray;)Landroid/graphics/Matrix;
+	public static final fun hasSkewTransform (Lcom/facebook/react/bridge/ReadableArray;)Z
+	public static final fun isAffine2DTransform (Lcom/facebook/react/bridge/ReadableArray;)Z
+}
+
 public final class com/facebook/react/uimanager/Spacing {
 	public static final field ALL I
 	public static final field BLOCK I

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4113,8 +4113,7 @@ public abstract class com/facebook/react/uimanager/SimpleViewManager : com/faceb
 public final class com/facebook/react/uimanager/SkewMatrixHelper {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/SkewMatrixHelper;
 	public static final fun buildAffine2DMatrix (Lcom/facebook/react/bridge/ReadableArray;FFLcom/facebook/react/bridge/ReadableArray;)Landroid/graphics/Matrix;
-	public static final fun hasSkewTransform (Lcom/facebook/react/bridge/ReadableArray;)Z
-	public static final fun isAffine2DTransform (Lcom/facebook/react/bridge/ReadableArray;)Z
+	public static final fun hasAffine2DSkewTransform (Lcom/facebook/react/bridge/ReadableArray;)Z
 }
 
 public final class com/facebook/react/uimanager/Spacing {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -583,8 +583,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-        && SkewMatrixHelper.hasSkewTransform(transforms)
-        && SkewMatrixHelper.isAffine2DTransform(transforms)) {
+        && SkewMatrixHelper.hasAffine2DSkewTransform(transforms)) {
       Matrix affine =
           SkewMatrixHelper.buildAffine2DMatrix(
               transforms,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -600,7 +600,10 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       view.setScaleY(1);
       view.setCameraDistance(0);
       view.setAnimationMatrix(affine);
-      view.setTag(R.id.skew_animation_matrix, Boolean.TRUE);
+      // Tag value is the matrix itself so TouchTargetHelper can use it for hit testing -- View's
+      // own getMatrix() does not compose mAnimationMatrix, so without this fallback the React
+      // hit-test path would still see the original rectangular bounds.
+      view.setTag(R.id.skew_animation_matrix, affine);
       return;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager;
 
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.os.Build;
 import android.text.TextUtils;
@@ -577,6 +578,29 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       view.setScaleX(1);
       view.setScaleY(1);
       view.setCameraDistance(0);
+      clearSkewAnimationMatrixIfActive(view);
+      return;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && SkewMatrixHelper.hasSkewTransform(transforms)
+        && SkewMatrixHelper.isAffine2DTransform(transforms)) {
+      Matrix affine =
+          SkewMatrixHelper.buildAffine2DMatrix(
+              transforms,
+              PixelUtil.toDIPFromPixel(view.getWidth()),
+              PixelUtil.toDIPFromPixel(view.getHeight()),
+              transformOrigin);
+      view.setTranslationX(0);
+      view.setTranslationY(0);
+      view.setRotation(0);
+      view.setRotationX(0);
+      view.setRotationY(0);
+      view.setScaleX(1);
+      view.setScaleY(1);
+      view.setCameraDistance(0);
+      view.setAnimationMatrix(affine);
+      view.setTag(R.id.skew_animation_matrix, Boolean.TRUE);
       return;
     }
 
@@ -626,6 +650,21 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
               scale * scale * cameraDistance * CAMERA_DISTANCE_NORMALIZATION_MULTIPLIER);
       view.setCameraDistance(normalizedCameraDistance);
     }
+
+    clearSkewAnimationMatrixIfActive(view);
+  }
+
+  // setAnimationMatrix is called only on the transition out of a skew matrix; calling it
+  // unconditionally would invalidate the View's RenderNode every frame for any non-skew animation.
+  private static <T extends View> void clearSkewAnimationMatrixIfActive(@NonNull T view) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      return;
+    }
+    if (view.getTag(R.id.skew_animation_matrix) == null) {
+      return;
+    }
+    view.setAnimationMatrix(null);
+    view.setTag(R.id.skew_animation_matrix, null);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SkewMatrixHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SkewMatrixHelper.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import android.graphics.Matrix
+import com.facebook.common.logging.FLog
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.common.ReactConstants
+
+/**
+ * Builds a 2D-affine [Matrix] from a `transform` array for the subset of operations Android `View`
+ * cannot represent through its individual property setters (specifically `skewX` / `skewY`). Used
+ * by [BaseViewManager.setTransformProperty] to apply such transforms via
+ * `View.setAnimationMatrix` on Android Q+.
+ */
+public object SkewMatrixHelper {
+
+  @JvmStatic
+  public fun hasSkewTransform(transforms: ReadableArray): Boolean {
+    if (isRawMatrixShorthand(transforms)) return false
+    for (i in 0 until transforms.size()) {
+      if (transforms.getType(i) != ReadableType.Map) continue
+      val map = transforms.getMap(i) ?: continue
+      val type = firstKey(map) ?: continue
+      if (type == "skewX" || type == "skewY") return true
+    }
+    return false
+  }
+
+  /**
+   * Returns true if [transforms] contains only operations representable by a Skia [Matrix] in 2D:
+   * `rotate` / `rotateZ`, `scale`, `scaleX` / `scaleY`, `translate` / `translateX` / `translateY`
+   * with zero Z, `skewX`, `skewY`. Returns false for `matrix`, `perspective`, `rotateX`, `rotateY`,
+   * a `translate` with a non-zero Z component, and the raw 16-element matrix shorthand used by
+   * Fabric LayoutAnimations.
+   */
+  @JvmStatic
+  public fun isAffine2DTransform(transforms: ReadableArray): Boolean {
+    if (isRawMatrixShorthand(transforms)) return false
+    for (i in 0 until transforms.size()) {
+      if (transforms.getType(i) != ReadableType.Map) continue
+      val map = transforms.getMap(i) ?: continue
+      val type = firstKey(map) ?: continue
+      when (type) {
+        "matrix",
+        "perspective",
+        "rotateX",
+        "rotateY" -> return false
+        "translate" -> {
+          val value = map.getArray(type)
+          if (value != null &&
+              value.size() > 2 &&
+              value.getType(2) == ReadableType.Number &&
+              value.getDouble(2) != 0.0) {
+            return false
+          }
+        }
+      }
+    }
+    return true
+  }
+
+  /**
+   * Builds a [Matrix] in pixel coordinates by walking [transforms] left-to-right and applying each
+   * operation via `Matrix.preX` around the resolved pivot. Pivot is the view center; if
+   * [transformOrigin] is set, it overrides per-axis (Number values are DIP, "P%" strings are
+   * P/100 of the view dimension; Z is ignored).
+   *
+   * Composition is pre-multiplication: when the resulting matrix is applied to a point, the
+   * rightmost (last) array entry is applied first. Matches CSS / iOS conventions and the
+   * left-to-right-iteration / right-multiply contract of [MatrixMathHelper.multiplyInto] used by
+   * [TransformHelper.processTransform].
+   */
+  @JvmStatic
+  public fun buildAffine2DMatrix(
+      transforms: ReadableArray,
+      viewWidthDip: Float,
+      viewHeightDip: Float,
+      transformOrigin: ReadableArray?,
+  ): Matrix {
+    val pivotXPx: Float
+    val pivotYPx: Float
+    if (transformOrigin == null) {
+      pivotXPx = PixelUtil.toPixelFromDIP(viewWidthDip / 2f)
+      pivotYPx = PixelUtil.toPixelFromDIP(viewHeightDip / 2f)
+    } else {
+      pivotXPx =
+          PixelUtil.toPixelFromDIP(
+              resolveOriginAxis(transformOrigin, 0, viewWidthDip, viewWidthDip / 2f))
+      pivotYPx =
+          PixelUtil.toPixelFromDIP(
+              resolveOriginAxis(transformOrigin, 1, viewHeightDip, viewHeightDip / 2f))
+    }
+
+    val matrix = Matrix()
+    for (i in 0 until transforms.size()) {
+      if (transforms.getType(i) != ReadableType.Map) continue
+      val map = transforms.getMap(i) ?: continue
+      val type = firstKey(map) ?: continue
+      when (type) {
+        "rotate",
+        "rotateZ" ->
+            matrix.preRotate(
+                Math.toDegrees(convertToRadians(map, type)).toFloat(), pivotXPx, pivotYPx)
+        "scale" -> {
+          val s = map.getDouble(type).toFloat()
+          matrix.preScale(s, s, pivotXPx, pivotYPx)
+        }
+        "scaleX" -> matrix.preScale(map.getDouble(type).toFloat(), 1f, pivotXPx, pivotYPx)
+        "scaleY" -> matrix.preScale(1f, map.getDouble(type).toFloat(), pivotXPx, pivotYPx)
+        "skewX" ->
+            matrix.preSkew(
+                Math.tan(convertToRadians(map, type)).toFloat(), 0f, pivotXPx, pivotYPx)
+        "skewY" ->
+            matrix.preSkew(
+                0f, Math.tan(convertToRadians(map, type)).toFloat(), pivotXPx, pivotYPx)
+        "translate" -> {
+          val value = map.getArray(type)
+          if (value != null && value.size() >= 1) {
+            val tx = parseTranslateValue(value, 0, viewWidthDip)
+            val ty = if (value.size() > 1) parseTranslateValue(value, 1, viewHeightDip) else 0.0
+            matrix.preTranslate(
+                PixelUtil.toPixelFromDIP(tx.toFloat()), PixelUtil.toPixelFromDIP(ty.toFloat()))
+          }
+        }
+        "translateX" ->
+            matrix.preTranslate(
+                PixelUtil.toPixelFromDIP(parseScalarTranslate(map, type, viewWidthDip).toFloat()),
+                0f)
+        "translateY" ->
+            matrix.preTranslate(
+                0f,
+                PixelUtil.toPixelFromDIP(parseScalarTranslate(map, type, viewHeightDip).toFloat()))
+      }
+    }
+    return matrix
+  }
+
+  private fun isRawMatrixShorthand(transforms: ReadableArray): Boolean =
+      transforms.size() == 16 && transforms.getType(0) == ReadableType.Number
+
+  private fun firstKey(map: ReadableMap): String? {
+    val iter = map.keySetIterator()
+    return if (iter.hasNextKey()) iter.nextKey() else null
+  }
+
+  private fun resolveOriginAxis(
+      origin: ReadableArray,
+      axis: Int,
+      dimensionDip: Float,
+      defaultDip: Float,
+  ): Float {
+    if (origin.size() <= axis) return defaultDip
+    return when (origin.getType(axis)) {
+      ReadableType.Number -> origin.getDouble(axis).toFloat()
+      ReadableType.String -> {
+        val part = origin.getString(axis) ?: return defaultDip
+        if (!part.endsWith("%")) return defaultDip
+        try {
+          (part.dropLast(1).toDouble() * dimensionDip / 100.0).toFloat()
+        } catch (e: NumberFormatException) {
+          defaultDip
+        }
+      }
+      else -> defaultDip
+    }
+  }
+
+  private fun parseTranslateValue(value: ReadableArray, index: Int, dimensionDip: Float): Double {
+    if (value.getType(index) != ReadableType.String) {
+      return value.getDouble(index)
+    }
+    val s = value.getString(index) ?: return 0.0
+    return parseTranslateString(s, dimensionDip)
+  }
+
+  private fun parseScalarTranslate(map: ReadableMap, key: String, dimensionDip: Float): Double {
+    if (map.getType(key) != ReadableType.String) {
+      return map.getDouble(key)
+    }
+    val s = map.getString(key) ?: return 0.0
+    return parseTranslateString(s, dimensionDip)
+  }
+
+  // Mirrors TransformHelper.parseTranslateValue; kept local for the same reason as
+  // convertToRadians below.
+  private fun parseTranslateString(s: String, dimensionDip: Float): Double {
+    return try {
+      if (s.endsWith("%")) {
+        s.dropLast(1).toDouble() * dimensionDip / 100.0
+      } else {
+        s.toDouble()
+      }
+    } catch (e: NumberFormatException) {
+      FLog.w(ReactConstants.TAG, "Invalid translate value: $s")
+      0.0
+    }
+  }
+
+  // Mirrors TransformHelper.convertToRadians; kept local so this helper is self-contained.
+  private fun convertToRadians(transformMap: ReadableMap, key: String): Double {
+    if (transformMap.getType(key) != ReadableType.String) {
+      return transformMap.getDouble(key)
+    }
+    var stringValue = transformMap.getString(key) ?: return 0.0
+    var inRadians = true
+    if (stringValue.endsWith("rad")) {
+      stringValue = stringValue.dropLast(3)
+    } else if (stringValue.endsWith("deg")) {
+      inRadians = false
+      stringValue = stringValue.dropLast(3)
+    }
+    val value = stringValue.toDouble()
+    return if (inRadians) value else MatrixMathHelper.degreesToRadians(value)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SkewMatrixHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SkewMatrixHelper.kt
@@ -22,8 +22,16 @@ import com.facebook.react.common.ReactConstants
  */
 public object SkewMatrixHelper {
 
+  /**
+   * Returns true only when [transforms] both contains a `skewX` / `skewY` operation and is fully
+   * representable as a 2D-affine [Matrix] (see [isAffine2DTransform]) — i.e. the case
+   * [BaseViewManager.setTransformProperty] applies via `View.setAnimationMatrix` on Android Q+.
+   */
   @JvmStatic
-  public fun hasSkewTransform(transforms: ReadableArray): Boolean {
+  public fun hasAffine2DSkewTransform(transforms: ReadableArray): Boolean =
+      hasSkewTransform(transforms) && isAffine2DTransform(transforms)
+
+  internal fun hasSkewTransform(transforms: ReadableArray): Boolean {
     if (isRawMatrixShorthand(transforms)) return false
     for (i in 0 until transforms.size()) {
       if (transforms.getType(i) != ReadableType.Map) continue
@@ -41,8 +49,7 @@ public object SkewMatrixHelper {
    * a `translate` with a non-zero Z component, and the raw 16-element matrix shorthand used by
    * Fabric LayoutAnimations.
    */
-  @JvmStatic
-  public fun isAffine2DTransform(transforms: ReadableArray): Boolean {
+  internal fun isAffine2DTransform(transforms: ReadableArray): Boolean {
     if (isRawMatrixShorthand(transforms)) return false
     for (i in 0 until transforms.size()) {
       if (transforms.getType(i) != ReadableType.Map) continue
@@ -165,7 +172,7 @@ public object SkewMatrixHelper {
         if (!part.endsWith("%")) return defaultDip
         try {
           (part.dropLast(1).toDouble() * dimensionDip / 100.0).toFloat()
-        } catch (e: NumberFormatException) {
+        } catch (_: NumberFormatException) {
           defaultDip
         }
       }
@@ -198,7 +205,7 @@ public object SkewMatrixHelper {
       } else {
         s.toDouble()
       }
-    } catch (e: NumberFormatException) {
+    } catch (_: NumberFormatException) {
       FLog.w(ReactConstants.TAG, "Invalid translate value: $s")
       0.0
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
@@ -13,6 +13,7 @@ import android.graphics.PointF
 import android.view.View
 import android.view.ViewGroup
 import com.facebook.common.logging.FLog
+import com.facebook.react.R
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.touch.ReactHitSlopView
@@ -298,7 +299,11 @@ public object TouchTargetHelper {
   ): Boolean {
     var localX = x + parent.scrollX - child.left
     var localY = y + parent.scrollY - child.top
-    val matrix = child.matrix
+    // BaseViewManager applies skewX / skewY through View.setAnimationMatrix, which is composed
+    // for drawing but not exposed via View.getMatrix(); fall back to the stashed matrix so hit
+    // testing follows the rendered parallelogram and not the original rectangle.
+    val skewMatrix = child.getTag(R.id.skew_animation_matrix) as? Matrix
+    val matrix = skewMatrix ?: child.matrix
     if (!matrix.isIdentity) {
       val inverseMatrix = inverseMatrix
       if (!matrix.invert(inverseMatrix)) {

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -66,6 +66,10 @@
   <!-- tag is used to invalidate transform style in view manager -->
   <item type="id" name="invalidate_transform"/>
 
+  <!-- tag stores Boolean.TRUE while a 2D-affine skew Matrix is active on the View via
+       setAnimationMatrix, so non-skew updates can clear it only on the transition out -->
+  <item type="id" name="skew_animation_matrix"/>
+
   <!-- tag is used to store if we should render the view to a hardware texture -->
   <item type="id" name="use_hardware_layer"/>
 

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -66,8 +66,9 @@
   <!-- tag is used to invalidate transform style in view manager -->
   <item type="id" name="invalidate_transform"/>
 
-  <!-- tag stores Boolean.TRUE while a 2D-affine skew Matrix is active on the View via
-       setAnimationMatrix, so non-skew updates can clear it only on the transition out -->
+  <!-- tag stores the active 2D-affine skew Matrix applied to the View via setAnimationMatrix,
+       so non-skew updates can clear it only on the transition out and TouchTargetHelper can
+       reuse it for hit testing -->
   <item type="id" name="skew_animation_matrix"/>
 
   <!-- tag is used to store if we should render the view to a hardware texture -->

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
@@ -119,6 +119,28 @@ class SkewMatrixHelperTest {
   }
 
   @Test
+  fun hasAffine2DSkewTransform_trueForSkewX() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    assertThat(SkewMatrixHelper.hasAffine2DSkewTransform(transforms)).isTrue()
+  }
+
+  @Test
+  fun hasAffine2DSkewTransform_falseForSkewWithRotateX() {
+    val transforms =
+        JavaOnlyArray.of(
+            JavaOnlyMap.of("skewX", "20deg"),
+            JavaOnlyMap.of("rotateX", "10deg"),
+        )
+    assertThat(SkewMatrixHelper.hasAffine2DSkewTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun hasAffine2DSkewTransform_falseForRotateOnly() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("rotate", "30deg"))
+    assertThat(SkewMatrixHelper.hasAffine2DSkewTransform(transforms)).isFalse()
+  }
+
+  @Test
   fun buildAffine2DMatrix_pureSkewX_producesExpectedEntries() {
     val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
     val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 0f, 0f, null))

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
@@ -35,13 +35,11 @@ class SkewMatrixHelperTest {
           densityDpi = DisplayMetrics.DENSITY_DEFAULT
         }
     DisplayMetricsHolder.setScreenDisplayMetrics(metrics)
-    DisplayMetricsHolder.setWindowDisplayMetrics(metrics)
   }
 
   @After
   fun tearDown() {
     DisplayMetricsHolder.setScreenDisplayMetrics(null)
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SkewMatrixHelperTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import android.graphics.Matrix
+import android.util.DisplayMetrics
+import com.facebook.react.bridge.JavaOnlyArray
+import com.facebook.react.bridge.JavaOnlyMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Tests for [SkewMatrixHelper]. */
+@RunWith(RobolectricTestRunner::class)
+class SkewMatrixHelperTest {
+
+  @Before
+  fun setUp() {
+    ReactNativeFeatureFlagsForTests.setUp()
+    val metrics =
+        DisplayMetrics().apply {
+          density = 1f
+          widthPixels = 1080
+          heightPixels = 1920
+          densityDpi = DisplayMetrics.DENSITY_DEFAULT
+        }
+    DisplayMetricsHolder.setScreenDisplayMetrics(metrics)
+    DisplayMetricsHolder.setWindowDisplayMetrics(metrics)
+  }
+
+  @After
+  fun tearDown() {
+    DisplayMetricsHolder.setScreenDisplayMetrics(null)
+    DisplayMetricsHolder.setWindowDisplayMetrics(null)
+  }
+
+  @Test
+  fun hasSkewTransform_trueForSkewX() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    assertThat(SkewMatrixHelper.hasSkewTransform(transforms)).isTrue()
+  }
+
+  @Test
+  fun hasSkewTransform_trueForSkewY() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewY", "10deg"))
+    assertThat(SkewMatrixHelper.hasSkewTransform(transforms)).isTrue()
+  }
+
+  @Test
+  fun hasSkewTransform_falseForRotate() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("rotate", "30deg"))
+    assertThat(SkewMatrixHelper.hasSkewTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun hasSkewTransform_falseForEmpty() {
+    assertThat(SkewMatrixHelper.hasSkewTransform(JavaOnlyArray())).isFalse()
+  }
+
+  @Test
+  fun hasSkewTransform_falseForRawMatrixShorthand() {
+    assertThat(SkewMatrixHelper.hasSkewTransform(identityMatrixShorthand())).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForRotateX() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("rotateX", "10deg"))
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForRotateY() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("rotateY", "10deg"))
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForPerspective() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("perspective", 800.0))
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForMatrix() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("matrix", identityMatrixShorthand()))
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForTranslateWithZ() {
+    val translate = JavaOnlyArray.of(10.0, 20.0, 5.0)
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("translate", translate))
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_falseForRawMatrixShorthand() {
+    assertThat(SkewMatrixHelper.isAffine2DTransform(identityMatrixShorthand())).isFalse()
+  }
+
+  @Test
+  fun isAffine2DTransform_trueForSkewScaleTranslateRotateZ() {
+    val transforms =
+        JavaOnlyArray.of(
+            JavaOnlyMap.of("skewX", "20deg"),
+            JavaOnlyMap.of("scale", 1.5),
+            JavaOnlyMap.of("translate", JavaOnlyArray.of(10.0, 20.0)),
+            JavaOnlyMap.of("rotateZ", "30deg"),
+        )
+    assertThat(SkewMatrixHelper.isAffine2DTransform(transforms)).isTrue()
+  }
+
+  @Test
+  fun buildAffine2DMatrix_pureSkewX_producesExpectedEntries() {
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 0f, 0f, null))
+    val tan20 = Math.tan(Math.toRadians(20.0)).toFloat()
+    assertThat(values[Matrix.MSCALE_X]).isCloseTo(1f, within(EPSILON))
+    assertThat(values[Matrix.MSCALE_Y]).isCloseTo(1f, within(EPSILON))
+    assertThat(values[Matrix.MSKEW_X]).isCloseTo(tan20, within(EPSILON))
+    assertThat(values[Matrix.MSKEW_Y]).isCloseTo(0f, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_X]).isCloseTo(0f, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_Y]).isCloseTo(0f, within(EPSILON))
+  }
+
+  @Test
+  fun buildAffine2DMatrix_scaleThenTranslate_appliesInCorrectOrder() {
+    // [scale: 2, translateX: 30] under pre-multiplication -> M = Scale * Translate.
+    // Applied to a point, translate runs first; mapping (0, 0) gives (60, 0).
+    val transforms =
+        JavaOnlyArray.of(
+            JavaOnlyMap.of("scale", 2.0),
+            JavaOnlyMap.of("translateX", 30.0),
+        )
+    val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 0f, 0f, null))
+    assertThat(values[Matrix.MSCALE_X]).isCloseTo(2f, within(EPSILON))
+    assertThat(values[Matrix.MSCALE_Y]).isCloseTo(2f, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_X]).isCloseTo(60f, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_Y]).isCloseTo(0f, within(EPSILON))
+  }
+
+  @Test
+  fun buildAffine2DMatrix_pivotIsViewCenter_whenTransformOriginNull() {
+    // skewX 20deg around pivot (50, 50) introduces MTRANS_X = -tan(20deg) * 50.
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 100f, 100f, null))
+    val tan20 = Math.tan(Math.toRadians(20.0)).toFloat()
+    assertThat(values[Matrix.MSKEW_X]).isCloseTo(tan20, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_X]).isCloseTo(-tan20 * 50f, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_Y]).isCloseTo(0f, within(EPSILON))
+  }
+
+  @Test
+  fun buildAffine2DMatrix_pivotRespectsTransformOrigin_numberValues() {
+    // Origin (0, 0) DIP overrides the view-center default; no pivot translation.
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    val origin = JavaOnlyArray.of(0.0, 0.0)
+    val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 100f, 100f, origin))
+    val tan20 = Math.tan(Math.toRadians(20.0)).toFloat()
+    assertThat(values[Matrix.MSKEW_X]).isCloseTo(tan20, within(EPSILON))
+    assertThat(values[Matrix.MTRANS_X]).isCloseTo(0f, within(EPSILON))
+  }
+
+  @Test
+  fun buildAffine2DMatrix_pivotRespectsTransformOrigin_percentValues() {
+    // "0%" "0%" -> pivot (0, 0); no pivot translation introduced.
+    val transforms = JavaOnlyArray.of(JavaOnlyMap.of("skewX", "20deg"))
+    val origin = JavaOnlyArray.of("0%", "0%")
+    val values = matrixValues(SkewMatrixHelper.buildAffine2DMatrix(transforms, 100f, 100f, origin))
+    assertThat(values[Matrix.MTRANS_X]).isCloseTo(0f, within(EPSILON))
+  }
+
+  private fun matrixValues(matrix: Matrix): FloatArray {
+    val values = FloatArray(9)
+    matrix.getValues(values)
+    return values
+  }
+
+  private fun identityMatrixShorthand(): JavaOnlyArray {
+    val arr = JavaOnlyArray()
+    for (i in 0 until 16) {
+      arr.pushDouble(if (i == 0 || i == 5 || i == 10 || i == 15) 1.0 else 0.0)
+    }
+    return arr
+  }
+
+  private companion object {
+    private const val EPSILON = 1e-4f
+  }
+}

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -9,7 +9,12 @@
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import type {
+  PressableAndroidRippleConfig,
+  PressableStateCallbackType,
+} from 'react-native';
 import type {AnimatedNode} from 'react-native/Libraries/Animated/AnimatedExports';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import * as React from 'react';
 import {useEffect, useState} from 'react';
@@ -207,6 +212,106 @@ function ScaleZeroHitTestExample(): React.Node {
         />
       </View>
       <Text testID="scale-zero-last-tapped">Last tapped: {lastTapped}</Text>
+    </View>
+  );
+}
+
+function SkewExample(): React.Node {
+  const [tapped, setTapped] = useState<string>('(none)');
+  const skewAnim = useAnimatedValue(0);
+
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(skewAnim, {
+          toValue: 1,
+          duration: 1500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(skewAnim, {
+          toValue: 0,
+          duration: 1500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [skewAnim]);
+
+  const animatedSkewX = skewAnim.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0deg', '20deg'],
+  });
+
+  const ripple: PressableAndroidRippleConfig = {
+    color: 'rgba(255,255,255,0.4)',
+  };
+  const tapStyle =
+    (extra: ViewStyleProp) =>
+    ({pressed}: PressableStateCallbackType): ViewStyleProp =>
+      [styles.skewBox, extra, pressed && styles.skewBoxPressed];
+
+  return (
+    <View testID="transform-skew-27649" style={styles.skewContainer}>
+      <Text style={styles.skewLabel}>Last tapped: {tapped}</Text>
+      <Text style={styles.skewNote}>
+        Tap any box to confirm hit testing follows the rendered shape.
+      </Text>
+      <View style={styles.skewRow}>
+        <Pressable
+          testID="skew-27649-x"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewX 20deg')}
+          style={tapStyle(styles.skewBoxX)}>
+          <Text style={styles.skewBoxText}>skewX</Text>
+        </Pressable>
+        <Pressable
+          testID="skew-27649-y"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewY 20deg')}
+          style={tapStyle(styles.skewBoxY)}>
+          <Text style={styles.skewBoxText}>skewY</Text>
+        </Pressable>
+        <Pressable
+          testID="skew-27649-xy"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewX+Y')}
+          style={tapStyle(styles.skewBoxXY)}>
+          <Text style={styles.skewBoxText}>skewX+Y</Text>
+        </Pressable>
+      </View>
+      <View style={styles.skewRow}>
+        <Pressable
+          testID="skew-27649-xr"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewX + rotate')}
+          style={tapStyle(styles.skewBoxXR)}>
+          <Text style={styles.skewBoxText}>+rotate</Text>
+        </Pressable>
+        <Pressable
+          testID="skew-27649-xs"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewX + scale')}
+          style={tapStyle(styles.skewBoxXS)}>
+          <Text style={styles.skewBoxText}>+scale</Text>
+        </Pressable>
+        <Pressable
+          testID="skew-27649-xt"
+          android_ripple={ripple}
+          onPress={() => setTapped('skewX + translate')}
+          style={tapStyle(styles.skewBoxXT)}>
+          <Text style={styles.skewBoxText}>+translate</Text>
+        </Pressable>
+      </View>
+      <Text style={styles.skewLabel}>Animated (useNativeDriver: true)</Text>
+      <Animated.View
+        testID="skew-27649-animated"
+        style={[styles.skewBox, {transform: [{skewX: animatedSkewX}]}]}>
+        <Text style={styles.skewBoxText}>0deg to 20deg</Text>
+      </Animated.View>
     </View>
   );
 }
@@ -409,6 +514,35 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 4,
   },
+  skewContainer: {paddingHorizontal: 16, paddingVertical: 12},
+  skewRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginVertical: 10,
+  },
+  skewLabel: {
+    fontSize: 12,
+    fontWeight: 'bold',
+    marginTop: 12,
+    marginBottom: 4,
+    color: 'black',
+  },
+  skewNote: {fontSize: 11, color: 'gray', marginTop: 6},
+  skewBox: {
+    width: 70,
+    height: 70,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'tomato',
+  },
+  skewBoxText: {color: 'white', fontWeight: 'bold', fontSize: 11},
+  skewBoxPressed: {opacity: 0.5},
+  skewBoxX: {transform: [{skewX: '20deg'}]},
+  skewBoxY: {transform: [{skewY: '20deg'}]},
+  skewBoxXY: {transform: [{skewX: '20deg'}, {skewY: '10deg'}]},
+  skewBoxXR: {transform: [{skewX: '20deg'}, {rotate: '15deg'}]},
+  skewBoxXS: {transform: [{skewX: '20deg'}, {scale: 1.1}]},
+  skewBoxXT: {transform: [{skewX: '20deg'}, {translateX: 8}]},
 });
 
 exports.title = 'Transforms';
@@ -585,6 +719,15 @@ exports.examples = [
       'A view with scaleY: 0 must not receive touches and must not inherit a sibling view’s hit region',
     render(): React.Node {
       return <ScaleZeroHitTestExample />;
+    },
+  },
+  {
+    title: 'Skew (#27649)',
+    name: 'skew-27649',
+    description:
+      'skewX/skewY rendering, hit testing, and native-driven animation on Android Q+ and iOS',
+    render(): React.Node {
+      return <SkewExample />;
     },
   },
 ] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -251,14 +251,18 @@ function SkewExample(): React.Node {
   };
   const tapStyle =
     (extra: ViewStyleProp) =>
-    ({pressed}: PressableStateCallbackType): ViewStyleProp =>
-      [styles.skewBox, extra, pressed && styles.skewBoxPressed];
+    ({pressed}: PressableStateCallbackType): ViewStyleProp => [
+      styles.skewBox,
+      extra,
+      pressed && styles.skewBoxPressed,
+    ];
 
   return (
     <View testID="transform-skew-27649" style={styles.skewContainer}>
       <Text style={styles.skewLabel}>Last tapped: {tapped}</Text>
       <Text style={styles.skewNote}>
-        Tap any box to confirm hit testing follows the rendered shape.
+        Tap any box to confirm hit testing follows the rendered parallelogram on
+        both platforms.
       </Text>
       <View style={styles.skewRow}>
         <Pressable


### PR DESCRIPTION
## Summary

Fixes #27649.

`skewX` / `skewY` are silently dropped on Android. `MatrixMathHelper.decomposeMatrix` correctly extracts the shear into `MatrixDecompositionContext.skew[]`, but `BaseViewManager.setTransformProperty` only reads `translation`, `rotationDegrees`, `scale` and `perspective`, and `View` has no `setSkewX` / `setSkewY` to apply the residual to. Skewed views render as rotated, non-uniformly scaled rectangles instead of parallelograms. (@quantizor's trace in https://github.com/facebook/react-native/issues/27649#issuecomment-4374769393 pinned the exact site.)

## Fix

New Kotlin helper `SkewMatrixHelper` with three static functions: `hasSkewTransform`, `isAffine2DTransform` (false on `matrix`, `perspective`, `rotateX`, `rotateY`, or a translate with non-zero Z), and `buildAffine2DMatrix`, which walks the transform array and pre-multiplies each op onto a `Matrix` around the resolved pivot, so the rightmost entry is applied to the point first, matching CSS / iOS and `TransformHelper.processTransform`.

`BaseViewManager.setTransformProperty` dispatches to that path only when `hasSkew && isAffine2D`, on API 29+: it zeroes the View transform props and calls `setAnimationMatrix`. Everything else (rotate, scale, translate, rotateX, rotateY, perspective, raw 4x4 matrix) flows through the existing decompose-and-set-View-props code unchanged.

Two supporting details:

- The applied `Matrix` is stashed in a `R.id.skew_animation_matrix` view tag, and the fallthrough path calls `setAnimationMatrix(null)` only when that tag is set. Ungated, every animated frame on every view would invalidate its RenderNode.
- `View.getMatrix()` does not compose `mAnimationMatrix`, so `TouchTargetHelper.getChildPoint` reads the same tag and inverse-maps through it when present. Hit testing then follows the rendered parallelogram, as it already does on iOS.

Pre-Q is left as is (skew still dropped), mirroring the existing API 29 gate at `BaseViewManager.java:118`.

### Prior attempts

- **#28862** fixed a JS-side decomposition bug (`skew[0]` zeroed by a duplicate orthogonalization) and is still in `main`. It corrected `decomposeMatrix`, not the application layer; this is the missing half.
- **#38494** is the closest in spirit. @javache's review objected to `setAnimationMatrix` being documented as an animation API, and to two divergent code paths. On the first: AndroidX `ViewUtilsApi21` uses it for static transforms in production today, and it was promoted to public API in 29. On the second: the dispatch here is narrowed to `hasSkew && isAffine2D`, so the new path only runs for transforms that are already broken. That PR's pre-Q reflection shim is not adopted.
- **#42676** simulated skew with 3D rotation plus non-uniform scale plus perspective. The 2x2 sub-matrix matches, but the full 4x4 does not, so composing with real `rotateX` / `rotateY` gives wrong results (acknowledged by the author).

## Changelog:

[ANDROID] [FIXED] - skewX / skewY transforms now render correctly on Android Q+.

## Test Plan

RNTester -> APIs -> Transforms -> "Skew (#27649)", a permanent example added here. Verified on the rn_test AVD (Pixel 8 Pro, Android 16, arm64-v8a).

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/qflen/react-native/f4585e841aba90b69c11474dbfdc3e9540b8f0ee/assets/27649/before_android_skew_scene.png" width="260"> | <img src="https://raw.githubusercontent.com/qflen/react-native/f4585e841aba90b69c11474dbfdc3e9540b8f0ee/assets/27649/after_android_skew_scene.png" width="260"> |
| Rotated rectangles: decompose keeps ~20 deg of rotation plus non-uniform scale and drops the shear. | True parallelograms, horizontal top and bottom edges, sides tilted 20 deg. |

The example also animates skewX from `0deg` to `20deg` with `useNativeDriver: true`. Native-driven transforms re-emit the array per frame through `TransformAnimatedNode.collectViewUpdates`, so the dispatch runs each frame and the skew animates smoothly.

Hit testing: swept taps 1 px either side of each edge of the skewX box (rect bounds `[116, 549] [300, 732]`). `(100, 555)` and `(330, 731)` sit inside the parallelogram but outside the rect, and register only with the `TouchTargetHelper` change; `(208, 640)` registers either way; `(350, 640)` is outside the parallelogram and correctly misses either way.

Negative case: the other transform examples (Translate-Rotate-Scale, Perspective-Rotate-Animation, Rotate-Scale, Transform-using-a-string, Transform-Matrix-2D / 3D) render bit-identically to `origin/main`.

Checks:

- `:ReactAndroid:testDebugUnitTest --tests 'com.facebook.react.uimanager.SkewMatrixHelperTest*'`, 17 / 17 pass (both predicates, plus matrix math for pure skewX, scale-then-translate ordering, default view-center pivot, and `transformOrigin` as Number and as "%" string).
- `yarn jest packages/react-native/Libraries/StyleSheet/__tests__/processTransform-test.js`, 16 / 16 and 19 snapshots, unchanged.
- `ktfmtCheck`, `yarn lint`, `yarn flow` clean.

iOS is untouched. It already handles skew via `CATransform3D`, and the AFTER rendering above matches it.
