### PR TITLE
fix(android): use the context's display for display metrics, not the device default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -137,7 +137,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     setClipChildren(false);
 
     if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
     }
   }
 
@@ -932,7 +932,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext());
       mVisibleViewArea = new Rect();
     }
 
@@ -1007,7 +1007,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -10,7 +10,9 @@ package com.facebook.react.uimanager
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.util.DisplayMetrics
+import android.view.Display
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -54,9 +56,19 @@ public object DisplayMetricsHolder {
     val screenDisplayMetrics = DisplayMetrics()
     screenDisplayMetrics.setTo(displayMetrics)
     try {
-      val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+      // Use the display the context is associated with, not the device's
+      // default display. They differ when the activity is running on a
+      // secondary display (Samsung DeX, desktop mode, external monitor,
+      // freeform window) — using the default display there reports the
+      // primary display's density/dimensions and breaks layout scaling.
+      val display: Display? =
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.display
+          } else {
+            (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager).defaultDisplay
+          }
       // getRealMetrics includes system decor (e.g. nav bar) excluded from resource metrics.
-      wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+      display?.getRealMetrics(screenDisplayMetrics)
     } catch (_: Exception) {
       // Non-visual contexts (e.g. Application) may throw on API 30+.
       // Falls back to resource display metrics copied via setTo() above.


### PR DESCRIPTION
## Summary:

`DisplayMetricsHolder.initDisplayMetrics` populates `screenDisplayMetrics` by calling `getRealMetrics` on `WindowManager.defaultDisplay`. `defaultDisplay` is always the device's _primary_ display, regardless of which display the activity is actually running on.

When an activity runs on a secondary display  (Samsung DeX, desktop mode an external monitor, a freeform window, or an emulator virtual display via `am start --display N`) its density and dimensions differ from the primary's. 

`PixelUtil` (`toPixelFromDIP` / `toDIPFromPixel` / `toPixelFromSP` / `getDisplayMetricDensity`) reads `screenDisplayMetrics` for every dp <-> px conversion the layout engine performs, so Fabric lays out content at the _primary_ display's scale into a window that doesn't have that scale. The visible content is clipped to a fraction of the activity window with the rest left black, and text renders at sub-pixel positions (blurry).

This is observable from JS — `Dimensions.get('window')` and `useWindowDimensions()` are correct, but `Dimensions.get('screen')` reports the primary display's `scale`:

```
window: { width: 1600, height: 720, scale: 1.5 }   <- the activity's display
screen: { width: 800,  height: 360, scale: 3   }   <- the device's primary display
```

This PR changes `initDisplayMetrics` to read from the display the `Context` is associated with, `Context.getDisplay()` on API 30+, falling back to `WindowManager.defaultDisplay` on older API levels, instead of always the device default. It also passes the view's own context (not the application context) from `ReactRootView`, so that context is associated with the activity's display.

Single-display behavior is unchanged: when the activity is on the primary display, the context's display is the default display, so the metrics are identical.

Fixes #56894 (also tracked in #55659).

## Changelog:

[ANDROID] [FIXED] - Display metrics now reflect the activity's display instead of the device's default display, fixing layout scaling on secondary displays / desktop mode / freeform windows.

## Test Plan:

Reproducer (standalone minimal app + commands): https://github.com/DouweBos/rn-secondary-display-repro

### Unit tests

`./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests "com.facebook.react.uimanager.DisplayMetricsHolderTest" --tests "com.facebook.react.uimanager.PixelUtilTest"`

### A/B on `rn-tester`, built from source

Built `rn-tester` from this branch and from its parent commit (this commit reverted), installed both on the same Pixel 9 Pro AVD (API 36) with a virtual secondary display at a different density than the primary:

```sh
adb emu multidisplay add 1 2400 1080 240 0   # 2400x1080 @240dpi (1.5x); primary is 3.0x
adb shell am start -n com.facebook.react.uiapp/.RNTesterActivity --display 2
SF_ID=$(adb shell dumpsys SurfaceFlinger --display-id | awk '/Virtual display/ {print $2; exit}')
adb shell screencap -d "$SF_ID" -p /sdcard/d.png && adb pull /sdcard/d.png .
```

**Before** (parent commit) — `screenDisplayMetrics` taken from the primary display; the dp ↔ px conversion uses the primary's 3.0x density on a 1.5x display, so text is clipped/garbled ("Comp" instead of "Components", "Bu", "DrawerLay", …) and the bottom tab indicator is sized for the wrong width:

![rn-tester before](https://github.com/DouweBos/rn-secondary-display-repro/raw/main/screenshots/rntester-secondary-before.png)

**After** (this branch) — metrics come from the activity's display; layout fills the window and all labels render fully and crisply:

![rn-tester after](https://github.com/DouweBos/rn-secondary-display-repro/raw/main/screenshots/rntester-secondary-after.png)