### PR TITLE
Set always_out_of_date on hermes-engine Replace Hermes phase

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -88,7 +88,7 @@ Pod::Spec.new do |spec|
     # We ignore this if we provide a specific tarball: the assumption here is that if you are providing a tarball, is because you want to
     # test something specific for that tarball.
     if source_type == HermesEngineSourceType::DOWNLOAD_PREBUILD_RELEASE_TARBALL
-      spec.script_phase = {
+      script_phase = {
         :name => "[Hermes] Replace Hermes for the right configuration, if needed",
         :execution_position => :before_compile,
         :script => <<-EOS
@@ -102,6 +102,15 @@ Pod::Spec.new do |spec|
         "$NODE_BINARY" "$REACT_NATIVE_PATH/sdks/hermes-engine/utils/replace_hermes_version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
         EOS
       }
+
+
+      # :always_out_of_date is only available in CocoaPods 1.13.0 and later
+      if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')
+        # always run the script without warning
+        script_phase[:always_out_of_date] = "1"
+      end
+
+      spec.script_phase = script_phase
     end
 
   elsif HermesEngineSourceType::isFromSource(source_type) then


### PR DESCRIPTION
## Summary:

`hermes-engine.podspec`'s `[Hermes] Replace Hermes for the right configuration, if needed` script_phase is missing `:always_out_of_date`, so Xcode 14+ emits a `will be run during every build because it does not specify any outputs` warning on every clean iOS build of every project on the default prebuilt-release-tarball Hermes path. 

Set the flag using the same guard shape as the two sibling phases in this package (#52133 and #49812) as well as in #48495.

## Changelog:

[IOS] [FIXED] - Set `always_out_of_date` on hermes-engine's `Replace Hermes` script phase

## Test Plan:

I ran `pod install` and `xcodebuild` on RN 0.85.3 with the default prebuilt Hermes.

- The warning on the Hermes phase turns into a `note`, the same as the phases that were already fixed.
- `Pods.xcodeproj/project.pbxproj` has `alwaysOutOfDate = 1;` on the phase.
- The phase still runs and still replaces the binary for the right configuration.
