### PR TITLE
Queue activity results before React context is ready

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -150,6 +150,7 @@ public class ReactHostImpl(
   private val reactInstanceEventListeners: MutableList<ReactInstanceEventListener> =
       CopyOnWriteArrayList()
   private val beforeDestroyListeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
+  private val pendingActivityResults: MutableList<PendingActivityResult> = CopyOnWriteArrayList()
 
   internal var reactHostInspectorTarget: ReactHostInspectorTarget? = null
   private var frameTimingsObserver: FrameTimingsObserver? = null
@@ -667,7 +668,9 @@ public class ReactHostImpl(
     if (currentContext != null) {
       currentContext.onActivityResult(activity, requestCode, resultCode, data)
     } else {
-      raiseSoftException(method, "Tried to access onActivityResult while context is not ready")
+      stateTracker.enterState(method, "Queuing activity result until context is ready")
+      pendingActivityResults.add(
+          PendingActivityResult(WeakReference(activity), requestCode, resultCode, data))
     }
   }
 
@@ -893,8 +896,31 @@ public class ReactHostImpl(
   @ThreadConfined(ThreadConfined.UI)
   private fun moveToHostDestroy(currentContext: ReactContext?) {
     reactLifecycleStateManager.moveToOnHostDestroy(currentContext)
+    pendingActivityResults.clear()
     currentActivity = null
     frameTimingsObserver?.setCurrentWindow(null)
+  }
+
+  private fun replayPendingActivityResults(reactContext: ReactContext) {
+    val activityResults = pendingActivityResults.toList()
+    pendingActivityResults.clear()
+
+    for (activityResult in activityResults) {
+      val activity = activityResult.activity.get()
+      if (activity != null) {
+        reactContext.onActivityResult(
+            activity,
+            activityResult.requestCode,
+            activityResult.resultCode,
+            activityResult.data,
+        )
+      } else {
+        raiseSoftException(
+            "replayPendingActivityResults()",
+            "Dropping queued activity result because activity was garbage collected",
+        )
+      }
+    }
   }
 
   private fun raiseSoftException(
@@ -1010,6 +1036,13 @@ public class ReactHostImpl(
       val isReloading: Boolean,
   )
 
+  private class PendingActivityResult(
+      val activity: WeakReference<Activity>,
+      val requestCode: Int,
+      val resultCode: Int,
+      val data: Intent?,
+  )
+
   @ThreadConfined("ReactHost")
   private fun getOrCreateReactInstanceTask(): Task<ReactInstance> {
     val method = "getOrCreateReactInstanceTask()"
@@ -1120,6 +1153,8 @@ public class ReactHostImpl(
            */
           reactLifecycleStateManager.resumeReactContextIfHostResumed(reactContext, currentActivity)
         }
+
+        replayPendingActivityResults(reactContext)
 
         stateTracker.enterState(method, "Executing ReactInstanceEventListeners")
         for (listener in reactInstanceEventListeners) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactHostTest.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.runtime
 
 import android.app.Activity
+import android.content.Intent
 import com.facebook.react.MemoryPressureRouter
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.LifecycleState
@@ -31,6 +32,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doNothing
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -167,5 +169,30 @@ class ReactHostTest {
     assertThat(reactHost.lifecycleState).isEqualTo(LifecycleState.BEFORE_RESUME)
     reactHost.onHostDestroy(activityController.get())
     assertThat(reactHost.lifecycleState).isEqualTo(LifecycleState.BEFORE_CREATE)
+  }
+
+  @Test
+  fun onActivityResult_beforeContextIsReady_replaysAfterStart() {
+    val activity = activityController.get()
+    val data = Intent("test.intent")
+
+    reactHost.onActivityResult(activity, 100, Activity.RESULT_OK, data)
+    reactHost.start()
+
+    val reactContext = mockedBridgelessReactContextCtor.constructed().first()
+    verify(reactContext).onActivityResult(activity, 100, Activity.RESULT_OK, data)
+  }
+
+  @Test
+  fun onActivityResult_beforeContextIsReady_dropsOnHostDestroy() {
+    val activity = activityController.get()
+    val data = Intent("test.intent")
+
+    reactHost.onActivityResult(activity, 100, Activity.RESULT_OK, data)
+    reactHost.onHostDestroy()
+    reactHost.start()
+
+    val reactContext = mockedBridgelessReactContextCtor.constructed().first()
+    verify(reactContext, never()).onActivityResult(activity, 100, Activity.RESULT_OK, data)
   }
 }


### PR DESCRIPTION
## Summary

Fixes #52114.

When `ReactHostImpl.onActivityResult` is invoked before the bridgeless React context is ready, the result is currently soft-exceptioned and dropped. This can lose results from external activities if the host activity is recreated before React has finished starting.

This change queues activity results while the React context is unavailable, replays them once the context is created, and clears queued results when the host is destroyed.

## Changelog:

[ANDROID] [FIXED] - Queue activity results received before bridgeless React context initialization

## Test plan

```sh
./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.runtime.ReactHostTest -Preact.internal.useHermesNightly=false
```

Also ran:

```sh
git diff --check
```
