### PR TITLE
Fix RCTDevSettings init

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -156,9 +156,6 @@ RCT_EXPORT_MODULE()
   };
   RCTDevSettingsUserDefaultsDataSource *dataSource =
       [[RCTDevSettingsUserDefaultsDataSource alloc] initWithDefaultValues:defaultValues];
-#if RCT_DEV
-  _packagerConnection = [RCTPackagerConnection new];
-#endif
   _isShakeGestureEnabled = true;
   return [self initWithDataSource:dataSource];
 }
@@ -176,6 +173,9 @@ RCT_EXPORT_MODULE()
 - (instancetype)initWithDataSource:(id<RCTDevSettingsDataSource>)dataSource
 {
   if (self = [super init]) {
+#if RCT_DEV
+    _packagerConnection = [RCTPackagerConnection new];
+#endif
     _dataSource = dataSource;
 
     [[NSNotificationCenter defaultCenter] addObserver:self


### PR DESCRIPTION
## Summary:
#54258 made RCTPackagerConnection a per RCTDevSettings instance and creates it in init. The issue is that init isn't the only way these instances are built, anything constructed through the public initWithDataSource bypasses init entirely, so initWithDataSource never creates _packagerConnection and it stays nil. Those instances silently stop receiving packager commands like reload and devMenu, because the connection they would register handlers on and receive over does not exist.

This moves the creation into initWithDataSource, so every construction path gets a connection. -init still delegates to initWithDataSource:, so the default path is unchanged.

## Changelog:

[IOS] [FIXED] - Create the RCTDevSettings packager connection in initWithDataSource so instances built that way also receive packager commands

## Test Plan:

- [[RCTDevSettings alloc] init].packagerConnection is non-nil (unchanged).
- [[RCTDevSettings alloc] initWithDataSource:dataSource]. packagerConnection is non-nil after this change (it was nil before).
- Verified in a host that subclasses RCTDevSettings via initWithDataSource (Expo Go's scoped dev settings), reload and devMenu from the CLI now reach the app over the packager connection. Before this change they were dropped because the subclass had a nil connection.
