### PR TITLE
Add stable API guards to text and textinput components (#57363)

### DIFF
--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -68,6 +68,7 @@ Pod::Spec.new do |s|
     add_dependency(ss, "React-debug")
     add_dependency(ss, "React-rendererdebug")
     add_dependency(ss, "React-utils")
+    add_dependency(ss, "React-cxxstableapi")
     add_dependency(ss, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
     add_dependency(ss, "React-Fabric", :additional_framework_paths => [
       "react/renderer/components/view/platform/cxx",

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -100,6 +100,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-networking", :framework_name => 'React_networking')
   add_dependency(s, "React-renderercss")
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  add_dependency(s, "React-cxxstableapi")
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -172,6 +172,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/view/",
                           "react/renderer/components/view/",
                       ),
+                      Pair(
+                          "../ReactCommon/react/renderer/components/view/React/",
+                          "React/",
+                      ),
                       Pair("../ReactCommon/react/renderer/components/view/platform/android/", ""),
                       // rrc_root
                       Pair(

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -196,6 +196,11 @@ val preparePrefab by
                           "react/renderer/components/text/",
                       ),
                       Pair(
+                          "../ReactCommon/react/renderer/components/text/React/",
+                          "React/",
+                      ),
+                      Pair("../ReactCommon/react/renderer/components/text/platform/android/", ""),
+                      Pair(
                           "../ReactCommon/react/renderer/attributedstring",
                           "react/renderer/attributedstring",
                       ),

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -196,6 +196,10 @@ val preparePrefab by
                           "react/renderer/components/text/",
                       ),
                       Pair(
+                          "../ReactCommon/react/renderer/components/text/React/",
+                          "React/",
+                      ),
+                      Pair(
                           "../ReactCommon/react/renderer/attributedstring",
                           "react/renderer/attributedstring",
                       ),

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "React-Core"
   s.dependency "React-debug"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "React-cxxreact"
@@ -136,6 +137,12 @@ Pod::Spec.new do |s|
       sss.dependency             "Yoga"
       sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
+    end
+
+    ss.subspec "viewUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/view/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/view/React"
     end
 
     ss.subspec "scrollview" do |sss|

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "React-Core"
   s.dependency "React-debug"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "React-cxxreact"
@@ -135,6 +136,12 @@ Pod::Spec.new do |s|
       sss.dependency             "Yoga"
       sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
+    end
+
+    ss.subspec "viewUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/view/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/view/React"
     end
 
     ss.subspec "scrollview" do |sss|

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "React-Core"
   s.dependency "React-debug"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-featureflags"
   s.dependency "React-utils"
   s.dependency "React-runtimescheduler"
@@ -107,6 +108,12 @@ Pod::Spec.new do |s|
                                   ["react/renderer/components/text/*.h",
                                   "react/renderer/components/text/platform/cxx/**/*.h"])
       sss.header_dir           = "react/renderer/components/text"
+    end
+
+    ss.subspec "textUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/text/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/text/React"
     end
 
     ss.subspec "iostextinput" do |sss|

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "React-Core"
   s.dependency "React-debug"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-featureflags"
   s.dependency "React-utils"
   s.dependency "React-runtimescheduler"
@@ -118,6 +119,12 @@ Pod::Spec.new do |s|
                                   ["react/renderer/components/text/*.h",
                                   "react/renderer/components/text/platform/cxx/**/*.h"])
       sss.header_dir           = "react/renderer/components/text"
+    end
+
+    ss.subspec "textUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/text/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/text/React"
     end
 
     ss.subspec "iostextinput" do |sss|

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <limits>
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/BaseParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/ParagraphShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/HostPlatformParagraphProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/BaseTextShadowNode.h>
 #include <react/renderer/components/text/ParagraphEventEmitter.h>
 #include <react/renderer/components/text/ParagraphProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/RawTextShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/core/Props.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/RawTextProps.h>
 #include <react/renderer/core/ConcreteShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/React/Text.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/React/Text.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/text` module - public
+// entry point.
+//
+//   #include <React/Text.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/text/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/text/BaseParagraphComponentDescriptor.h>
+#include <react/renderer/components/text/BaseParagraphProps.h>
+#include <react/renderer/components/text/BaseTextProps.h>
+#include <react/renderer/components/text/BaseTextShadowNode.h>
+#include <react/renderer/components/text/HostPlatformParagraphProps.h>
+#include <react/renderer/components/text/ParagraphComponentDescriptor.h>
+#include <react/renderer/components/text/ParagraphEventEmitter.h>
+#include <react/renderer/components/text/ParagraphProps.h>
+#include <react/renderer/components/text/ParagraphShadowNode.h>
+#include <react/renderer/components/text/ParagraphState.h>
+#include <react/renderer/components/text/RawTextComponentDescriptor.h>
+#include <react/renderer/components/text/RawTextProps.h>
+#include <react/renderer/components/text/RawTextShadowNode.h>
+#include <react/renderer/components/text/SelectableParagraphComponentDescriptor.h>
+#include <react/renderer/components/text/SelectableParagraphShadowNode.h>
+#include <react/renderer/components/text/TextComponentDescriptor.h>
+#include <react/renderer/components/text/TextEffectComponentDescriptor.h>
+#include <react/renderer/components/text/TextEffectProps.h>
+#include <react/renderer/components/text/TextEffectShadowNode.h>
+#include <react/renderer/components/text/TextProps.h>
+#include <react/renderer/components/text/TextShadowNode.h>
+#include <react/renderer/components/text/stateConversions.h>
+
+#ifdef ANDROID
+#include <react/renderer/components/text/conversions.h>
+#include <react/renderer/components/text/primitives.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/text/SelectableParagraphComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/SelectableParagraphComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/BaseParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/SelectableParagraphShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/SelectableParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/SelectableParagraphShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/ParagraphShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/TextShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/TextEffectShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextEffectShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/TextEffectProps.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/ConcreteShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/components/text/BaseTextProps.h>
 #include <react/renderer/core/Props.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <limits>
 
 #include <react/renderer/components/text/BaseTextShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <limits>
 #include <memory>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawValue.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 enum class DataDetectorType {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/HostPlatformParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/HostPlatformParagraphProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/text/BaseParagraphProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/ParagraphState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/text/stateConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/stateConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/text/ParagraphState.h>
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/components/text/BaseTextProps.h>
 #include <react/renderer/components/textinput/basePrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <glog/logging.h>
 
 #include <react/renderer/attributedstring/AttributedString.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/textinput/basePrimitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawValue.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 namespace facebook::react {
 
 enum class SubmitBehavior {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "AndroidTextInputShadowNode.h"
 #include "AndroidTextInputState.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/view/ViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/Props.h>
 #include <react/renderer/graphics/Color.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "AndroidTextInputEventEmitter.h"
 #include "AndroidTextInputProps.h"
 #include "AndroidTextInputState.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/iostextinput/TextInputShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/components/iostextinput/conversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/iostextinput/TextInputProps.h>
 #include <react/renderer/components/textinput/BaseTextInputShadowNode.h>
 #include <react/renderer/components/textinput/TextInputEventEmitter.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/iostextinput/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/textinput/basePrimitives.h>
 #include <optional>
 #include <string>

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/components/iostextinput/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cinttypes>
 #include <optional>
 #include <string>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/AccessibilityPrimitives.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <mutex>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/AccessibilityProps.h>
 #include <react/renderer/components/view/YogaStylableProps.h>
 #include <react/renderer/components/view/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(rrc_view
         glog_init
         jsi
         logger
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_css

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/graphicsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/LayoutConformanceShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/YogaStylableProps.h>
 #include <react/renderer/components/view/propsConversions.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/LayoutConformanceProps.h>
 #include <react/renderer/components/view/YogaLayoutableShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/PointerEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/EventPayload.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/view` module - public
+// entry point.
+//
+//   #include <React/View.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/view/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
+// this block so later *direct* includes in the same TU are still caught.
+#define RN_UMBRELLA_CONTEXT
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+#include <react/renderer/components/view/AccessibilityPrimitives.h>
+#include <react/renderer/components/view/AccessibilityProps.h>
+#include <react/renderer/components/view/BackgroundImagePropsConversions.h>
+#include <react/renderer/components/view/BaseTouch.h>
+#include <react/renderer/components/view/BaseViewEventEmitter.h>
+#include <react/renderer/components/view/BaseViewProps.h>
+#include <react/renderer/components/view/BoxShadowPropsConversions.h>
+#include <react/renderer/components/view/CSSConversions.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/view/FilterPropsConversions.h>
+#include <react/renderer/components/view/HostPlatformTouch.h>
+#include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h>
+#include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
+#include <react/renderer/components/view/LayoutConformanceComponentDescriptor.h>
+#include <react/renderer/components/view/LayoutConformanceProps.h>
+#include <react/renderer/components/view/LayoutConformanceShadowNode.h>
+#include <react/renderer/components/view/PointerEvent.h>
+#include <react/renderer/components/view/Touch.h>
+#include <react/renderer/components/view/TouchEvent.h>
+#include <react/renderer/components/view/TouchEventEmitter.h>
+#include <react/renderer/components/view/ViewComponentDescriptor.h>
+#include <react/renderer/components/view/ViewEventEmitter.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/view/ViewPropsInterpolation.h>
+#include <react/renderer/components/view/ViewShadowNode.h>
+#include <react/renderer/components/view/YogaLayoutableShadowNode.h>
+#include <react/renderer/components/view/YogaStylableProps.h>
+#include <react/renderer/components/view/accessibilityPropsConversions.h>
+#include <react/renderer/components/view/conversions.h>
+#include <react/renderer/components/view/primitives.h>
+#include <react/renderer/components/view/propsConversions.h>
+
+#ifdef ANDROID
+#include <react/renderer/components/view/NativeDrawable.h>
+#endif
+
+#if defined(TARGET_OS_OSX) && TARGET_OS_OSX
+#include <react/renderer/components/view/HostPlatformViewEvents.h>
+#include <react/renderer/components/view/KeyEvent.h>
+#include <react/renderer/components/view/MouseEvent.h>
+#endif
+
+#ifdef USE_WINUI_FABRIC
+#include <react/renderer/components/view/KeyEvent.h>
+#include <react/renderer/components/view/WindowsViewEvents.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/Touch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/DebugStringConvertible.h>
 
 #include <react/renderer/components/view/Touch.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/PointerEvent.h>
 #include <react/renderer/components/view/TouchEvent.h>
 #include <react/renderer/core/EventEmitter.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/HostPlatformViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/graphics/Transform.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <yoga/style/Style.h>
 
 #include <react/renderer/core/Props.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/debug/react_native_expect.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/components/view/NativeDrawable.h>
 #include <react/renderer/components/view/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformTouch.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseTouch.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewEventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/tvos/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/ShadowNodeTraits.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/RectangleCorners.h>
 #include <react/renderer/graphics/RectangleEdges.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/scripts/ios-prebuild/__tests__/headers-inventory-test.js
+++ b/packages/react-native/scripts/ios-prebuild/__tests__/headers-inventory-test.js
@@ -56,6 +56,47 @@ describe('scanHeader include classification', () => {
       {token: 'b.h', cxxGuarded: true},
     ]);
   });
+
+  test('includes for non-iOS platforms are ignored', () => {
+    const src = [
+      '#ifdef ANDROID',
+      '#include <android/only.h>',
+      '#endif',
+      '#if defined(TARGET_OS_OSX) && TARGET_OS_OSX',
+      '#include <macos/only.h>',
+      '#endif',
+      '#if defined(USE_WINUI_FABRIC)',
+      '#include <windows/only.h>',
+      '#endif',
+      '#include <ios/available.h>',
+      '',
+    ].join('\n');
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'ios/available.h', cxxGuarded: false},
+    ]);
+  });
+
+  test('#else after a non-iOS platform guard is scanned', () => {
+    const src = [
+      '#ifdef ANDROID',
+      '#include <android/only.h>',
+      '#else',
+      '#include <ios/available.h>',
+      '#endif',
+      '',
+    ].join('\n');
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'ios/available.h', cxxGuarded: false},
+    ]);
+  });
+
+  test('unknown platform conditions remain conservatively scanned', () => {
+    const src =
+      '#ifdef UNKNOWN_PLATFORM\n#include <maybe/available.h>\n#endif\n';
+    expect(scanHeader(src).includes).toEqual([
+      {token: 'maybe/available.h', cxxGuarded: false},
+    ]);
+  });
 });
 
 describe('scanHeader C++ / ObjC surface detection', () => {

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -359,6 +359,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
           },
 
           {
+            name: 'textUmbrella',
+            headerPatterns: ['react/renderer/components/text/React/*.h'],
+            headerDir: 'React',
+          },
+
+          {
             name: 'iostextinput',
             headerPatterns: [
               'react/renderer/components/textinput/*.h',

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -114,6 +114,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
           },
 
           {
+            name: 'viewUmbrella',
+            headerPatterns: ['react/renderer/components/view/React/*.h'],
+            headerDir: 'React',
+          },
+
+          {
             name: 'scrollview',
             headerPatterns: ['react/renderer/components/scrollview/**/*.h'],
             headerDir: 'react/renderer/components/scrollview',

--- a/packages/react-native/scripts/ios-prebuild/headers-inventory.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-inventory.js
@@ -128,9 +128,9 @@ const SDK_PREFIXES = new Set([
 /**
  * Scans a header's text line by line, tracking the preprocessor-conditional
  * stack just enough to know whether a line is only compiled under
- * `__cplusplus`. Returns the include list and language-marker observations.
- * Heuristic by design: nested #if logic beyond __cplusplus is treated as
- * "other" and ignored.
+ * `__cplusplus` or is unreachable in the iOS packaged layout. Returns the
+ * include list and language-marker observations. Heuristic by design: unknown
+ * #if logic is treated as "other" and scanned conservatively.
  */
 function scanHeader(text /*: string */) /*: {
   includes: Array<IncludeRef>,
@@ -143,9 +143,28 @@ function scanHeader(text /*: string */) /*: {
   let hasUnguardedCxx = false;
   let hasGuardedCxx = false;
 
-  // Stack frames: 'cpp' (only under __cplusplus), 'notcpp', 'other'.
-  const stack /*: Array<'cpp' | 'notcpp' | 'other'> */ = [];
+  // Stack frames: 'cpp' (only under __cplusplus), 'notcpp', 'inactive'
+  // (known to be excluded from an iOS build), or 'other'.
+  const stack /*: Array<'cpp' | 'notcpp' | 'inactive' | 'other'> */ = [];
   const inCxxOnly = () => stack.includes('cpp');
+  const isInactive = () => stack.includes('inactive');
+  const isKnownInactiveIosCondition = (
+    directive /*: string */,
+    expression /*: string */,
+  ) /*: boolean */ => {
+    const trimmed = expression.trim();
+    if (directive === 'ifdef') {
+      return trimmed === 'ANDROID' || trimmed === 'USE_WINUI_FABRIC';
+    }
+    if (directive !== 'if' && directive !== 'elif') {
+      return false;
+    }
+    return (
+      /^defined\s+(?:ANDROID|USE_WINUI_FABRIC)$/.test(trimmed) ||
+      /^defined\s*\(\s*(?:ANDROID|USE_WINUI_FABRIC)\s*\)$/.test(trimmed) ||
+      /^defined\s*\(\s*TARGET_OS_OSX\s*\)\s*&&\s*TARGET_OS_OSX$/.test(trimmed)
+    );
+  };
 
   const includeRe = /^\s*#\s*(?:include|import)\s+(?:<([^>]+)>|"([^"]+)")/;
   const objcRe =
@@ -183,10 +202,14 @@ function scanHeader(text /*: string */) /*: {
       const mentionsCpp = /__cplusplus/.test(rest);
       if (directive === 'ifdef' || directive === 'if') {
         stack.push(
-          mentionsCpp &&
-            !/!\s*defined|defined\s*\(\s*__cplusplus\s*\)\s*==\s*0/.test(rest)
-            ? 'cpp'
-            : 'other',
+          isKnownInactiveIosCondition(directive, rest)
+            ? 'inactive'
+            : mentionsCpp &&
+                !/!\s*defined|defined\s*\(\s*__cplusplus\s*\)\s*==\s*0/.test(
+                  rest,
+                )
+              ? 'cpp'
+              : 'other',
         );
       } else if (directive === 'ifndef') {
         stack.push(mentionsCpp ? 'notcpp' : 'other');
@@ -197,10 +220,20 @@ function scanHeader(text /*: string */) /*: {
         );
       } else if (directive === 'elif') {
         stack.pop();
-        stack.push(mentionsCpp ? 'cpp' : 'other');
+        stack.push(
+          isKnownInactiveIosCondition(directive, rest)
+            ? 'inactive'
+            : mentionsCpp
+              ? 'cpp'
+              : 'other',
+        );
       } else if (directive === 'endif') {
         stack.pop();
       }
+      continue;
+    }
+
+    if (isInactive()) {
       continue;
     }
 

--- a/scripts/cxx-api/umbrella-codemod.py
+++ b/scripts/cxx-api/umbrella-codemod.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env fbpython
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import re
+from pathlib import Path
+
+GUARD = {
+    "public": "UmbrellaGuard.h",
+    "frameworks": "FrameworksGuard.h",
+    "private": "PrivateGuard.h",
+}
+LICENSE = """/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+"""
+
+CXXSTABLEAPI_DEP = 'react_native_xplat_target("react/cxxstableapi:cxxstableapi")'
+
+
+class Codemod:
+    def __init__(self, apply: bool):
+        self.apply = apply
+        self.changed = []
+        self.warnings = []
+
+    def _write(self, path: Path, text: str):
+        rel = path.name
+        if self.apply:
+            path.write_text(text)
+            print(f"  ~ wrote {rel}")
+        else:
+            print(f"  ~ (dry-run) would write {rel}")
+        self.changed.append(str(path))
+
+    def warn(self, msg: str):
+        self.warnings.append(msg)
+        print(f"  !! {msg}")
+
+    # ---- discovery -------------------------------------------------------
+    @staticmethod
+    def public_headers(d: Path):
+        # Top-level *.h only (matches the standard subdir_glob([("", "*.h")])).
+        # Excludes the React/ umbrella subdir, which is a child dir.
+        return sorted(p for p in d.glob("*.h") if p.is_file())
+
+    @staticmethod
+    def module_prefix(buck: str):
+        m = re.search(r'prefix\s*=\s*"([^"]+)"', buck)
+        return m.group(1)
+
+    # ---- header guards ---------------------------------------------------
+    def add_guard_include(self, path: Path, guard: str):
+        text = path.read_text()
+        inc = f"#include <react/cxxstableapi/{guard}>"
+        if inc in text:
+            return
+        m = re.search(r"#pragma once\n", text)
+        if not m:
+            self.warn(f"no #pragma once in {path.name}; skipped guard")
+            return
+        end = m.end()
+        rest = text[end:]
+        rest = rest[1:] if rest.startswith("\n") else rest
+        self._write(path, text[:end] + "\n" + inc + "\n\n" + rest)
+
+    # ---- umbrella --------------------------------------------------------
+    def write_umbrella(self, d: Path, prefix: str, name: str, headers):
+        incs = "\n".join(f"#include <{prefix}/{h.name}>" for h in headers)
+        body = f"""{LICENSE}
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `{prefix}` module - public entry point.
+//
+//   #include <React/{name}.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<{prefix}/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
+// this block so later *direct* includes in the same TU are still caught.
+#define RN_UMBRELLA_CONTEXT
+
+{incs}
+
+#undef RN_UMBRELLA_CONTEXT
+"""
+        out = d / "React" / f"{name}.h"
+        if self.apply:
+            out.parent.mkdir(exist_ok=True)
+        self._write(out, body)
+
+    # ---- BUCK ------------------------------------------------------------
+    @staticmethod
+    def _match_paren(text: str, open_idx: int) -> int:
+        """Index just past the ')' that matches the '(' at open_idx."""
+        depth, i = 0, open_idx
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+            i += 1
+        return len(text)
+
+    @classmethod
+    def _enclosing_rule(cls, text: str, pos: int):
+        """(start, end) of the top-level call (e.g. rn_xplat_cxx_library(...))
+        that encloses `pos`. Used to scope edits to the right target in BUCK
+        files that declare several libraries."""
+        starts = [
+            m.start() for m in re.finditer(r"^\w+\(", text, re.M) if m.start() < pos
+        ]
+        if not starts:
+            return None
+        start = starts[-1]
+        return (start, cls._match_paren(text, text.find("(", start)))
+
+    def _exclude_react_from_headers(self, block: str) -> str:
+        """Exclude React/** from a private `headers = glob(...)` so the umbrella
+        does not flatten into a basename collision with a real header."""
+        hm = re.search(r"headers\s*=\s*glob\(", block)
+        if not hm:
+            return block  # header-only module: no private headers glob
+        hstart = block.index("(", hm.start())
+        hend = self._match_paren(block, hstart)
+        hglob = block[hstart:hend]
+        if "React/**/*.h" in hglob:
+            return block
+        ex = re.search(r"exclude\s*=\s*glob\(", hglob)
+        if ex:
+            ex_end = self._match_paren(hglob, hglob.index("(", ex.start()))
+            new = hglob[:ex_end] + ' + ["React/**/*.h"]' + hglob[ex_end:]
+        else:
+            new = hglob[:-1].rstrip() + ', exclude = ["React/**/*.h"])'
+        return block[:hstart] + new + block[hend:]
+
+    def edit_buck(self, d: Path, tier: str, name: str):
+        buck = d / "BUCK"
+        text = orig = buck.read_text()
+
+        if "react_native_xplat_target" not in text:
+            text = text.replace(
+                '"rn_xplat_cxx_library"',
+                '"react_native_xplat_target",\n    "rn_xplat_cxx_library"',
+                1,
+            )
+
+        ehm = re.search(r"^\s*exported_headers\s*=", text, re.M)
+        if ehm is None:
+            self.warn("no exported_headers field in BUCK; wire deps/flags by hand")
+            if text != orig:
+                self._write(buck, text)
+            return
+        eh = ehm.start()
+
+        # public: merge the umbrella into exported_headers (idempotent).
+        if tier == "public":
+            if f'"React/{name}.h"' in text:
+                pass  # already merged
+            else:
+                sg = text.find("subdir_glob(", eh)
+                if sg != -1:
+                    i = self._match_paren(text, text.index("(", sg))
+                    # If the subdir_glob is part of a larger expression -- e.g.
+                    # `subdir_glob(...) + selects.with_or(...)` -- inserting the
+                    # union here would break operator precedence and produce a
+                    # `dict | Select` parse error. Detect and skip.
+                    tail = text[i : i + 200].lstrip()
+                    if tail.startswith(("+", "|")):
+                        self.warn(
+                            "exported_headers is an aggregate expression "
+                            "(subdir_glob + ...); merge the umbrella "
+                            f'"React/{name}.h" into exported_headers by hand'
+                        )
+                    else:
+                        union = f' | {{\n        "React/{name}.h": "React/{name}.h",\n    }}'
+                        text = text[:i] + union + text[i:]
+                else:
+                    self.warn(
+                        "exported_headers is not a plain subdir_glob; merge the "
+                        f'umbrella "React/{name}.h" into exported_headers by hand'
+                    )
+
+        # Scope the remaining edits to the rule that owns exported_headers, so a
+        # multi-target BUCK file (e.g. a separate `test-deps` lib) gets the dep
+        # and flags on the right target. Match the field assignment (not a stray
+        # "exported_headers" mention in a comment).
+        ehm = re.search(r"^\s*exported_headers\s*=", text, re.M)
+        span = self._enclosing_rule(text, ehm.start())
+        if span is None:
+            self.warn("could not locate the enclosing library rule in BUCK")
+            if text != orig:
+                self._write(buck, text)
+            return
+        s, e = span
+        block = self._wire_library_block(text[s:e], tier)
+        text = text[:s] + block + text[e:]
+        if text != orig:
+            self._write(buck, text)
+
+    def _wire_library_block(self, block: str, tier: str) -> str:
+        """Add the cxxstableapi exported_dep, -DRN_BUILDING, and (public) the
+        React/** headers-glob exclusion to a single library rule block."""
+        if "react/cxxstableapi:cxxstableapi" not in block:
+            if "exported_deps = [" in block:
+                block = block.replace(
+                    "exported_deps = [",
+                    f"exported_deps = [\n        {CXXSTABLEAPI_DEP},",
+                    1,
+                )
+            elif "\n    visibility = " in block:
+                block = block.replace(
+                    "\n    visibility = ",
+                    f"\n    exported_deps = [{CXXSTABLEAPI_DEP}],\n    visibility = ",
+                    1,
+                )
+            else:
+                self.warn("could not add cxxstableapi exported_dep to BUCK")
+        if "RN_BUILDING" not in block:
+            if "preprocessor_flags" in block:
+                # Existing preprocessor_flags assignment - inserting another
+                # would produce a "repeated named argument" Starlark error.
+                # Skip and let the maintainer merge -DRN_BUILDING manually.
+                self.warn(
+                    "preprocessor_flags already set; add -DRN_BUILDING to the "
+                    "existing assignment by hand"
+                )
+            elif "\n    visibility = " in block:
+                block = block.replace(
+                    "\n    visibility = ",
+                    '\n    preprocessor_flags = ["-DRN_BUILDING"],\n    visibility = ',
+                    1,
+                )
+        if tier == "public":
+            block = self._exclude_react_from_headers(block)
+        return block
+
+    # ---- CMake -----------------------------------------------------------
+    def edit_cmake(self, d: Path, tier: str):
+        cm = d / "CMakeLists.txt"
+        if not cm.exists():
+            self.warn("no CMakeLists.txt")
+            return
+        text = orig = cm.read_text()
+        m = re.search(r"add_library\((\w+)(\s+INTERFACE)?", text)
+        if not m:
+            self.warn("no add_library in CMakeLists.txt")
+            return
+        tgt = m.group(1)
+        # INTERFACE libs need the INTERFACE keyword; OBJECT/STATIC use plain
+        # link + PUBLIC includes. Mixing forms on one target is a CMake error.
+        iface = bool(m.group(2))
+        link_scope = "INTERFACE " if iface else ""
+        inc_scope = "INTERFACE" if iface else "PUBLIC"
+        if "react_cxxstableapi" not in text:
+            text += f"\ntarget_link_libraries({tgt} {link_scope}react_cxxstableapi)\n"
+        if tier == "public" and "CMAKE_CURRENT_SOURCE_DIR" not in text:
+            text += (
+                "\n# Vend the umbrella as <React/...>: expose the module dir so "
+                "the\n# React/ subdir resolves for dependents.\n"
+                f"target_include_directories({tgt} {inc_scope} "
+                "${CMAKE_CURRENT_SOURCE_DIR})\n"
+            )
+        if text != orig:
+            self._write(cm, text)
+
+    # ---- podspec ---------------------------------------------------------
+    def edit_podspec(self, d: Path, tier: str):
+        specs = list(d.glob("*.podspec"))
+        if not specs:
+            self.warn("no podspec")
+            return
+        spec = specs[0]
+        text = orig = spec.read_text()
+
+        if "React-cxxstableapi" not in text:
+            text = re.sub(
+                r"(resolve_use_frameworks\([^\n]*\)\n)",
+                r'\1\n  s.dependency "React-cxxstableapi"\n',
+                text,
+                count=1,
+            )
+
+        if tier == "public" and 'subspec "Umbrella"' not in text:
+            if re.search(r's\.exclude_files\s*=\s*"', text):
+                text = re.sub(
+                    r's\.exclude_files\s*=\s*"([^"]*)"',
+                    r's.exclude_files          = ["\1", "React"]',
+                    text,
+                    count=1,
+                )
+            elif "exclude_files" not in text:
+                text = re.sub(
+                    r'(\n\s*s\.header_dir\s*=\s*"[^"]*"\n)',
+                    r'\1  s.exclude_files          = "React"\n',
+                    text,
+                    count=1,
+                )
+            subspec = (
+                '\n  s.subspec "Umbrella" do |ss|\n'
+                '    ss.source_files        = "React/*.h"\n'
+                '    ss.header_dir          = "React"\n'
+                '    ss.header_mappings_dir = "React"\n'
+                "  end\n"
+            )
+            last = text.rfind("\nend")
+            text = text[:last] + "\n" + subspec + text[last:]
+
+        if text != orig:
+            self._write(spec, text)
+
+    # ---- Android Prefab (central build.gradle.kts) -----------------------
+    def edit_gradle(self, d: Path, prefix: str):
+        # Find packages/react-native ancestor to locate the gradle file.
+        parts = d.parts
+        try:
+            i = len(parts) - 1 - parts[::-1].index("react-native")
+        except ValueError:
+            self.warn("cannot locate packages/react-native for gradle edit")
+            return
+        gradle = Path(*parts[: i + 1]) / "ReactAndroid" / "build.gradle.kts"
+        if not gradle.exists():
+            self.warn(f"gradle file not found at {gradle}")
+            return
+        text = gradle.read_text()
+        umbrella_pair = (
+            f"Pair(\n                          "
+            f'"../ReactCommon/{prefix}/React/",\n                          '
+            f'"React/",\n                      ),'
+        )
+        if f'"../ReactCommon/{prefix}/React/"' in text:
+            return  # already added
+        # Locate the module's existing source Pair and insert after its `),`.
+        anchor = f'"../ReactCommon/{prefix}/"'
+        pos = text.find(anchor)
+        if pos == -1:
+            self.warn(
+                f"no Prefab entry for {prefix}; if it is Android-exposed, add the "
+                f"<React/...> Pair to build.gradle.kts by hand"
+            )
+            return
+        close = text.find("),", pos)
+        if close == -1:
+            self.warn(f"malformed Prefab entry for {prefix}; add gradle Pair by hand")
+            return
+        insert_at = close + 2
+        new = (
+            text[:insert_at]
+            + "\n                      "
+            + umbrella_pair
+            + text[insert_at:]
+        )
+        if new != text:
+            self._write(gradle, new)
+
+    # ---- driver ----------------------------------------------------------
+    def run_target(self, d: Path, tier: str, name: str):
+        if tier not in GUARD:
+            self.warn(f"{d}: bad tier {tier!r}; skipped")
+            return
+        if not (d / "BUCK").exists():
+            self.warn(f"{d}: no BUCK; skipped")
+            return
+        if tier == "public" and not name:
+            self.warn(f"{d}: public tier needs a name; skipped")
+            return
+        buck = (d / "BUCK").read_text()
+        try:
+            prefix = self.module_prefix(buck)
+        except AttributeError:
+            self.warn(f"{d}: no subdir_glob prefix in BUCK; skipped")
+            return
+        headers = self.public_headers(d)
+        print(
+            f"\n== {d.name}  tier={tier}  prefix={prefix}  "
+            f"headers={[h.name for h in headers]}"
+        )
+        for h in headers:
+            self.add_guard_include(h, GUARD[tier])
+        if tier == "public":
+            self.write_umbrella(d, prefix, name, headers)
+        self.edit_buck(d, tier, name or "")
+        self.edit_cmake(d, tier)
+        self.edit_podspec(d, tier)
+        if tier == "public":
+            self.edit_gradle(d, prefix)
+
+
+def parse_config(path: Path):
+    out = []
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        cols = [c.strip() for c in line.split("|")]
+        d, tier = cols[0], cols[1]
+        name = cols[2] if len(cols) > 2 else ""
+        out.append((d, tier, name))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target", help="single target dir")
+    ap.add_argument("--tier", choices=list(GUARD))
+    ap.add_argument("--name", default="", help="umbrella name (public only)")
+    ap.add_argument("--config", help="batch config file: `dir | tier | name?`")
+    ap.add_argument("--root", default=".", help="base dir for relative target paths")
+    ap.add_argument(
+        "--apply", action="store_true", help="write changes (default: dry-run)"
+    )
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    targets = []
+    if args.config:
+        targets = parse_config(Path(args.config))
+    elif args.target:
+        targets = [(args.target, args.tier, args.name)]
+    else:
+        ap.error("provide --target/--tier or --config")
+
+    cm = Codemod(apply=args.apply)
+    print("MODE:", "APPLY" if args.apply else "DRY-RUN")
+    for d, tier, name in targets:
+        p = Path(d)
+        if not p.is_absolute():
+            p = (root / d).resolve()
+        cm.run_target(p, tier, name)
+
+    print(
+        f"\nsummary: {len(cm.changed)} file(s) "
+        f"{'written' if args.apply else 'would change'}, "
+        f"{len(cm.warnings)} warning(s)"
+    )
+    if not args.apply:
+        print("dry-run only; re-run with --apply to write, then `arc f`.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

This diff rolls umbrella guards for `react/renderer/components/text` and `react/renderer/components/textinput`.

Initially, we consider `text` component target as `public` and `textinput` as `for frameworks`, so the umbrella is added only to the `text` target.

This diff also adds missing `components/text/platform/android/` to the prefab as otherwise the Text umbrella cannot be properly resolved on Android.

Changelog:
[Internal]

Reviewed By: cipolleschi

Differential Revision: D109849283
