### PR TITLE
Remove Community CLI platform config (upstreamed)

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -25,7 +25,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "react-native.config.js"
   ],
   "scripts": {
     "prepack": "node ../../scripts/build/prepack.js"

--- a/packages/community-cli-plugin/react-native.config.js
+++ b/packages/community-cli-plugin/react-native.config.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+const {
+  bundleCommand,
+  startCommand,
+} = require('@react-native/community-cli-plugin');
+
+module.exports = {
+  commands: [bundleCommand, startCommand],
+};

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -70,13 +70,6 @@ try {
 
 const commands /*: Array<Command> */ = [];
 
-const {
-  bundleCommand,
-  startCommand,
-} = require('@react-native/community-cli-plugin');
-
-commands.push(bundleCommand, startCommand);
-
 const codegenCommand /*: Command */ = {
   name: 'codegen',
   options: [

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -14,61 +14,14 @@
 import type {Command} from '@react-native-community/cli-types';
  */
 
-// React Native shouldn't be exporting itself like this, the Community Template should be be directly
-// depending on and injecting:
-// - @react-native-community/cli-platform-android
-// - @react-native-community/cli-platform-ios
-// - @react-native/community-cli-plugin
-// - codegen command should be inhoused into @react-native-community/cli
+// Platforms and core commands are no longer registered here:
+// - The iOS and Android platforms have moved back to being installed
+//   with the core @react-native-community/cli package.
+// - `start`/`bundle` are self-registered from @react-native/community-cli-plugin,
+//   which is required on the template since 0.87.
 //
-// This is a temporary workaround.
-
-const verbose = Boolean(process.env.DEBUG?.includes('react-native'));
-
-function findCommunityPlatformPackage(
-  spec /*: string */,
-  startDir /*: string */ = process.cwd(),
-) {
-  // In monorepos, we cannot make any assumptions on where
-  // `@react-native-community/*` gets installed. The safest way to find it
-  // (barring adding an optional peer dependency) is to start from the project
-  // root.
-  //
-  // Note that we're assuming that the current working directory is the project
-  // root. This is also what `@react-native-community/cli` assumes (see
-  // https://github.com/react-native-community/cli/blob/14.x/packages/cli-tools/src/findProjectRoot.ts).
-  const main = require.resolve(spec, {paths: [startDir]});
-  // $FlowFixMe[unsupported-syntax]
-  return require(main);
-}
-
-let android;
-try {
-  android = findCommunityPlatformPackage(
-    '@react-native-community/cli-platform-android',
-  );
-} catch {
-  if (verbose) {
-    console.warn(
-      '@react-native-community/cli-platform-android not found, the react-native.config.js may be unusable.',
-    );
-  }
-}
-
-let ios;
-try {
-  ios = findCommunityPlatformPackage(
-    '@react-native-community/cli-platform-ios',
-  );
-} catch {
-  if (verbose) {
-    console.warn(
-      '@react-native-community/cli-platform-ios not found, the react-native.config.js may be unusable.',
-    );
-  }
-}
-
-const commands /*: Array<Command> */ = [];
+// The `codegen` command remains here for now, as its executor is tightly
+// coupled to this package's directory layout.
 
 const codegenCommand /*: Command */ = {
   name: 'codegen',
@@ -103,30 +56,6 @@ const codegenCommand /*: Command */ = {
     ),
 };
 
-commands.push(codegenCommand);
-
-const config = {
-  commands,
-  platforms: {} /*:: as {[string]: Readonly<{
-      projectConfig: unknown,
-      dependencyConfig: unknown,
-    }>} */,
+module.exports = {
+  commands: [codegenCommand],
 };
-
-if (ios != null) {
-  config.commands.push(...ios.commands);
-  config.platforms.ios = {
-    projectConfig: ios.projectConfig,
-    dependencyConfig: ios.dependencyConfig,
-  };
-}
-
-if (android != null) {
-  config.commands.push(...android.commands);
-  config.platforms.android = {
-    projectConfig: android.projectConfig,
-    dependencyConfig: android.dependencyConfig,
-  };
-}
-
-module.exports = config;


### PR DESCRIPTION
Summary:
Depends on https://github.com/react-native-community/cli/pull/2817. See also https://github.com/react-native-community/template/pull/235.

Progress towards deleting the `react-native.config.js` file we ship with `react-native`. These Community CLI plugins are moving back to being included by default (and in the first place, should not have been wired up here!).

Changelog:
[General][Changed] - Platform registration config for the Community CLI is removed from the `react-native` package. No breaking change with `react-native-community/cli` 21.x (required).

Differential Revision: D109872883


