### PR TITLE
Add repository metadata to `@react-native/core-cli-utils`

### DIFF
--- a/private/core-cli-utils/package.json
+++ b/private/core-cli-utils/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.0",
   "description": "Reference implementation of React Native CLI tooling",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/react/react-native.git",
+    "directory": "private/core-cli-utils"
+  },
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",


### PR DESCRIPTION
Summary:
This package is published to npm, despite being under `private` - so I missed adding `repository` metadata to it as requried by trusted publish.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D109031681


