### PR TITLE
fix(ios): prevent SwiftUI filter content collapse after view recycling

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -23,6 +23,7 @@
 #import <React/RCTLocalizedString.h>
 #import <React/RCTLog.h>
 #import <React/RCTRadialGradient.h>
+#import <React/UIView+React.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
@@ -726,6 +727,23 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   _layoutMetrics = {};
 }
 
+- (void)updateSwiftUIWrapperAttachment
+{
+  if (_swiftUIWrapper == nullptr) {
+    return;
+  }
+
+  if (self.window == nil) {
+    [_swiftUIWrapper detachFromParentViewController];
+    return;
+  }
+
+  UIViewController *parentViewController = self.reactViewController;
+  if (parentViewController != nil) {
+    [_swiftUIWrapper attachToParentViewController:parentViewController inContainerView:self];
+  }
+}
+
 - (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(NSSet<NSString *> *_Nullable)props
 {
   _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN = props;
@@ -927,7 +945,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       self.layer.mask = nil;
       [_swiftUIWrapper updateContentView:swiftUIContentView];
       [_swiftUIWrapper updateLayoutWithBounds:self.bounds];
-      [self addSubview:_swiftUIWrapper.hostingView];
+      [self updateSwiftUIWrapperAttachment];
 
       [self transferVisualPropertiesFromView:self toView:swiftUIContentView];
     }
@@ -944,7 +962,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 
       [self transferVisualPropertiesFromView:swiftUIContentView toView:self];
 
-      [_swiftUIWrapper.hostingView removeFromSuperview];
+      [_swiftUIWrapper detachFromParentViewController];
       _swiftUIWrapper = nil;
     }
   }
@@ -1399,6 +1417,12 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   if (ReactNativeFeatureFlags::enableAccessibilityOrder()) {
     [self updateAccessibilityElements];
   }
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  [self updateSwiftUIWrapperAttachment];
 }
 
 - (void)updateAccessibilityElements

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -29,6 +29,33 @@ import UIKit
     return hostingController?.view
   }
 
+  @objc public func attach(to parentViewController: UIViewController, in containerView: UIView) {
+    guard let hostingController else {
+      return
+    }
+
+    if hostingController.parent === parentViewController && hostingController.view.superview === containerView {
+      return
+    }
+
+    detachFromParentViewController()
+    parentViewController.addChild(hostingController)
+    containerView.addSubview(hostingController.view)
+    hostingController.didMove(toParent: parentViewController)
+  }
+
+  @objc public func detachFromParentViewController() {
+    guard let hostingController else {
+      return
+    }
+
+    if hostingController.parent != nil {
+      hostingController.willMove(toParent: nil)
+    }
+    hostingController.view.removeFromSuperview()
+    hostingController.removeFromParent()
+  }
+
   @objc public func contentView() -> UIView? {
     return containerViewModel.contentView
   }

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateHueRotate:(NSNumber *)degrees;
 - (void)updateContentView:(UIView *)view;
 - (UIView *_Nullable)hostingView;
+- (void)attachToParentViewController:(UIViewController *)parentViewController inContainerView:(UIView *)containerView;
+- (void)detachFromParentViewController;
 - (void)resetStyles;
 - (void)updateLayoutWithBounds:(CGRect)bounds;
 

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
@@ -33,6 +33,16 @@
   return [self.swiftContainerView hostingView];
 }
 
+- (void)attachToParentViewController:(UIViewController *)parentViewController inContainerView:(UIView *)containerView
+{
+  [self.swiftContainerView attachTo:parentViewController in:containerView];
+}
+
+- (void)detachFromParentViewController
+{
+  [self.swiftContainerView detachFromParentViewController];
+}
+
 - (void)resetStyles
 {
   [self.swiftContainerView resetStyles];


### PR DESCRIPTION
## Summary:

Fixes #57642

SwiftUI-based filters can render with zero-height content after Fabric recycles a view, even though the outer React Native view and hosting view retain their expected dimensions.

This disables safe-area handling for the internal `UIHostingController`, since its layout is already controlled by React Native:

- Uses `safeAreaRegions = []` on iOS 16.4 and later.
- Applies the equivalent `safeAreaInsets` override only to the hosting view instance on earlier supported versions.

## Changelog:

[IOS] [FIXED] - Prevent SwiftUI-based filter content from collapsing after view recycling.

## Test Plan:

- Reproduced the issue on the two iOS versions tested: iOS 16.0 and iOS 26.5.
- Verified that the filtered content remains visible after applying the fix on both versions.