### PR TITLE
feat(ios): honor textAlignVertical on Paragraph and multiline TextInput

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -55,7 +55,7 @@ typedef NS_ENUM(NSInteger, RCTUITextViewTextAlignmentVertical) {
  * multiline value can sit centered or pushed to the bottom of a tall fixed
  * frame. Defaults to `Auto` (top-aligned, current behavior).
  */
-@property (nonatomic, assign) RCTUITextViewTextAlignmentVertical textAlignmentVertical;
+@property (nonatomic, assign) RCTUITextViewTextAlignmentVertical textAlignVertical;
 
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewButtonLabel;

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -13,6 +13,19 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /*
+ * Mirrors `facebook::react::TextAlignmentVertical` (kept private to avoid
+ * exposing C++ types from this ObjC header). Keep the integer values in
+ * sync with `enum class TextAlignmentVertical` in
+ * `ReactCommon/react/renderer/attributedstring/primitives.h`.
+ */
+typedef NS_ENUM(NSInteger, RCTUITextViewTextAlignmentVertical) {
+  RCTUITextViewTextAlignmentVerticalAuto = 0,
+  RCTUITextViewTextAlignmentVerticalTop,
+  RCTUITextViewTextAlignmentVerticalBottom,
+  RCTUITextViewTextAlignmentVerticalCenter,
+};
+
+/*
  * Just regular UITextView... but much better!
  */
 @interface RCTUITextView : UITextView <RCTBackedTextInputViewProtocol>
@@ -35,6 +48,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 
 @property (nonatomic, assign) BOOL caretHidden;
+
+/*
+ * Block-axis alignment of the text within the host view's bounds, mirroring
+ * Android's `textAlignVertical`. Applied via `contentInset.top` so a short
+ * multiline value can sit centered or pushed to the bottom of a tall fixed
+ * frame. Defaults to `Auto` (top-aligned, current behavior).
+ */
+@property (nonatomic, assign) RCTUITextViewTextAlignmentVertical textAlignmentVertical;
 
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewButtonLabel;

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -150,6 +150,15 @@ static UIColor *defaultPlaceholderColor(void)
   [self _invalidatePlaceholderVisibility];
 }
 
+- (void)setTextAlignmentVertical:(RCTUITextViewTextAlignmentVertical)textAlignmentVertical
+{
+  if (_textAlignmentVertical == textAlignmentVertical) {
+    return;
+  }
+  _textAlignmentVertical = textAlignmentVertical;
+  [self setNeedsLayout];
+}
+
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
   _disableKeyboardShortcuts = disableKeyboardShortcuts;
@@ -280,10 +289,45 @@ static UIColor *defaultPlaceholderColor(void)
 {
   [super layoutSubviews];
 
+  [self _applyVerticalAlignmentInset];
+
   CGRect textFrame = UIEdgeInsetsInsetRect(self.bounds, self.textContainerInset);
   CGFloat placeholderHeight = [_placeholderView sizeThatFits:textFrame.size].height;
   textFrame.size.height = MIN(placeholderHeight, textFrame.size.height);
   _placeholderView.frame = textFrame;
+}
+
+// Mirrors CSS Box Alignment Level 3 `align-content` on a block container
+// (https://drafts.csswg.org/css-align-3/#align-content-property): top is the
+// existing default, center vertically centers the content within the bounds,
+// bottom flushes it to the bottom. Overflow (content taller than bounds) falls
+// back to top so nothing gets clipped. UIScrollView's `contentInset.top` is
+// the right hook: it shifts the default scroll origin and is left untouched
+// by RN's existing wiring (only `textContainerInset` is set externally).
+- (void)_applyVerticalAlignmentInset
+{
+  CGFloat boundsHeight = CGRectGetHeight(self.bounds);
+  CGFloat contentHeight = self.contentSize.height;
+  CGFloat topInset = 0;
+  if (boundsHeight > contentHeight) {
+    switch (_textAlignmentVertical) {
+      case RCTUITextViewTextAlignmentVerticalCenter:
+        topInset = (boundsHeight - contentHeight) / 2;
+        break;
+      case RCTUITextViewTextAlignmentVerticalBottom:
+        topInset = boundsHeight - contentHeight;
+        break;
+      case RCTUITextViewTextAlignmentVerticalAuto:
+      case RCTUITextViewTextAlignmentVerticalTop:
+        topInset = 0;
+        break;
+    }
+  }
+  UIEdgeInsets contentInset = self.contentInset;
+  if (contentInset.top != topInset) {
+    contentInset.top = topInset;
+    self.contentInset = contentInset;
+  }
 }
 
 - (CGSize)intrinsicContentSize

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -150,12 +150,12 @@ static UIColor *defaultPlaceholderColor(void)
   [self _invalidatePlaceholderVisibility];
 }
 
-- (void)setTextAlignmentVertical:(RCTUITextViewTextAlignmentVertical)textAlignmentVertical
+- (void)setTextAlignVertical:(RCTUITextViewTextAlignmentVertical)textAlignVertical
 {
-  if (_textAlignmentVertical == textAlignmentVertical) {
+  if (_textAlignVertical == textAlignVertical) {
     return;
   }
-  _textAlignmentVertical = textAlignmentVertical;
+  _textAlignVertical = textAlignVertical;
   [self setNeedsLayout];
 }
 
@@ -306,25 +306,28 @@ static UIColor *defaultPlaceholderColor(void)
 // by RN's existing wiring (only `textContainerInset` is set externally).
 - (void)_applyVerticalAlignmentInset
 {
+  // Fast path for apps that don't use the feature: skip the contentSize read.
+  if (_textAlignVertical == RCTUITextViewTextAlignmentVerticalAuto ||
+      _textAlignVertical == RCTUITextViewTextAlignmentVerticalTop) {
+    if (self.contentInset.top != 0) {
+      UIEdgeInsets contentInset = self.contentInset;
+      contentInset.top = 0;
+      self.contentInset = contentInset;
+    }
+    return;
+  }
   CGFloat boundsHeight = CGRectGetHeight(self.bounds);
   CGFloat contentHeight = self.contentSize.height;
   CGFloat topInset = 0;
   if (boundsHeight > contentHeight) {
-    switch (_textAlignmentVertical) {
-      case RCTUITextViewTextAlignmentVerticalCenter:
-        topInset = (boundsHeight - contentHeight) / 2;
-        break;
-      case RCTUITextViewTextAlignmentVerticalBottom:
-        topInset = boundsHeight - contentHeight;
-        break;
-      case RCTUITextViewTextAlignmentVerticalAuto:
-      case RCTUITextViewTextAlignmentVerticalTop:
-        topInset = 0;
-        break;
+    if (_textAlignVertical == RCTUITextViewTextAlignmentVerticalCenter) {
+      topInset = (boundsHeight - contentHeight) / 2;
+    } else if (_textAlignVertical == RCTUITextViewTextAlignmentVerticalBottom) {
+      topInset = boundsHeight - contentHeight;
     }
   }
-  UIEdgeInsets contentInset = self.contentInset;
-  if (contentInset.top != topInset) {
+  if (self.contentInset.top != topInset) {
+    UIEdgeInsets contentInset = self.contentInset;
     contentInset.top = topInset;
     self.contentInset = contentInset;
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -200,7 +200,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (newTextInputProps.multiline &&
       newTextInputProps.paragraphAttributes.textAlignVertical !=
           oldTextInputProps.paragraphAttributes.textAlignVertical) {
-    [self _applyTextAlignmentVerticalToMultilineView:newTextInputProps.paragraphAttributes.textAlignVertical];
+    [self _applyTextAlignVerticalToMultilineView:newTextInputProps.paragraphAttributes.textAlignVertical];
   }
 
   if (newTextInputProps.traits.autocapitalizationType != oldTextInputProps.traits.autocapitalizationType) {
@@ -838,14 +838,14 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
   if (multiline) {
     const auto &textInputProps = static_cast<const TextInputProps &>(*_props);
-    [self _applyTextAlignmentVerticalToMultilineView:textInputProps.paragraphAttributes.textAlignVertical];
+    [self _applyTextAlignVerticalToMultilineView:textInputProps.paragraphAttributes.textAlignVertical];
   }
 }
 
 // Single-line `UITextField` centers its content vertically inside the field
 // frame natively, so this routing is only meaningful when the backed view is
 // the multiline `RCTUITextView`. UITextField callers no-op.
-- (void)_applyTextAlignmentVerticalToMultilineView:
+- (void)_applyTextAlignVerticalToMultilineView:
     (const std::optional<facebook::react::TextAlignmentVertical> &)textAlignVertical
 {
   if (![_backedTextInputView isKindOfClass:[RCTUITextView class]]) {
@@ -868,7 +868,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
         break;
     }
   }
-  ((RCTUITextView *)_backedTextInputView).textAlignmentVertical = mapped;
+  ((RCTUITextView *)_backedTextInputView).textAlignVertical = mapped;
 }
 
 - (void)_setShowSoftInputOnFocus:(BOOL)showSoftInputOnFocus

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -197,6 +197,12 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     [self _setMultiline:newTextInputProps.multiline];
   }
 
+  if (newTextInputProps.multiline &&
+      newTextInputProps.paragraphAttributes.textAlignVertical !=
+          oldTextInputProps.paragraphAttributes.textAlignVertical) {
+    [self _applyTextAlignmentVerticalToMultilineView:newTextInputProps.paragraphAttributes.textAlignVertical];
+  }
+
   if (newTextInputProps.traits.autocapitalizationType != oldTextInputProps.traits.autocapitalizationType) {
     _backedTextInputView.autocapitalizationType =
         RCTUITextAutocapitalizationTypeFromAutocapitalizationType(newTextInputProps.traits.autocapitalizationType);
@@ -829,6 +835,40 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   RCTCopyBackedTextInput(_backedTextInputView, backedTextInputView);
   _backedTextInputView = backedTextInputView;
   [self addSubview:_backedTextInputView];
+
+  if (multiline) {
+    const auto &textInputProps = static_cast<const TextInputProps &>(*_props);
+    [self _applyTextAlignmentVerticalToMultilineView:textInputProps.paragraphAttributes.textAlignVertical];
+  }
+}
+
+// Single-line `UITextField` centers its content vertically inside the field
+// frame natively, so this routing is only meaningful when the backed view is
+// the multiline `RCTUITextView`. UITextField callers no-op.
+- (void)_applyTextAlignmentVerticalToMultilineView:
+    (const std::optional<facebook::react::TextAlignmentVertical> &)textAlignVertical
+{
+  if (![_backedTextInputView isKindOfClass:[RCTUITextView class]]) {
+    return;
+  }
+  RCTUITextViewTextAlignmentVertical mapped = RCTUITextViewTextAlignmentVerticalAuto;
+  if (textAlignVertical.has_value()) {
+    switch (*textAlignVertical) {
+      case facebook::react::TextAlignmentVertical::Auto:
+        mapped = RCTUITextViewTextAlignmentVerticalAuto;
+        break;
+      case facebook::react::TextAlignmentVertical::Top:
+        mapped = RCTUITextViewTextAlignmentVerticalTop;
+        break;
+      case facebook::react::TextAlignmentVertical::Bottom:
+        mapped = RCTUITextViewTextAlignmentVerticalBottom;
+        break;
+      case facebook::react::TextAlignmentVertical::Center:
+        mapped = RCTUITextViewTextAlignmentVerticalCenter;
+        break;
+    }
+  }
+  ((RCTUITextView *)_backedTextInputView).textAlignmentVertical = mapped;
 }
 
 - (void)_setShowSoftInputOnFocus:(BOOL)showSoftInputOnFocus

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -35,6 +35,41 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   }
 }
 
+// Block-axis offset to apply to the line-box stack when painting / hit-testing.
+// Mirrors the CSS Box Alignment Level 3 `align-content` algorithm on a block
+// container (https://drafts.csswg.org/css-align-3/#align-content-property):
+// start/center/end positioning of the content within the box, with "safe"
+// overflow handling (when content exceeds the box, fall back to start).
+// Matches Android's `TextLayoutManager.getVerticalOffset` exactly so Paragraph
+// renders identically across platforms.
+static CGFloat RCTVerticalOffsetForTextAlignment(
+    NSLayoutManager *layoutManager,
+    NSTextContainer *textContainer,
+    const ParagraphAttributes &paragraphAttributes,
+    CGFloat boxHeight)
+{
+  if (!paragraphAttributes.textAlignVertical.has_value()) {
+    return 0;
+  }
+  TextAlignmentVertical align = *paragraphAttributes.textAlignVertical;
+  if (align == TextAlignmentVertical::Auto || align == TextAlignmentVertical::Top) {
+    return 0;
+  }
+  CGFloat textHeight = [layoutManager usedRectForTextContainer:textContainer].size.height;
+  if (textHeight >= boxHeight) {
+    return 0;
+  }
+  switch (align) {
+    case TextAlignmentVertical::Center:
+      return (boxHeight - textHeight) / 2;
+    case TextAlignmentVertical::Bottom:
+      return boxHeight - textHeight;
+    case TextAlignmentVertical::Auto:
+    case TextAlignmentVertical::Top:
+      return 0;
+  }
+}
+
 - (TextMeasurement)measureNSAttributedString:(NSAttributedString *)attributedString
                          paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                layoutContext:(TextLayoutContext)layoutContext
@@ -88,8 +123,12 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 
   [self processTruncatedAttributedText:textStorage textContainer:textContainer layoutManager:layoutManager];
 
-  [layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:frame.origin];
-  [layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:frame.origin];
+  CGFloat verticalOffset =
+      RCTVerticalOffsetForTextAlignment(layoutManager, textContainer, paragraphAttributes, frame.size.height);
+  CGPoint origin = CGPointMake(frame.origin.x, frame.origin.y + verticalOffset);
+
+  [layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:origin];
+  [layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:origin];
 
 #if TARGET_OS_MACCATALYST
   CGContextRestoreGState(context);
@@ -113,8 +152,9 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                   withinSelectedGlyphRange:range
                                            inTextContainer:textContainer
                                                 usingBlock:^(CGRect enclosingRect, __unused BOOL *anotherStop) {
+                                                  CGRect shiftedRect = CGRectOffset(enclosingRect, 0, verticalOffset);
                                                   UIBezierPath *path = [UIBezierPath
-                                                      bezierPathWithRoundedRect:CGRectInset(enclosingRect, -2, -2)
+                                                      bezierPathWithRoundedRect:CGRectInset(shiftedRect, -2, -2)
                                                                    cornerRadius:2];
                                                   if (highlightPath != nullptr) {
                                                     [highlightPath appendPath:path];
@@ -264,8 +304,12 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   NSLayoutManager *layoutManager = textStorage.layoutManagers.firstObject;
   NSTextContainer *textContainer = layoutManager.textContainers.firstObject;
 
+  CGFloat verticalOffset =
+      RCTVerticalOffsetForTextAlignment(layoutManager, textContainer, paragraphAttributes, frame.size.height);
+  CGPoint adjustedPoint = CGPointMake(point.x, point.y - verticalOffset);
+
   CGFloat fraction;
-  NSUInteger characterIndex = [layoutManager characterIndexForPoint:point
+  NSUInteger characterIndex = [layoutManager characterIndexForPoint:adjustedPoint
                                                     inTextContainer:textContainer
                            fractionOfDistanceBetweenInsertionPoints:&fraction];
 
@@ -300,6 +344,9 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
   NSRange characterRange = [layoutManager characterRangeForGlyphRange:glyphRange actualGlyphRange:NULL];
 
+  CGFloat verticalOffset =
+      RCTVerticalOffsetForTextAlignment(layoutManager, textContainer, paragraphAttributes, frame.size.height);
+
   [textStorage enumerateAttribute:enumerateAttribute
                           inRange:characterRange
                           options:0
@@ -314,7 +361,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                                   inTextContainer:textContainer
                                                        usingBlock:^(CGRect enclosingRect, BOOL *_Nonnull stop) {
                                                          block(
-                                                             enclosingRect,
+                                                             CGRectOffset(enclosingRect, 0, verticalOffset),
                                                              [textStorage attributedSubstringFromRange:range].string,
                                                              value);
                                                          *stop = YES;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -2351,6 +2351,7 @@ interface RCTUITextView : public UITextView <RCTBackedTextInputViewProtocol> {
   public @property (assign) BOOL contextMenuHidden;
   public @property (assign) BOOL disableKeyboardShortcuts;
   public @property (assign) CGFloat preferredMaxLayoutWidth;
+  public @property (assign) RCTUITextViewTextAlignmentVertical textAlignVertical;
   public @property (assign) UITextFieldViewMode clearButtonMode;
   public @property (assign, readonly) BOOL dictationRecognizing;
   public @property (assign, readonly) BOOL textWasPasted;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -2351,6 +2351,7 @@ interface RCTUITextView : public UITextView <RCTBackedTextInputViewProtocol> {
   public @property (assign) BOOL contextMenuHidden;
   public @property (assign) BOOL disableKeyboardShortcuts;
   public @property (assign) CGFloat preferredMaxLayoutWidth;
+  public @property (assign) RCTUITextViewTextAlignmentVertical textAlignVertical;
   public @property (assign) UITextFieldViewMode clearButtonMode;
   public @property (assign, readonly) BOOL dictationRecognizing;
   public @property (assign, readonly) BOOL textWasPasted;


### PR DESCRIPTION
## Summary:

`textAlignVertical` (and the CSS-style `verticalAlign`) has worked on Android since #34567, but iOS silently ignores it on both `<Text>` and multiline `<TextInput>`: every value paints content at the top of the host view. This PR closes both halves of the gap so a fixed-height Text or multiline TextInput with `verticalAlign: 'middle'` (or `'bottom'`) renders the same on iOS as on Android. Single-line TextInput (`UITextField`) already centers natively and is intentionally not routed.

**Scope: New Architecture only.** This wires the Fabric iOS renderer (the default since 0.76): the Fabric Paragraph path in `RCTTextLayoutManager` and the Fabric multiline TextInput path in `RCTTextInputComponentView` / `RCTUITextView`. The legacy (Paper) iOS `<Text>` and `<TextInput>` managers (`RCTTextViewManager` / `RCTBaseTextInputViewManager`) are intentionally not wired, so apps still on the old renderer are unaffected. Thanks to @popsiclelmlm for flagging the ambiguity.

Computation matches Android's existing `TextLayoutManager.getVerticalOffset` exactly: 0 for `auto` / `top`, `(boxHeight - textHeight) / 2` for `center`, `boxHeight - textHeight` for `bottom`, and 0 when content overflows the box. This is the CSS Box Alignment Level 3 [`align-content`](https://drafts.csswg.org/css-align-3/#align-content-property) algorithm with safe overflow on a block container.

### Paragraph (`<Text>`)

The offset is applied at three sites in `RCTTextLayoutManager.mm`:

- `drawAttributedString` shifts the paint origin for the background pass, glyph pass, and highlight rect path.
- `getEventEmitterWithAttributeString` reverse-offsets the incoming touch point so hit-testing still resolves the correct character.
- `getRectWithAttributedString` forward-offsets the enumerated link/button rects so VoiceOver focuses on the right region.

Keeping all three in lockstep avoids the class of bug where a centered link "renders below the touch target" or accessibility reads the wrong frame. Measurement is unchanged: alignment shifts the line-box stack inside the box, it doesn't alter intrinsic text size.

### Multiline TextInput

The offset is applied via `UIScrollView.contentInset.top` inside `RCTUITextView.layoutSubviews`. This is the right hook on iOS: it shifts the default scroll origin without interfering with text layout, user scrolling, or RN's existing `textContainerInset` wiring (which is used for padding). When content grows past the bounds, the inset clamps to 0 and normal scrolling takes over.

`RCTTextInputComponentView.updateProps` reads `paragraphAttributes.textAlignVertical` (already parsed by `BaseTextInputProps`), maps the C++ enum to an ObjC bridge enum (`RCTUITextViewTextAlignmentVertical`), and pushes it to the backed `RCTUITextView`. The mapping is also re-applied when the backed view switches from single-line to multiline so the new view picks up the alignment on the same render. The default `Auto` / `Top` case short-circuits before reading `contentSize` so apps that don't use the feature pay zero per-layout overhead.

No public header changes; ABI is preserved.

## Changelog:

[IOS] [ADDED] - Honor `textAlignVertical` (and the equivalent `verticalAlign` style) on `<Text>` and multiline `<TextInput>` on the New Architecture

## Test Plan:

Tested in a Fabric / Hermes V1 / new-arch Expo app on iPhone 17 simulator (iOS 26.4) at all three values, for both Text and multiline TextInput:

| `vertical-align` | Result |
| --- | --- |
| `top` (default) | Content flush to top of host view (unchanged) |
| `middle` / `center` | Content centered in host view |
| `bottom` | Content flush to bottom of host view |

For Text: decorations (underline, strike) follow the glyphs in all three positions. Touching anywhere on a centered or bottom-aligned link still emits the correct press event. Overflow (text taller than the box) falls back to top to avoid clipping content.

For multiline TextInput: the caret and placeholder sit at the requested position before any text is typed. Typing extends content naturally; once the content fills past the fixed height, scrolling takes over and the alignment offset clamps to top.

## Related

- #34567: original Android implementation (merged August 2022). This PR completes the cross-platform story.
- #26926: closed historic report ("textAlignVertical: center not working") where the iOS-Text symptom is exactly the one this fix addresses. The thread documents the wrap-in-`<View justifyContent="center">` workaround users have been adopting.
- #32198: closed-stale report of the same iOS-Text symptom for emoji.


