### PR TITLE
guard shrink-factor division against floating-point near-zero (#57175)

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -929,8 +929,15 @@ static float distributeFreeSpaceSecondPass(
       if (flexShrinkScaledFactor != 0) {
         float childSize = YGUndefined;
 
+        // Use a relative epsilon guard instead of exact equality: after the
+        // first pass removes all constrained items,
+        // totalFlexShrinkScaledFactors may be near-zero rather than exactly 0
+        // due to floating-point cancellation.  Dividing by a near-zero value
+        // produces a gigantic childSize that overwhelms the min/max clamp.
+        const float shrinkFactorMagnitude =
+            std::abs(flexLine.layout.totalFlexShrinkScaledFactors);
         if (yoga::isDefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
-            flexLine.layout.totalFlexShrinkScaledFactors == 0) {
+            shrinkFactorMagnitude < 1e-6f) {
           childSize = childFlexBasis + flexShrinkScaledFactor;
         } else {
           childSize = childFlexBasis +

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -1104,8 +1104,15 @@ static float distributeFreeSpaceSecondPass(
       if (flexShrinkScaledFactor != 0) {
         float childSize = YGUndefined;
 
+        // Use a relative epsilon guard instead of exact equality: after the
+        // first pass removes all constrained items,
+        // totalFlexShrinkScaledFactors may be near-zero rather than exactly 0
+        // due to floating-point cancellation.  Dividing by a near-zero value
+        // produces a gigantic childSize that overwhelms the min/max clamp.
+        const float shrinkFactorMagnitude =
+            std::abs(flexLine.layout.totalFlexShrinkScaledFactors);
         if (yoga::isDefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
-            flexLine.layout.totalFlexShrinkScaledFactors == 0) {
+            shrinkFactorMagnitude < 1e-6f) {
           childSize = childFlexBasis + flexShrinkScaledFactor;
         } else {
           childSize = childFlexBasis +


### PR DESCRIPTION
Summary:

fixes https://github.com/facebook/yoga/issues/1665.

**problem:** when all flex children are frozen to their min-width in the first
pass, `totalFlexShrinkScaledFactors` is reduced to near-zero by floating-point
cancellation rather than exactly 0. the guard in `distributeFreeSpaceSecondPass`
uses exact equality (`== 0`), so it never fires, and the second pass divides
`remainingFreeSpace` by a value on the order of 1e-7, producing a childSize on
the order of 1e11 that overwhelms the min/max clamp.

**fix:** replace the exact-zero check with a relative epsilon guard
(`shrinkFactorMagnitude < 1e-6f`). when the magnitude is that small, all items
were already frozen in the first pass; the safe fallback (`childFlexBasis +
flexShrinkScaledFactor`) applies and the subsequent `boundAxisWithAutoMin` clamps
correctly to minWidth.

regression: `YGFlexShrinkBorderBug.flex_basis_0_border_minwidth_row` reproduces
the original crash — 4 children, `borderWidth` difference of 1e-6 across them,
all now compute to their correct minWidth.

## Changelog:
[Internal] -

X-link: https://github.com/facebook/yoga/pull/1974

Reviewed By: javache

Differential Revision: D108030908

Pulled By: cipolleschi


