### PR TITLE
Add guards for react/renderer/components/view (#57357) (#57357) (#57357)

### DIFF
--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -68,6 +68,7 @@ Pod::Spec.new do |s|
     add_dependency(ss, "React-debug")
     add_dependency(ss, "React-rendererdebug")
     add_dependency(ss, "React-utils")
+    add_dependency(ss, "React-cxxstableapi")
     add_dependency(ss, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
     add_dependency(ss, "React-Fabric", :additional_framework_paths => [
       "react/renderer/components/view/platform/cxx",

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -100,6 +100,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-networking", :framework_name => 'React_networking')
   add_dependency(s, "React-renderercss")
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  add_dependency(s, "React-cxxstableapi")
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -172,6 +172,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/view/",
                           "react/renderer/components/view/",
                       ),
+                      Pair(
+                          "../ReactCommon/react/renderer/components/view/React/",
+                          "React/",
+                      ),
                       Pair("../ReactCommon/react/renderer/components/view/platform/android/", ""),
                       // rrc_root
                       Pair(

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "React-Core"
   s.dependency "React-debug"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "React-cxxreact"
@@ -136,6 +137,12 @@ Pod::Spec.new do |s|
       sss.dependency             "Yoga"
       sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
+    end
+
+    ss.subspec "viewUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/view/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/view/React"
     end
 
     ss.subspec "scrollview" do |sss|

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cinttypes>
 #include <optional>
 #include <string>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/AccessibilityPrimitives.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <mutex>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/AccessibilityProps.h>
 #include <react/renderer/components/view/YogaStylableProps.h>
 #include <react/renderer/components/view/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(rrc_view
         glog_init
         jsi
         logger
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_css

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/graphicsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/LayoutConformanceShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/YogaStylableProps.h>
 #include <react/renderer/components/view/propsConversions.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/LayoutConformanceProps.h>
 #include <react/renderer/components/view/YogaLayoutableShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/view` module - public
+// entry point.
+//
+//   #include <React/View.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/view/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
+// this block so later *direct* includes in the same TU are still caught.
+#define RN_UMBRELLA_CONTEXT
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#include <react/renderer/components/view/AccessibilityPrimitives.h>
+#include <react/renderer/components/view/AccessibilityProps.h>
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/components/view/BaseTouch.h>
+#include <react/renderer/components/view/BaseViewEventEmitter.h>
+#include <react/renderer/components/view/BaseViewProps.h>
+#include <react/renderer/components/view/BoxShadowPropsConversions.h>
+#include <react/renderer/components/view/CSSConversions.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/view/FilterPropsConversions.h>
+#include <react/renderer/components/view/HostPlatformTouch.h>
+#include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h>
+#include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
+#include <react/renderer/components/view/LayoutConformanceComponentDescriptor.h>
+#include <react/renderer/components/view/LayoutConformanceProps.h>
+#include <react/renderer/components/view/LayoutConformanceShadowNode.h>
+#include <react/renderer/components/view/PointerEvent.h>
+#include <react/renderer/components/view/Touch.h>
+#include <react/renderer/components/view/TouchEvent.h>
+#include <react/renderer/components/view/TouchEventEmitter.h>
+#include <react/renderer/components/view/ViewComponentDescriptor.h>
+#include <react/renderer/components/view/ViewEventEmitter.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/view/ViewPropsInterpolation.h>
+#include <react/renderer/components/view/ViewShadowNode.h>
+#include <react/renderer/components/view/YogaLayoutableShadowNode.h>
+#include <react/renderer/components/view/YogaStylableProps.h>
+#include <react/renderer/components/view/accessibilityPropsConversions.h>
+#include <react/renderer/components/view/conversions.h>
+#include <react/renderer/components/view/primitives.h>
+#include <react/renderer/components/view/propsConversions.h>
+
+#ifdef ANDROID
+#include <react/renderer/components/view/NativeDrawable.h>
+#endif
+
+#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#include <react/renderer/components/view/HostPlatformViewEvents.h>
+#include <react/renderer/components/view/KeyEvent.h>
+#include <react/renderer/components/view/MouseEvent.h>
+#endif
+
+#ifdef USE_WINUI_FABRIC
+#include <react/renderer/components/view/KeyEvent.h>
+#include <react/renderer/components/view/WindowsViewEvents.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/DebugStringConvertible.h>
 
 #include <react/renderer/components/view/Touch.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/PointerEvent.h>
 #include <react/renderer/components/view/TouchEvent.h>
 #include <react/renderer/core/EventEmitter.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/graphics/Transform.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <yoga/style/Style.h>
 
 #include <react/renderer/core/Props.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/debug/react_native_expect.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/components/view/NativeDrawable.h>
 #include <react/renderer/components/view/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/RectangleCorners.h>
 #include <react/renderer/graphics/RectangleEdges.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-inventory-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-inventory-test.js
@@ -56,6 +56,47 @@ describe('scanHeader include classification', () => {
       {token: 'b.h', cxxGuarded: true},
     ]);
   });
+
+  test('includes for non-iOS platforms are ignored', () => {
+    const src = [
+      '#ifdef ANDROID',
+      '#include <android/only.h>',
+      '#endif',
+      '#if defined(TARGET_OS_OSX) && TARGET_OS_OSX',
+      '#include <macos/only.h>',
+      '#endif',
+      '#if defined(USE_WINUI_FABRIC)',
+      '#include <windows/only.h>',
+      '#endif',
+      '#include <ios/available.h>',
+      '',
+    ].join('\n');
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'ios/available.h', cxxGuarded: false},
+    ]);
+  });
+
+  test('#else after a non-iOS platform guard is scanned', () => {
+    const src = [
+      '#ifdef ANDROID',
+      '#include <android/only.h>',
+      '#else',
+      '#include <ios/available.h>',
+      '#endif',
+      '',
+    ].join('\n');
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'ios/available.h', cxxGuarded: false},
+    ]);
+  });
+
+  test('unknown platform conditions remain conservatively scanned', () => {
+    const src =
+      '#ifdef UNKNOWN_PLATFORM\n#include <maybe/available.h>\n#endif\n';
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'maybe/available.h', cxxGuarded: false},
+    ]);
+  });
 });
 
 describe('scanHeader C++ / ObjC surface detection', () => {

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -114,6 +114,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
           },
 
           {
+            name: 'viewUmbrella',
+            headerPatterns: ['react/renderer/components/view/React/*.h'],
+            headerDir: 'React',
+          },
+
+          {
             name: 'scrollview',
             headerPatterns: ['react/renderer/components/scrollview/**/*.h'],
             headerDir: 'react/renderer/components/scrollview',

--- a/packages/react-native/scripts/ios-prebuild/headers-inventory.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-inventory.js
@@ -128,9 +128,9 @@ const SDK_PREFIXES = new Set([
 /**
  * Scans a header's text line by line, tracking the preprocessor-conditional
  * stack just enough to know whether a line is only compiled under
- * `__cplusplus`. Returns the include list and language-marker observations.
- * Heuristic by design: nested #if logic beyond __cplusplus is treated as
- * "other" and ignored.
+ * `__cplusplus` or is unreachable in the iOS packaged layout. Returns the
+ * include list and language-marker observations. Heuristic by design: unknown
+ * #if logic is treated as "other" and scanned conservatively.
  */
 function scanHeader(text /*: string */) /*: {
   includes: Array<IncludeRef>,
@@ -143,9 +143,28 @@ function scanHeader(text /*: string */) /*: {
   let hasUnguardedCxx = false;
   let hasGuardedCxx = false;
 
-  // Stack frames: 'cpp' (only under __cplusplus), 'notcpp', 'other'.
-  const stack /*: Array<'cpp' | 'notcpp' | 'other'> */ = [];
+  // Stack frames: 'cpp' (only under __cplusplus), 'notcpp', 'inactive'
+  // (known to be excluded from an iOS build), or 'other'.
+  const stack /*: Array<'cpp' | 'notcpp' | 'inactive' | 'other'> */ = [];
   const inCxxOnly = () => stack.includes('cpp');
+  const isInactive = () => stack.includes('inactive');
+  const isKnownInactiveIosCondition = (
+    directive /*: string */,
+    expression /*: string */,
+  ) /*: boolean */ => {
+    const trimmed = expression.trim();
+    if (directive === 'ifdef') {
+      return trimmed === 'ANDROID' || trimmed === 'USE_WINUI_FABRIC';
+    }
+    if (directive !== 'if' && directive !== 'elif') {
+      return false;
+    }
+    return (
+      /^defined\s+(?:ANDROID|USE_WINUI_FABRIC)$/.test(trimmed) ||
+      /^defined\s*\(\s*(?:ANDROID|USE_WINUI_FABRIC)\s*\)$/.test(trimmed) ||
+      /^defined\s*\(\s*TARGET_OS_OSX\s*\)\s*&&\s*TARGET_OS_OSX$/.test(trimmed)
+    );
+  };
 
   const includeRe = /^\s*#\s*(?:include|import)\s+(?:<([^>]+)>|"([^"]+)")/;
   const objcRe =
@@ -183,10 +202,14 @@ function scanHeader(text /*: string */) /*: {
       const mentionsCpp = /__cplusplus/.test(rest);
       if (directive === 'ifdef' || directive === 'if') {
         stack.push(
-          mentionsCpp &&
-            !/!\s*defined|defined\s*\(\s*__cplusplus\s*\)\s*==\s*0/.test(rest)
-            ? 'cpp'
-            : 'other',
+          isKnownInactiveIosCondition(directive, rest)
+            ? 'inactive'
+            : mentionsCpp &&
+                !/!\s*defined|defined\s*\(\s*__cplusplus\s*\)\s*==\s*0/.test(
+                  rest,
+                )
+              ? 'cpp'
+              : 'other',
         );
       } else if (directive === 'ifndef') {
         stack.push(mentionsCpp ? 'notcpp' : 'other');
@@ -197,10 +220,20 @@ function scanHeader(text /*: string */) /*: {
         );
       } else if (directive === 'elif') {
         stack.pop();
-        stack.push(mentionsCpp ? 'cpp' : 'other');
+        stack.push(
+          isKnownInactiveIosCondition(directive, rest)
+            ? 'inactive'
+            : mentionsCpp
+              ? 'cpp'
+              : 'other',
+        );
       } else if (directive === 'endif') {
         stack.pop();
       }
+      continue;
+    }
+
+    if (isInactive()) {
       continue;
     }
 


### PR DESCRIPTION
Summary:
Roll umbrella with umbrella guards for headers under `react/renderer/components/view` subtree. Initially, we assume that the entire target is public, so each header within includes a public umbrella guard.

Changelog:
[Internal]

Pulled By:
coado


coado

Reviewed By: cipolleschi

Differential Revision: D109847184
