### PR TITLE
fix(android): Prevent text cut-off by clamping lineHeight to font height

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.kt
@@ -18,7 +18,7 @@ import kotlin.math.floor
  * (does not impact space before the first line or after the last).
  */
 internal class CustomLineHeightSpan(height: Float) : LineHeightSpan, ReactSpan {
-  val lineHeight: Int = ceil(height.toDouble()).toInt()
+  val requestedLineHeight: Int = ceil(height.toDouble()).toInt()
 
   override fun chooseHeight(
       text: CharSequence,
@@ -38,19 +38,17 @@ internal class CustomLineHeightSpan(height: Float) : LineHeightSpan, ReactSpan {
     // if line-fit-edge is not leading and this is not the root inline box, if the half-leading is
     // positive, treat it as zero. The layout bounds exactly encloses this effective A′ and D′.
 
-    val leading = lineHeight - ((-fm.ascent) + fm.descent)
+
+    // Calculate the font's natural height
+    val fontHeight = (-fm.ascent) + fm.descent
+    // Clamp lineHeight to at least the font's natural height
+    val lineHeight = if (requestedLineHeight < fontHeight) fontHeight else requestedLineHeight
+    val leading = lineHeight - fontHeight
     fm.ascent -= ceil(leading / 2.0f).toInt()
     fm.descent += floor(leading / 2.0f).toInt()
 
-    // The top of the first line, and the bottom of the last line, may influence bounds of the
-    // paragraph, so we match them to the text ascent/descent. It is otherwise desirable to allow
-    // line boxes to overlap (to allow too large glyphs to be drawn outside them), so we do not
-    // adjust the top/bottom of interior line-boxes.
-    if (start == 0) {
-      fm.top = fm.ascent
-    }
-    if (end == text.length) {
-      fm.bottom = fm.descent
-    }
+    // Always set top and bottom to match ascent and descent to avoid clipping on any line.
+    fm.top = fm.ascent
+    fm.bottom = fm.descent
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory.
-->

## Summary

On Android 15 & 16, text was being cut off when `lineHeight` was set smaller than the font’s ascent + descent, due to changes in the platform’s text rendering.  
This patch updates `CustomLineHeightSpan` to always ensure the line box is at least as large as the font’s required height, and sets `fm.top`/`fm.bottom` to match the adjusted ascent/descent for all lines.  
This prevents descenders and ascenders from being clipped, matching native TextView and web behavior, and does not affect other text features or layouts.  
Fixes #56402, #53286, #56402

## Changelog:

[Android] [Fixed] - Prevent text cut-off when `lineHeight` is less than font size by clamping line height to font metrics in `CustomLineHeightSpan`. This ensures text is never clipped on Android 15 & 16 and matches native TextView/web behavior. Fixes #56402, #53286, 56402

_For more details, see:_  
https://reactnative.dev/contributing/changelogs-in-pull-requests

## Test Plan

- Render text with various combinations of `fontSize` and `lineHeight`, including cases where `lineHeight < fontSize`.
- Verify that no text is clipped on Android 15 & 16, especially for characters with descenders (e.g., “g”, “y”, “p”).
- Confirm that text renders correctly on older Android versions and that layouts are unaffected for normal line heights.
- Run existing text rendering tests and visual regression tests to ensure no regressions.

Example test code:

```jsx
<Text style={{fontSize: 24, lineHeight: 8, borderWidth: 1, borderColor: 'red'}}>
  gyqp
</Text>