### PR TITLE
fix(iOS): reset accessibilityViewIsModal on view recycle to avoid trapping VoiceOver

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -802,14 +802,18 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   //     UIImageView whose natural a11y behavior would be clobbered
   //     by forcing NO / None here. Per-subclass reset is a separate
   //     follow-up.
+  //   * `accessibilityRespondsToUserInteraction` — its UIKit default is
+  //     not a fixed value but "derived from other accessibility
+  //     properties" (per the UIAccessibility.h header; e.g. an element
+  //     with UIAccessibilityTraitNotEnabled returns NO). Writing any
+  //     explicit value here would replace the derived behavior with a
+  //     constant, which is worse than the staleness it would fix.
   self.accessibilityElement.accessibilityLabel = nil;
   self.accessibilityElement.accessibilityLanguage = nil;
   self.accessibilityElement.accessibilityHint = nil;
   self.accessibilityElement.accessibilityValue = nil;
   self.accessibilityElement.accessibilityViewIsModal = NO;
   self.accessibilityElement.accessibilityElementsHidden = NO;
-  // UIView default for accessibilityRespondsToUserInteraction is YES.
-  self.accessibilityElement.accessibilityRespondsToUserInteraction = YES;
   self.accessibilityIgnoresInvertColors = NO;
   // Clear only the `accessibilityState` bits the setter writes via
   // self.accessibilityTraits (.NotEnabled / .Selected). Subclass

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -781,6 +781,13 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   _removeClippedSubviews = NO;
   _reactSubviews = [NSMutableArray new];
   _layoutMetrics = EmptyLayoutMetrics;
+
+  // Reset accessibilityViewIsModal so it does not leak across recycled views.
+  // updateProps only writes this property when (oldProps != newProps); after a
+  // view is recycled _props resets to the default (NO), so a recycled view that
+  // is reused without the prop keeps the stale YES and traps VoiceOver / UI
+  // automation against a now-unrelated subtree (empty accessibility tree).
+  self.accessibilityElement.accessibilityViewIsModal = NO;
 }
 
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(NSSet<NSString *> *_Nullable)props

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -782,12 +782,52 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   _reactSubviews = [NSMutableArray new];
   _layoutMetrics = EmptyLayoutMetrics;
 
-  // Reset accessibilityViewIsModal so it does not leak across recycled views.
-  // updateProps only writes this property when (oldProps != newProps); after a
-  // view is recycled _props resets to the default (NO), so a recycled view that
-  // is reused without the prop keeps the stale YES and traps VoiceOver / UI
-  // automation against a now-unrelated subtree (empty accessibility tree).
+  // Reset accessibility state so it does not leak across recycled views.
+  // updateProps writes most accessibility properties only when
+  // (oldProps != newProps); after recycle _props is reset to the
+  // AccessibilityProps default-constructed values, so any UIKit-side
+  // state previously set stays stale unless cleared here.
+  //
+  // The most visible failure this guards against is
+  // `accessibilityViewIsModal` / `accessibilityElementsHidden` trapping
+  // VoiceOver against a now-unrelated subtree (empty accessibility
+  // tree).
+  //
+  // Skipped on purpose:
+  //   * `isAccessibilityElement` and `accessibilityTraits` — their
+  //     UIKit defaults depend on the underlying view subclass
+  //     (UIControl / UILabel / UIImageView start with different
+  //     defaults than UIView). For RCTText/Image ComponentView
+  //     `accessibilityElement` resolves to an inner UILabel /
+  //     UIImageView whose natural a11y behavior would be clobbered
+  //     by forcing NO / None here. Per-subclass reset is a separate
+  //     follow-up.
+  self.accessibilityElement.accessibilityLabel = nil;
+  self.accessibilityElement.accessibilityLanguage = nil;
+  self.accessibilityElement.accessibilityHint = nil;
+  self.accessibilityElement.accessibilityValue = nil;
   self.accessibilityElement.accessibilityViewIsModal = NO;
+  self.accessibilityElement.accessibilityElementsHidden = NO;
+  // UIView default for accessibilityRespondsToUserInteraction is YES.
+  self.accessibilityElement.accessibilityRespondsToUserInteraction = YES;
+  self.accessibilityIgnoresInvertColors = NO;
+  // Clear only the `accessibilityState` bits the setter writes via
+  // self.accessibilityTraits (.NotEnabled / .Selected). Subclass
+  // default traits are preserved.
+  self.accessibilityTraits &= ~(UIAccessibilityTraitNotEnabled | UIAccessibilityTraitSelected);
+  if ([self.accessibilityElement respondsToSelector:@selector(setAccessibilityIdentifier:)]) {
+    ((UIView *)self.accessibilityElement).accessibilityIdentifier = nil;
+  } else {
+    self.accessibilityIdentifier = nil;
+  }
+#if !TARGET_OS_TV
+  if (@available(iOS 13.0, *)) {
+    self.showsLargeContentViewer = NO;
+    self.largeContentTitle = nil;
+  }
+#endif
+  _accessibilityOrderNativeIDs = nil;
+  self.accessibilityElements = nil;
 }
 
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(NSSet<NSString *> *_Nullable)props


### PR DESCRIPTION
## Summary

`RCTViewComponentView` applies `accessibilityViewIsModal` in `updateProps` only when the prop changes:

```objc
// `accessibilityViewIsModal`
if (oldViewProps.accessibilityViewIsModal != newViewProps.accessibilityViewIsModal) {
  self.accessibilityElement.accessibilityViewIsModal = newViewProps.accessibilityViewIsModal;
}
```

…but `prepareForRecycle` never resets it. So when a view that had `aria-modal` / `accessibilityViewIsModal` is recycled and later reused for a different view that does **not** set the prop, the diff is `NO (recycled default) == NO (new)` and `updateProps` skips it — the stale `accessibilityViewIsModal = YES` **leaks onto the recycled view**.

A leftover modal view makes UIKit treat its subtree as the only accessible content, so VoiceOver and UI automation see an **empty accessibility tree for the rest of the window** until an unrelated layout pass recovers it.

This is easy to hit with transparent modals (e.g. a `react-native-screens` `transparentModal`) on iOS: open a modal → close it → reopen it. The recycled content view keeps the stale flag and competes with the modal's own transition view, collapsing the whole window's accessibility tree. It is intermittent because it depends on which pooled view instance is reused.

## Changelog:

[iOS] [Fixed] - Reset `accessibilityViewIsModal` in `prepareForRecycle` so a stale modal flag no longer leaks onto recycled views and traps VoiceOver

## Test Plan

Repro (iOS, Fabric):
1. Render a `<View aria-modal>` (for example the content of a transparent modal), then unmount it so its underlying `RCTViewComponentView` returns to the recycle pool.
2. Mount other content that reuses the recycled view without `aria-modal`.

- **Before:** the reused view still reports `accessibilityViewIsModal == YES`; VoiceOver / `Accessibility Inspector` / a `maestro hierarchy` dump show a collapsed (near-empty) accessibility tree for the window.
- **After:** the reused view reports `accessibilityViewIsModal == NO`; the accessibility tree is intact.

Verified on an iOS 26 simulator with a transparent-modal open → close → reopen cycle: UI-automation flows that read the accessibility tree go from intermittently failing to passing every run.
