### PR TITLE
fix(ios): make Podfile.lock SPEC CHECKSUMS deterministic across machines

### DIFF
--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -61,6 +61,6 @@ Pod::Spec.new do |spec|
   # Fabric must be able to access private headers (which should not be included in the umbrella header)
   all_header_files = 'yoga/**/*.h'
   all_header_files = File.join('ReactCommon/yoga', all_header_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
-  spec.private_header_files = Dir.glob(all_header_files) - Dir.glob(public_header_files)
+  spec.private_header_files = Dir.glob(all_header_files).sort - Dir.glob(public_header_files).sort
   spec.preserve_paths = [all_header_files]
 end

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -70,9 +70,14 @@ Pod::Spec.new do |spec|
       hermes_compiler_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
         "require.resolve(\"hermes-compiler\", {paths: [\"#{react_native_path}\"]})", __dir__]).strip
       )
+      hermesc_path = File.join(hermes_compiler_path, 'hermesc', 'osx-bin', 'hermesc')
+
+      require 'pathname'
+      pods_root = Pod::Config.instance.sandbox.root
+      relative_hermesc = Pathname.new(hermesc_path).relative_path_from(pods_root)
 
       spec.user_target_xcconfig = {
-        'HERMES_CLI_PATH' => "#{hermes_compiler_path}/hermesc/osx-bin/hermesc"
+        'HERMES_CLI_PATH' => "$(PODS_ROOT)/#{relative_hermesc}"
       }
     end
 


### PR DESCRIPTION
## Summary

Two sources of non-determinism cause `Podfile.lock` SPEC CHECKSUMS to differ between machines, breaking `pod install --deployment` in CI and creating unnecessary churn in PRs.

### Fix 1: Sort `Dir.glob` results in `Yoga.podspec`

`Dir.glob` returns files in filesystem-dependent order (varies across macOS APFS volumes, case sensitivity settings, and Linux ext4/xfs). Since CocoaPods evaluates the podspec at install time, the resulting array order differs between machines, producing different spec checksums.

```ruby
# Before
spec.private_header_files = Dir.glob(all_header_files) - Dir.glob(public_header_files)

# After
spec.private_header_files = Dir.glob(all_header_files).sort - Dir.glob(public_header_files).sort
```

### Fix 2: Use a Pods-relative path in `hermes-engine.podspec`

`require.resolve` with `__dir__` resolves to an absolute path containing the developer's home directory (e.g., `/Users/alice/project/node_modules/...`). This absolute path gets baked into `user_target_xcconfig`, which differs per machine.

Instead of hardcoding a relative path (which assumes a specific project layout), we dynamically compute the relative path from `Pod::Config.instance.sandbox.root` to the resolved `hermes-compiler` location. This supports any project layout (standard apps, monorepos, RNTester, etc.) while keeping the xcconfig deterministic.

```ruby
# Before — absolute path baked in
spec.user_target_xcconfig = {
  'HERMES_CLI_PATH' => "#{hermes_compiler_path}/hermesc/osx-bin/hermesc"
}

# After — dynamic relative path via $(PODS_ROOT)
pods_root = Pod::Config.instance.sandbox.root
relative_hermesc = Pathname.new(hermesc_path).relative_path_from(pods_root)

spec.user_target_xcconfig = {
  'HERMES_CLI_PATH' => "$(PODS_ROOT)/#{relative_hermesc}"
}
```

## Changelog:

[IOS] [FIXED] - Make Podfile.lock SPEC CHECKSUMS deterministic across machines by sorting Dir.glob results in Yoga.podspec and using a dynamically computed Pods-relative path in hermes-engine.podspec

## Test Plan

1. Run `pod install` on machine A, record `Podfile.lock`
2. Run `pod install` on machine B (different username/home directory)
3. Verify SPEC CHECKSUMS are identical between both runs

We have verified this fix in our production app — after patching, running `pod install` consecutively produces zero diff in `Podfile.lock`.

Supersedes #56977 (closed due to force-push history issue).
Fixes https://github.com/facebook/react-native/issues/56975

Made with [Cursor](https://cursor.com)