### PR TITLE
Move Community CLI discovery config into plugin package

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -25,7 +25,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "react-native.config.js"
   ],
   "scripts": {
     "prepack": "node ../../scripts/build/prepack.js"

--- a/packages/community-cli-plugin/react-native.config.js
+++ b/packages/community-cli-plugin/react-native.config.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+const {
+  bundleCommand,
+  startCommand,
+} = require('@react-native/community-cli-plugin');
+
+module.exports = {
+  commands: [bundleCommand, startCommand],
+};

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -70,13 +70,6 @@ try {
 
 const commands /*: Array<Command> */ = [];
 
-const {
-  bundleCommand,
-  startCommand,
-} = require('@react-native/community-cli-plugin');
-
-commands.push(bundleCommand, startCommand);
-
 const codegenCommand /*: Command */ = {
   name: 'codegen',
   options: [


### PR DESCRIPTION
Summary:
Self-register commands from the `community-cli-plugin` package via `react-native.config.js` — meaning we can remove the redirect within `packages/react-native/react-native.config.js`.

Progress towards removing `community-cli-plugin` as a direct dep of `react-native`, and paired with https://github.com/react-native-community/template/pull/235.

Changelog:
[General][Breaking] - `@react-native/community-cli-plugin` will no longer be auto-detected from `react-native`. It must now be specified in `devDependencies`.

Differential Revision: D109869538


