### PR TITLE
Fix RetryableMountingLayerException crash in updateOverflowInset

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -898,7 +898,16 @@ internal constructor(
       return
     }
 
-    val viewState = getViewState(reactTag)
+    val viewState = getNullableViewState(reactTag)
+    if (viewState == null) {
+      ReactSoftExceptionLogger.logSoftException(
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
+          ReactNoCrashSoftException(
+              "Unable to find viewState for tag $reactTag for updateOverflowInset"
+          ),
+      )
+      return
+    }
     // Do not layout Root Views
     if (viewState.isRoot) {
       return


### PR DESCRIPTION
Summary:
Fix a crash in `SurfaceMountingManager.updateOverflowInset()` where `getViewState()` throws `RetryableMountingLayerException` when the view state for a tag is not found in the registry.

The crash occurs during batch mount item execution when an `updateOverflowInset` operation references a view tag that has been removed from the registry due to normal lifecycle race conditions. The surface is still active (not stopped), but the view has already been deleted.

The fix replaces `getViewState(reactTag)` (which throws) with `getNullableViewState(reactTag)` + null check + soft exception logging + early return. This matches the defensive pattern already used by peer methods in the same class: `updateLayout`, `addViewAt`, and `removeViewAt`.

Logview link: [252c85116a7ab5c4ec93ef3c3373cf9d](https://www.internalfb.com/logview/system_vros_crashes/252c85116a7ab5c4ec93ef3c3373cf9d)

Differential Revision: D104400233


