### PR TITLE
Remove legacy RCTTimingModule (#57037)

### DIFF
--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -87,12 +87,6 @@ RCT_EXTERN void RCTRegisterModule(Class);
 - (void)start;
 
 /**
- * Used by RCTModuleData to register the module for frame updates after it is
- * lazily initialized.
- */
-- (void)registerModuleForFrameUpdates:(id<RCTBridgeModule>)module withModuleData:(RCTModuleData *)moduleData;
-
-/**
  * Dispatch work to a module's queue - this is also supports the fake RCTJSThread
  * queue. Exposed for the RCTProfiler
  */

--- a/packages/react-native/React/Base/RCTDisplayLink.h
+++ b/packages/react-native/React/Base/RCTDisplayLink.h
@@ -7,23 +7,12 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol RCTBridgeModule;
-@class RCTModuleData;
-
-@protocol RCTDisplayLinkModuleHolder
-- (id<RCTBridgeModule>)instance;
-- (Class)moduleClass;
-- (dispatch_queue_t)methodQueue;
-@end
+@protocol RCTFrameUpdateObserver;
 
 @interface RCTDisplayLink : NSObject
 
-- (instancetype)init;
+- (instancetype)initWithFrameUpdateObserver:(id<RCTFrameUpdateObserver>)observer;
 - (void)invalidate;
-- (void)registerModuleForFrameUpdates:(id<RCTBridgeModule>)module
-                     withModuleHolder:(id<RCTDisplayLinkModuleHolder>)moduleHolder
-    __attribute__((deprecated(
-        "registerModuleForFrameUpdates is part of the legacy architecture and will be removed in a future React Native release.")));
 - (void)addToRunLoop:(NSRunLoop *)runLoop;
 
 @end

--- a/packages/react-native/React/Base/RCTDisplayLink.m
+++ b/packages/react-native/React/Base/RCTDisplayLink.m
@@ -11,9 +11,7 @@
 #import <QuartzCore/CADisplayLink.h>
 
 #import "RCTAssert.h"
-#import "RCTBridgeModule.h"
 #import "RCTFrameUpdate.h"
-#import "RCTModuleData.h"
 #import "RCTProfile.h"
 
 #define RCTAssertRunLoop() \
@@ -21,66 +19,42 @@
 
 @implementation RCTDisplayLink {
   CADisplayLink *_jsDisplayLink;
-  NSMutableSet<id<RCTDisplayLinkModuleHolder>> *_frameUpdateObservers;
+  id<RCTFrameUpdateObserver> _frameUpdateObserver;
   NSRunLoop *_runLoop;
 }
 
-- (instancetype)init
+- (instancetype)initWithFrameUpdateObserver:(id<RCTFrameUpdateObserver>)observer
 {
   if ((self = [super init])) {
-    _frameUpdateObservers = [NSMutableSet new];
+    _frameUpdateObserver = observer;
     _jsDisplayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(_jsThreadUpdate:)];
+
+    __weak typeof(self) weakSelf = self;
+    observer.pauseCallback = ^{
+      typeof(self) strongSelf = weakSelf;
+      if (!strongSelf) {
+        return;
+      }
+
+      CFRunLoopRef cfRunLoop = [strongSelf->_runLoop getCFRunLoop];
+      if (!cfRunLoop) {
+        return;
+      }
+
+      if ([NSRunLoop currentRunLoop] == strongSelf->_runLoop) {
+        [weakSelf updateJSDisplayLinkState];
+      } else {
+        CFRunLoopPerformBlock(cfRunLoop, kCFRunLoopDefaultMode, ^{
+          @autoreleasepool {
+            [weakSelf updateJSDisplayLinkState];
+          }
+        });
+        CFRunLoopWakeUp(cfRunLoop);
+      }
+    };
   }
 
   return self;
-}
-
-- (void)registerModuleForFrameUpdates:(id<RCTBridgeModule>)module
-                     withModuleHolder:(id<RCTDisplayLinkModuleHolder>)moduleHolder
-{
-  if (![moduleHolder.moduleClass conformsToProtocol:@protocol(RCTFrameUpdateObserver)] ||
-      [_frameUpdateObservers containsObject:moduleHolder]) {
-    return;
-  }
-
-  [_frameUpdateObservers addObject:moduleHolder];
-
-  // Don't access the module instance via moduleHolder, as this will cause deadlock
-  id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)module;
-  __weak typeof(self) weakSelf = self;
-  observer.pauseCallback = ^{
-    typeof(self) strongSelf = weakSelf;
-    if (!strongSelf) {
-      return;
-    }
-
-    CFRunLoopRef cfRunLoop = [strongSelf->_runLoop getCFRunLoop];
-    if (!cfRunLoop) {
-      return;
-    }
-
-    if ([NSRunLoop currentRunLoop] == strongSelf->_runLoop) {
-      [weakSelf updateJSDisplayLinkState];
-    } else {
-      CFRunLoopPerformBlock(cfRunLoop, kCFRunLoopDefaultMode, ^{
-        @autoreleasepool {
-          [weakSelf updateJSDisplayLinkState];
-        }
-      });
-      CFRunLoopWakeUp(cfRunLoop);
-    }
-  };
-
-  // Assuming we're paused right now, we only need to update the display link's state
-  // when the new observer is not paused. If it not paused, the observer will immediately
-  // start receiving updates anyway.
-  if (![observer isPaused] && _runLoop) {
-    CFRunLoopPerformBlock([_runLoop getCFRunLoop], kCFRunLoopDefaultMode, ^{
-      @autoreleasepool {
-        [self updateJSDisplayLinkState];
-      }
-    });
-  }
 }
 
 - (void)addToRunLoop:(NSRunLoop *)runLoop
@@ -96,23 +70,11 @@
 
 - (void)invalidate
 {
-  // ensure observer callbacks do not hold a reference to weak self via pauseCallback
-  for (id<RCTDisplayLinkModuleHolder> moduleHolder in _frameUpdateObservers) {
-    id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleHolder.instance;
-    [observer setPauseCallback:nil];
-  }
-  [_frameUpdateObservers removeAllObjects]; // just to be explicit
+  // ensure the observer callback does not hold a reference to weak self via pauseCallback
+  [_frameUpdateObserver setPauseCallback:nil];
+  _frameUpdateObserver = nil;
 
   [_jsDisplayLink invalidate];
-}
-
-- (void)dispatchBlock:(dispatch_block_t)block queue:(dispatch_queue_t)queue
-{
-  if (queue == RCTJSThread) {
-    block();
-  } else if (queue) {
-    dispatch_async(queue, block);
-  }
 }
 
 - (void)_jsThreadUpdate:(CADisplayLink *)displayLink
@@ -121,22 +83,11 @@
 
   RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[RCTDisplayLink _jsThreadUpdate:]", nil);
 
+  // This always runs on the JS thread run loop, which is the queue the frame
+  // update observer expects its callbacks on, so dispatch inline.
   RCTFrameUpdate *frameUpdate = [[RCTFrameUpdate alloc] initWithDisplayLink:displayLink];
-  for (id<RCTDisplayLinkModuleHolder> moduleHolder in _frameUpdateObservers) {
-    id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleHolder.instance;
-    if (!observer.paused) {
-      if (moduleHolder.methodQueue) {
-        RCTProfileBeginFlowEvent();
-        [self
-            dispatchBlock:^{
-              RCTProfileEndFlowEvent();
-              [observer didUpdateFrame:frameUpdate];
-            }
-                    queue:moduleHolder.methodQueue];
-      } else {
-        [observer didUpdateFrame:frameUpdate];
-      }
-    }
+  if (!_frameUpdateObserver.paused) {
+    [_frameUpdateObserver didUpdateFrame:frameUpdate];
   }
 
   [self updateJSDisplayLinkState];
@@ -150,16 +101,7 @@
 {
   RCTAssertRunLoop();
 
-  BOOL pauseDisplayLink = YES;
-  for (id<RCTDisplayLinkModuleHolder> moduleHolder in _frameUpdateObservers) {
-    id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleHolder.instance;
-    if (!observer.paused) {
-      pauseDisplayLink = NO;
-      break;
-    }
-  }
-
-  _jsDisplayLink.paused = pauseDisplayLink;
+  _jsDisplayLink.paused = _frameUpdateObserver == nil || _frameUpdateObserver.paused;
 }
 
 @end

--- a/packages/react-native/React/CoreModules/RCTTiming.h
+++ b/packages/react-native/React/CoreModules/RCTTiming.h
@@ -7,7 +7,6 @@
 
 #import <Foundation/Foundation.h>
 
-#import <React/RCTBridgeModule.h>
 #import <React/RCTFrameUpdate.h>
 #import <React/RCTInitializing.h>
 #import <React/RCTInvalidating.h>
@@ -22,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface RCTTiming : NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing>
+@interface RCTTiming : NSObject <RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing>
 
 - (instancetype)initWithDelegate:(id<RCTTimingDelegate>)delegate;
 - (void)createTimerForNextFrame:(NSNumber *)callbackID

--- a/packages/react-native/React/CoreModules/RCTTiming.mm
+++ b/packages/react-native/React/CoreModules/RCTTiming.mm
@@ -7,16 +7,10 @@
 
 #import "RCTTiming.h"
 
-#import <FBReactNativeSpec/FBReactNativeSpec.h>
-
 #import <React/RCTAssert.h>
-#import <React/RCTBridge+Private.h>
-#import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
-
-#import "CoreModulesPlugins.h"
 
 static const NSTimeInterval kMinimumSleepInterval = 1;
 
@@ -82,7 +76,7 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
 + (instancetype)proxyWithTarget:(id)target
 {
   _RCTTimingProxy *proxy = [self new];
-  if (proxy) {
+  if (proxy != nil) {
     proxy->_target = target;
   }
   return proxy;
@@ -103,11 +97,8 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
   id<RCTTimingDelegate> _timingDelegate;
 }
 
-@synthesize bridge = _bridge;
 @synthesize paused = _paused;
 @synthesize pauseCallback = _pauseCallback;
-
-RCT_EXPORT_MODULE()
 
 - (instancetype)initWithDelegate:(id<RCTTimingDelegate>)delegate
 {
@@ -165,15 +156,9 @@ RCT_EXPORT_MODULE()
   [_sleepTimer invalidate];
 }
 
-- (dispatch_queue_t)methodQueue
-{
-  return RCTJSThread;
-}
-
 - (void)invalidate
 {
   [self stopTimers];
-  _bridge = nil;
   _timingDelegate = nil;
 }
 
@@ -220,7 +205,7 @@ RCT_EXPORT_MODULE()
 
 - (void)startTimers
 {
-  if ((!_bridge && !_timingDelegate) || _inBackground || ![self hasPendingTimers]) {
+  if ((!_timingDelegate) || _inBackground || ![self hasPendingTimers]) {
     return;
   }
 
@@ -259,11 +244,7 @@ RCT_EXPORT_MODULE()
     NSArray<NSNumber *> *sortedTimers = [[timersToCall sortedArrayUsingComparator:^(_RCTTimer *a, _RCTTimer *b) {
       return [a.target compare:b.target];
     }] valueForKey:@"callbackID"];
-    if (_bridge) {
-      [_bridge enqueueJSCall:@"JSTimers" method:@"callTimers" args:@[ sortedTimers ] completion:NULL];
-    } else {
-      [_timingDelegate callTimers:sortedTimers];
-    }
+    [_timingDelegate callTimers:sortedTimers];
   }
 
   for (_RCTTimer *timer in timersToCall) {
@@ -282,23 +263,19 @@ RCT_EXPORT_MODULE()
     if (kFrameDuration - frameElapsed >= kIdleCallbackFrameDeadline) {
       NSTimeInterval currentTimestamp = [[NSDate date] timeIntervalSince1970];
       NSNumber *absoluteFrameStartMS = @((currentTimestamp - frameElapsed) * 1000);
-      if (_bridge) {
-        [_bridge enqueueJSCall:@"JSTimers" method:@"callIdleCallbacks" args:@[ absoluteFrameStartMS ] completion:NULL];
-      } else {
-        [_timingDelegate callIdleCallbacks:absoluteFrameStartMS];
-      }
+      [_timingDelegate callIdleCallbacks:absoluteFrameStartMS];
     }
   }
 
   // Switch to a paused state only if we didn't call any timer this frame, so if
   // in response to this timer another timer is scheduled, we don't pause and unpause
   // the displaylink frivolously.
-  NSUInteger timerCount;
+  NSUInteger timerCount = 0;
   @synchronized(_timers) {
     timerCount = _timers.count;
   }
   if (_inBackground) {
-    if (timerCount) {
+    if (timerCount != 0u) {
       [self scheduleSleepTimer:nextScheduledTarget];
     }
   } else if (!_sendIdleEvents && timersToCall.count == 0) {
@@ -318,7 +295,7 @@ RCT_EXPORT_MODULE()
 - (void)scheduleSleepTimer:(NSDate *)sleepTarget
 {
   @synchronized(self) {
-    if (!_sleepTimer || !_sleepTimer.valid) {
+    if ((_sleepTimer == nil) || !_sleepTimer.valid) {
       _sleepTimer = [[NSTimer alloc] initWithFireDate:sleepTarget
                                              interval:0
                                                target:[_RCTTimingProxy proxyWithTarget:self]
@@ -341,35 +318,6 @@ RCT_EXPORT_MODULE()
     // Immediately dispatch frame, so we don't have to wait on the displaylink.
     [self didUpdateFrame:nil];
   }
-}
-
-/**
- * A method used for asynchronously creating a timer. If the timer has already expired,
- * (based on the provided jsSchedulingTime) then it will be immediately invoked.
- *
- * There's a small difference between the time when we call
- * setTimeout/setInterval/requestAnimation frame and the time it actually makes
- * it here. This is important and needs to be taken into account when
- * calculating the timer's target time. We calculate this by passing in
- * Date.now() from JS and then subtracting that from the current time here.
- */
-RCT_EXPORT_METHOD(
-    createTimer : (double)callbackID duration : (NSTimeInterval)jsDuration jsSchedulingTime : (double)
-        jsSchedulingTime repeats : (BOOL)repeats)
-{
-  NSNumber *callbackIdObjc = [NSNumber numberWithDouble:callbackID];
-  NSDate *schedulingTime = [RCTConvert NSDate:[NSNumber numberWithDouble:jsSchedulingTime]];
-  if (jsDuration == 0 && repeats == NO) {
-    // For super fast, one-off timers, just enqueue them immediately rather than waiting a frame.
-    if (_bridge) {
-      [_bridge _immediatelyCallTimer:callbackIdObjc];
-    } else {
-      [_timingDelegate immediatelyCallTimer:callbackIdObjc];
-    }
-    return;
-  }
-
-  [self createTimerForNextFrame:callbackIdObjc duration:jsDuration jsSchedulingTime:schedulingTime repeats:repeats];
 }
 
 /**
@@ -407,22 +355,12 @@ RCT_EXPORT_METHOD(
   }
 }
 
-RCT_EXPORT_METHOD(deleteTimer : (double)timerID)
+- (void)deleteTimer:(double)timerID
 {
   @synchronized(_timers) {
-    [_timers removeObjectForKey:[NSNumber numberWithDouble:timerID]];
+    [_timers removeObjectForKey:@(timerID)];
   }
   if (![self hasPendingTimers]) {
-    [self stopTimers];
-  }
-}
-
-RCT_EXPORT_METHOD(setSendIdleEvents : (BOOL)sendIdleEvents)
-{
-  _sendIdleEvents = sendIdleEvents;
-  if (sendIdleEvents) {
-    [self startTimers];
-  } else if (![self hasPendingTimers]) {
     [self stopTimers];
   }
 }

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -61,37 +61,6 @@
 using namespace facebook;
 using namespace facebook::react;
 
-__attribute__((deprecated(
-    "RCTBridgelessDisplayLinkModuleHolder is part of the legacy architecture and will be removed in a future React Native release.")))
-@interface RCTBridgelessDisplayLinkModuleHolder : NSObject<RCTDisplayLinkModuleHolder>
-- (instancetype)initWithModule:(id<RCTBridgeModule>)module;
-@end
-
-@implementation RCTBridgelessDisplayLinkModuleHolder {
-  id<RCTBridgeModule> _module;
-}
-- (instancetype)initWithModule:(id<RCTBridgeModule>)module
-{
-  _module = module;
-  return self;
-}
-
-- (id<RCTBridgeModule>)instance
-{
-  return _module;
-}
-
-- (Class)moduleClass
-{
-  return [_module class];
-}
-
-- (dispatch_queue_t)methodQueue
-{
-  return _module.methodQueue;
-}
-@end
-
 @interface RCTInstance () <RCTTurboModuleManagerDelegate>
 @end
 
@@ -423,7 +392,7 @@ __attribute__((deprecated(
   }];
 
   // DisplayLink is used to call timer callbacks.
-  _displayLink = [RCTDisplayLink new];
+  _displayLink = [[RCTDisplayLink alloc] initWithFrameUpdateObserver:timing];
 
   auto &inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   ReactInstance::JSRuntimeFlags options = {.isProfiling = inspectorFlags.getIsProfilingBuild()};
@@ -447,12 +416,7 @@ __attribute__((deprecated(
 
     [strongSelf->_delegate instance:strongSelf didInitializeRuntime:runtime];
 
-// Set up Display Link
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    id<RCTDisplayLinkModuleHolder> moduleHolder = [[RCTBridgelessDisplayLinkModuleHolder alloc] initWithModule:timing];
-    [strongSelf->_displayLink registerModuleForFrameUpdates:timing withModuleHolder:moduleHolder];
-#pragma clang diagnostic pop
+    // Set up Display Link
     [strongSelf->_displayLink addToRunLoop:[NSRunLoop currentRunLoop]];
 
     // Attempt to load bundle synchronously, fallback to asynchronously.

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1028,10 +1028,9 @@ interface RCTDiffClampAnimatedNode : public RCTValueAnimatedNode {
 }
 
 interface RCTDisplayLink : public NSObject {
-  public virtual instancetype init();
+  public virtual instancetype initWithFrameUpdateObserver:(id<RCTFrameUpdateObserver> observer);
   public virtual void addToRunLoop:(NSRunLoop* runLoop);
   public virtual void invalidate();
-  public virtual void registerModuleForFrameUpdates:withModuleHolder:(id<RCTBridgeModule> module, id<RCTDisplayLinkModuleHolder> moduleHolder);
 }
 
 interface RCTDisplayWeakRefreshable : public NSObject {
@@ -1982,7 +1981,7 @@ interface RCTThirdPartyComponentsProvider : public NSObject {
   public virtual static NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
 }
 
-interface RCTTiming : public NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
+interface RCTTiming : public NSObject <RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
   public virtual instancetype initWithDelegate:(id<RCTTimingDelegate> delegate);
   public virtual void createTimerForNextFrame:duration:jsSchedulingTime:repeats:(NSNumber* callbackID, NSTimeInterval jsDuration, _Nullable NSDate* jsSchedulingTime, BOOL repeats);
   public virtual void deleteTimer:(double timerID);
@@ -2771,12 +2770,6 @@ protocol RCTDevSettingsDataSource : public NSObject {
 
 protocol RCTDevSettingsInspectable : public NSObject {
   public @property (assign) BOOL isInspectable;
-}
-
-protocol RCTDisplayLinkModuleHolder {
-  public virtual Class moduleClass();
-  public virtual dispatch_queue_t methodQueue();
-  public virtual id<RCTBridgeModule> instance();
 }
 
 protocol RCTDisplayRefreshable {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1028,10 +1028,9 @@ interface RCTDiffClampAnimatedNode : public RCTValueAnimatedNode {
 }
 
 interface RCTDisplayLink : public NSObject {
-  public virtual instancetype init();
+  public virtual instancetype initWithFrameUpdateObserver:(id<RCTFrameUpdateObserver> observer);
   public virtual void addToRunLoop:(NSRunLoop* runLoop);
   public virtual void invalidate();
-  public virtual void registerModuleForFrameUpdates:withModuleHolder:(id<RCTBridgeModule> module, id<RCTDisplayLinkModuleHolder> moduleHolder);
 }
 
 interface RCTDisplayWeakRefreshable : public NSObject {
@@ -1975,7 +1974,7 @@ interface RCTThirdPartyComponentsProvider : public NSObject {
   public virtual static NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
 }
 
-interface RCTTiming : public NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
+interface RCTTiming : public NSObject <RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
   public virtual instancetype initWithDelegate:(id<RCTTimingDelegate> delegate);
   public virtual void createTimerForNextFrame:duration:jsSchedulingTime:repeats:(NSNumber* callbackID, NSTimeInterval jsDuration, _Nullable NSDate* jsSchedulingTime, BOOL repeats);
   public virtual void deleteTimer:(double timerID);
@@ -2763,12 +2762,6 @@ protocol RCTDevSettingsDataSource : public NSObject {
 
 protocol RCTDevSettingsInspectable : public NSObject {
   public @property (assign) BOOL isInspectable;
-}
-
-protocol RCTDisplayLinkModuleHolder {
-  public virtual Class moduleClass();
-  public virtual dispatch_queue_t methodQueue();
-  public virtual id<RCTBridgeModule> instance();
 }
 
 protocol RCTDisplayRefreshable {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1028,10 +1028,9 @@ interface RCTDiffClampAnimatedNode : public RCTValueAnimatedNode {
 }
 
 interface RCTDisplayLink : public NSObject {
-  public virtual instancetype init();
+  public virtual instancetype initWithFrameUpdateObserver:(id<RCTFrameUpdateObserver> observer);
   public virtual void addToRunLoop:(NSRunLoop* runLoop);
   public virtual void invalidate();
-  public virtual void registerModuleForFrameUpdates:withModuleHolder:(id<RCTBridgeModule> module, id<RCTDisplayLinkModuleHolder> moduleHolder);
 }
 
 interface RCTDisplayWeakRefreshable : public NSObject {
@@ -1982,7 +1981,7 @@ interface RCTThirdPartyComponentsProvider : public NSObject {
   public virtual static NSDictionary<NSString*, Class<RCTComponentViewProtocol>>* thirdPartyFabricComponents();
 }
 
-interface RCTTiming : public NSObject <RCTBridgeModule, RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
+interface RCTTiming : public NSObject <RCTInvalidating, RCTFrameUpdateObserver, RCTInitializing> {
   public virtual instancetype initWithDelegate:(id<RCTTimingDelegate> delegate);
   public virtual void createTimerForNextFrame:duration:jsSchedulingTime:repeats:(NSNumber* callbackID, NSTimeInterval jsDuration, _Nullable NSDate* jsSchedulingTime, BOOL repeats);
   public virtual void deleteTimer:(double timerID);
@@ -2771,12 +2770,6 @@ protocol RCTDevSettingsDataSource : public NSObject {
 
 protocol RCTDevSettingsInspectable : public NSObject {
   public @property (assign) BOOL isInspectable;
-}
-
-protocol RCTDisplayLinkModuleHolder {
-  public virtual Class moduleClass();
-  public virtual dispatch_queue_t methodQueue();
-  public virtual id<RCTBridgeModule> instance();
 }
 
 protocol RCTDisplayRefreshable {


### PR DESCRIPTION
Summary:



## Changelog: 
[IOS][Fixed] Remove legacy RCTTimingModule

Reviewed By: javache

Differential Revision: D107201906


