### PR TITLE
Add SceneDelegate support (#57700)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -19,8 +19,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * @deprecated RCTAppDelegate is deprecated and will be removed in a future version of React Native. Use
- `RCTReactNativeFactory` instead.
+ * @deprecated RCTAppDelegate is deprecated and will be removed in a future version of React Native. For new apps
+ * using the UIScene lifecycle, implement your own `SceneDelegate` with `RCTReactNativeFactory` (see integration
+ * docs). For AppDelegate-only apps, use `RCTReactNativeFactory` directly.
+ *
+ * Scene-based apps must keep `UIApplicationSupportsMultipleScenes` set to `false` in Info.plist. Define
+ * `RN_ALLOW_MULTIPLE_SCENES` on the app target to downgrade the unsupported-configuration crash to a warning.
  *
  * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
  * It is not mandatory to use it, but it could simplify your AppDelegate code.
@@ -55,18 +59,11 @@ NS_ASSUME_NONNULL_BEGIN
  *   - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
  */
 __attribute__((deprecated(
-    "RCTAppDelegate is deprecated and will be removed in a future version of React Native. Use `RCTReactNativeFactory` instead.")))
+    "RCTAppDelegate is deprecated and will be removed in a future version of React Native. For UIScene apps implement your own SceneDelegate with RCTReactNativeFactory; otherwise use RCTReactNativeFactory.")))
 @interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate<UIApplicationDelegate>
 
 /// The window object, used to render the UViewControllers
 @property (nonatomic, strong, nonnull) UIWindow *window;
-
-#if !defined(RCT_REMOVE_LEGACY_ARCH)
-@property (nonatomic, nullable) RCTBridge *bridge
-    __attribute__((deprecated("The bridge is deprecated and will be removed when removing the legacy architecture.")));
-@property (nonatomic, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter __attribute__((
-    deprecated("The bridge adapter is deprecated and will be removed when removing the legacy architecture.")));
-#endif
 
 @property (nonatomic, strong, nullable) NSString *moduleName;
 @property (nonatomic, strong, nullable) NSDictionary *initialProps;

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -66,7 +66,7 @@
 
 - (NSURL *_Nullable)bundleURL
 {
-  [NSException raise:@"RCTAppDelegate::bundleURL not implemented"
+  [NSException raise:@"RCTReactNativeFactoryDelegate::bundleURL not implemented"
               format:@"Subclasses must implement a valid getBundleURL method"];
   return nullptr;
 }

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -58,6 +58,15 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
 
 @interface RCTReactNativeFactory : NSObject
 
+/**
+ * Bootstrap entrypoints:
+ * - **AppDelegate path**: `startReactNativeWithModuleName:inWindow:launchOptions:` — call from
+ *   `application:didFinishLaunchingWithOptions:` or `RCTAppDelegate`.
+ * - **SceneDelegate path**: `startReactNativeWithModuleName:inWindow:connectionOptions:` — call from
+ *   `scene:willConnectToSession:options:` in your app-owned `SceneDelegate` (subclass
+ *   `RCTDefaultReactNativeFactoryDelegate` and conform to `UIWindowSceneDelegate`).
+ */
+
 - (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate;
 
 - (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate releaseLevel:(RCTReleaseLevel)releaseLevel;
@@ -73,9 +82,33 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
                      initialProperties:(NSDictionary *_Nullable)initialProperties
                          launchOptions:(NSDictionary *_Nullable)launchOptions;
 
+/**
+ * SceneDelegate entrypoint to start a React Native instance with the specified module name, window, and connection
+ * options for linking and user activity information. Only the first item in `URLContexts` and `userActivities` is used.
+ * @param moduleName name of the JS module to load
+ * @param window the window to launch in
+ * @param connectionOptions the scene's connection options
+ */
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow *_Nullable)window
+                     connectionOptions:(UISceneConnectionOptions *_Nullable)connectionOptions;
+
+/**
+ * SceneDelegate entrypoint to start a React Native instance with the specified module name, window, initial properties,
+ * and connection options. Only the first item in `URLContexts` and `userActivities` is used.
+ * @param moduleName name of the JS module to load
+ * @param window the window to launch in
+ * @param initialProperties the initial root properties
+ * @param connectionOptions the scene's connection options
+ */
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow *_Nullable)window
+                     initialProperties:(NSDictionary *_Nullable)initialProperties
+                     connectionOptions:(UISceneConnectionOptions *_Nullable)connectionOptions;
+
 #if !defined(RCT_REMOVE_LEGACY_ARCH)
-@property (nonatomic, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter __attribute__((
-    deprecated("The bridgeAdapter is deprecated and will be removed when removing the legacy architecture.")));
+@property (nonatomic, nullable) RCTBridge *bridge
+    __attribute__((deprecated("The bridge is deprecated and will be removed when removing the legacy architecture.")));
 #endif
 
 @property (nonatomic, strong, nonnull) RCTRootViewFactory *rootViewFactory;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -9,7 +9,6 @@
 #import <React/RCTBundleManager.h>
 #import <React/RCTColorSpaceUtils.h>
 #import <React/RCTDevMenu.h>
-#import <React/RCTLog.h>
 #import <React/RCTRootView.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <React/RCTUtils.h>
@@ -40,7 +39,35 @@ using namespace facebook::react;
     RCTHostDelegate,
     RCTJSRuntimeConfiguratorProtocol,
     RCTTurboModuleManagerDelegate>
+
 @end
+
+static NSDictionary *RCTConvertConnectionOptionsToLaunchOptions(UISceneConnectionOptions *connectionOptions)
+{
+  NSMutableDictionary *launchOptions = [NSMutableDictionary dictionary];
+
+  if (connectionOptions.URLContexts.count > 0) {
+    UIOpenURLContext *urlContext = connectionOptions.URLContexts.allObjects.firstObject;
+
+    if (urlContext.URL != nil) {
+      launchOptions[UIApplicationLaunchOptionsURLKey] = urlContext.URL;
+    }
+  }
+
+  if (connectionOptions.userActivities.count > 0) {
+    NSUserActivity *activity = connectionOptions.userActivities.allObjects.firstObject;
+
+    if (activity != nil) {
+      NSMutableDictionary *userActivityDict = [NSMutableDictionary dictionary];
+      userActivityDict[UIApplicationLaunchOptionsUserActivityTypeKey] = activity.activityType;
+      userActivityDict[@"UIApplicationLaunchOptionsUserActivityKey"] = activity;
+
+      launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey] = userActivityDict;
+    }
+  }
+
+  return launchOptions;
+}
 
 @implementation RCTReactNativeFactory
 
@@ -93,6 +120,29 @@ using namespace facebook::react;
   [_delegate setRootView:rootView toRootViewController:rootViewController];
   window.rootViewController = rootViewController;
   [window makeKeyAndVisible];
+}
+
+#pragma mark - UIScene.ConnectionOptions
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow *_Nullable)window
+                     connectionOptions:(UISceneConnectionOptions *_Nullable)connectionOptions
+{
+  [self startReactNativeWithModuleName:moduleName
+                              inWindow:window
+                     initialProperties:nil
+                         launchOptions:RCTConvertConnectionOptionsToLaunchOptions(connectionOptions)];
+}
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow *_Nullable)window
+                     initialProperties:(NSDictionary *_Nullable)initialProperties
+                     connectionOptions:(UISceneConnectionOptions *_Nullable)connectionOptions
+{
+  [self startReactNativeWithModuleName:moduleName
+                              inWindow:window
+                     initialProperties:initialProperties
+                         launchOptions:RCTConvertConnectionOptionsToLaunchOptions(connectionOptions)];
 }
 
 #pragma mark - RCTUIConfiguratorProtocol

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -184,11 +184,6 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  */
 @interface RCTRootViewFactory : NSObject
 
-#if !defined(RCT_REMOVE_LEGACY_ARCH)
-@property (nonatomic, strong, nullable) RCTBridge *bridge;
-@property (nonatomic, strong, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
-#endif
-
 @property (nonatomic, strong, nullable) RCTHost *reactHost;
 
 - (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -11,7 +11,6 @@
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#import "RCTAppDelegate.h"
 #import "RCTAppSetupUtils.h"
 
 #if RN_DISABLE_OSS_PLUGIN_HEADER

--- a/packages/react-native/Libraries/AppDelegate/RCTUIConfiguratorProtocol.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTUIConfiguratorProtocol.h
@@ -20,8 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * This method can be used to customize the rootView that is passed to React Native.
- * A typical example is to override this method in the AppDelegate to change the background color.
- * To achieve this, add in your `AppDelegate.mm`:
+ * Override on your `RCTReactNativeFactoryDelegate` (e.g. in AppDelegate, SceneDelegate, or
+ * `RCTAppDelegate` subclass). Example:
  * ```
  * - (void)customizeRootView:(RCTRootView *)rootView
  * {

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -59,6 +59,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTTypeSafety"
   s.dependency "React-RCTNetwork"
   s.dependency "React-RCTImage"
+  s.dependency "React-RCTLinking"
   s.dependency "React-CoreModules"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.h
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.h
@@ -11,17 +11,42 @@
 
 @interface RCTLinkingManager : RCTEventEmitter
 
+/**
+ * Deep linking integration supports two iOS lifecycle paths:
+ * - **AppDelegate methods** (below): use when the app does not declare `UIApplicationSceneManifest` in Info.plist.
+ * - **SceneDelegate methods** (below): use when the app uses the UIScene lifecycle. Forward these from your
+ *   app-owned `SceneDelegate`.
+ */
+
+#pragma mark - AppDelegate methods
+
+/// Lifecycle method informing of a URL being opened with the app.
+/// Invoke from AppDelegate for non-scene apps (no `UIApplicationSceneManifest` in Info.plist).
+/// Note: this is an implementation using the iOS 9.0-26.0 API
 + (BOOL)application:(nonnull UIApplication *)app
             openURL:(nonnull NSURL *)URL
             options:(nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options;
 
+/// Lifecycle method handling a URL being opened with the app.
+/// Invoke from AppDelegate for non-scene apps.
+/// Note: this is an implementation using the iOS 4.2-9.0 API
 + (BOOL)application:(nonnull UIApplication *)application
               openURL:(nonnull NSURL *)URL
     sourceApplication:(nullable NSString *)sourceApplication
            annotation:(nonnull id)annotation;
 
+/// Lifecycle method handling user activity being performed.
+/// Invoke from AppDelegate for non-scene apps.
 + (BOOL)application:(nonnull UIApplication *)application
     continueUserActivity:(nonnull NSUserActivity *)userActivity
       restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler;
+
+#pragma mark - SceneDelegate methods
+
+/// Handles user activity for scene-based apps. Invoke from your SceneDelegate.
++ (void)scene:(nonnull UIScene *)scene continueUserActivity:(nonnull NSUserActivity *)userActivity;
+
+/// Handles URLs opened while the app is running for scene-based apps. Invoke from your SceneDelegate.
++ (void)scene:(nonnull UIScene *)scene openURLContexts:(nonnull NSSet<UIOpenURLContext *> *)URLContexts;
 
 @end

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -17,23 +17,37 @@
 
 static NSString *const kOpenURLNotification = @"RCTOpenURLNotification";
 
-static void postNotificationWithURL(NSURL *URL, id sender)
-{
-  NSDictionary<NSString *, id> *payload = @{@"url" : URL.absoluteString};
-  [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:sender userInfo:payload];
-}
-
 @interface RCTLinkingManager () <NativeLinkingManagerSpec>
+
+/// Common logic for handling user activities originating from both AppDelegate- and SceneDelegate- lifecycle methods
++ (void)handleUserActivity:(NSUserActivity *)userActivity window:(UIWindow *)window;
+
+/// Common logic for handling user activities from AppDelegate-lifecycle methods.
++ (BOOL)handleAppDelegateURL:(NSURL *)URL app:(UIApplication *)app;
+
+/// Posts a URL notification that will be handled by the emitter to JS; this method is used to invoke instance methods
+/// of RCTLinkingManager from class methods via NSNotificationCenter.
+/// @param URL The URL to be emitted.
++ (void)postNotificationWithURL:(NSURL *)URL;
+
 @end
 
 @implementation RCTLinkingManager
 
 RCT_EXPORT_MODULE()
 
++ (void)postNotificationWithURL:(NSURL *)URL
+{
+  NSDictionary<NSString *, id> *payload = @{@"url" : URL.absoluteString};
+  [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:nil userInfo:payload];
+}
+
 - (dispatch_queue_t)methodQueue
 {
   return dispatch_get_main_queue();
 }
+
+#pragma mark - RCTEventEmitter methods
 
 - (void)startObserving
 {
@@ -53,33 +67,72 @@ RCT_EXPORT_MODULE()
   return @[ @"url" ];
 }
 
+#pragma mark - JS methods
+
 + (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)URL
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
 {
-  postNotificationWithURL(URL, self);
-  return YES;
+  return [self handleAppDelegateURL:URL app:app];
 }
 
-// Corresponding api deprecated in iOS 9
 + (BOOL)application:(UIApplication *)application
               openURL:(NSURL *)URL
     sourceApplication:(NSString *)sourceApplication
            annotation:(id)annotation
 {
-  postNotificationWithURL(URL, self);
-  return YES;
+  return [self handleAppDelegateURL:URL app:application];
 }
 
 + (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
       restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler
 {
+  if (RCTIsSceneDelegateApp()) {
+    return NO;
+  }
+
+  [RCTLinkingManager handleUserActivity:userActivity window:RCTKeyWindow()];
+  return YES;
+}
+
+#pragma mark - SceneDelegate methods
+
++ (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity
+{
+  [RCTLinkingManager handleUserActivity:userActivity window:RCTKeyWindow()];
+}
+
++ (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+  if (URLContexts.count == 0) {
+    return;
+  }
+
+  NSURL *URL = URLContexts.allObjects.firstObject.URL;
+  if (URL == nil) {
+    return;
+  }
+  [RCTLinkingManager postNotificationWithURL:URL];
+}
+
+#pragma mark - Common logic methods
+
++ (void)handleUserActivity:(NSUserActivity *)userActivity window:(UIWindow *)window
+{
   // This can be nullish when launching an App Clip.
   if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil) {
-    NSDictionary *payload = @{@"url" : userActivity.webpageURL.absoluteString};
-    [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:self userInfo:payload];
+    [RCTLinkingManager postNotificationWithURL:userActivity.webpageURL];
   }
+}
+
++ (BOOL)handleAppDelegateURL:(NSURL *)URL app:(UIApplication *)app
+{
+  if (RCTIsSceneDelegateApp()) {
+    return NO;
+  }
+
+  [RCTLinkingManager postNotificationWithURL:URL];
   return YES;
 }
 

--- a/packages/react-native/React/Base/RCTJavaScriptLoader.mm
+++ b/packages/react-native/React/Base/RCTJavaScriptLoader.mm
@@ -257,7 +257,7 @@ static void attemptAsynchronousLoadOfBundleAtURL(
                              [@"Could not connect to development server.\n\n"
                                "Ensure the following:\n"
                                "- Node server is running and available on the same network - run 'npm start' from react-native root\n"
-                               "- Node server URL is correctly set in AppDelegate\n"
+                               "- Node server URL is correctly set in your AppDelegate or SceneDelegate factory delegate\n"
                                "- WiFi is enabled and connected to the same network as the Node Server\n\n"
                                "URL: " stringByAppendingString:scriptURL.absoluteString],
                          NSLocalizedFailureReasonErrorKey : error.localizedDescription,

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -93,6 +93,9 @@ RCT_EXTERN UIApplication *__nullable RCTSharedApplication(void);
 // or view controller
 RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 
+// Is this app a SceneDelegate app?
+RCT_EXTERN BOOL RCTIsSceneDelegateApp(void);
+
 // Returns the presented view controller, useful if you need
 // e.g. to present a modal view controller or alert over it
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -390,7 +390,11 @@ CGSize RCTScreenSize(void)
 
   if (CGSizeEqualToSize(size, CGSizeZero)) {
     RCTUnsafeExecuteOnMainQueueSync(^{
-      CGSize screenSize = [UIScreen mainScreen].bounds.size;
+      UIScreen *screen = RCTKeyWindow().screen;
+      if (screen == nil) {
+        screen = UIScreen.screens.firstObject;
+      }
+      CGSize screenSize = screen.bounds.size;
       size = CGSizeMake(MIN(screenSize.width, screenSize.height), MAX(screenSize.width, screenSize.height));
       cachedSize.store(size, std::memory_order_relaxed);
     });
@@ -638,11 +642,57 @@ UIWindow *__nullable RCTKeyWindow(void)
     // Calling keyWindow on a UIScene which is not a UIWindowScene can cause a crash
     UIWindowScene *windowScene = (UIWindowScene *)sceneToUse;
     if (@available(iOS 15.0, tvOS 15.0, *)) {
-      return windowScene.keyWindow;
+      UIWindow *keyWindow = windowScene.keyWindow;
+      if (keyWindow != nil) {
+        return keyWindow;
+      }
+    }
+    UIWindow *window = nil;
+    for (window in windowScene.windows) {
+      if (window.isKeyWindow) {
+        return window;
+      }
     }
   }
 
+  // Fallback for apps still on the legacy UIApplicationDelegate lifecycle (no
+  // SceneDelegate / no UIApplicationSceneManifest, or scene migration disabled).
+  // Their key window is created and owned by the app delegate and is not attached
+  // to a foreground UIWindowScene, so the scene-based lookup above finds nothing.
+  // This diff moved several call sites from `delegate.window` to RCTKeyWindow(),
+  // so without this fallback RCTKeyWindow() returns nil for those apps and RN's
+  // window/screen/dimension resolution (RCTViewportSize, RCTDeviceInfo,
+  // RCTPresentedViewController, …) breaks — the RN UI never renders.
+  //
+  // Gate this on the legacy lifecycle: scene-based apps (UIApplicationSceneManifest
+  // present) own their window through a UIWindowScene, and the app delegate's
+  // `window` there is nil or a stale/secondary window. Falling back to it for a
+  // scene app returns the wrong window instead of the correct `nil`, regressing
+  // scene-based hosts (e.g. RNTester's SceneDelegate scheme). Keep the fallback
+  // strictly for the legacy path.
+  if (!RCTIsSceneDelegateApp()) {
+    return RCTSharedApplication().delegate.window;
+  }
+
   return nil;
+}
+
+BOOL RCTIsSceneDelegateApp(void)
+{
+  if (@available(iOS 13.0, *)) {
+    NSDictionary *sceneManifest = [[NSBundle mainBundle] infoDictionary][@"UIApplicationSceneManifest"];
+
+    if (sceneManifest != nil) {
+      NSDictionary *sceneConfigurations = sceneManifest[@"UISceneConfigurations"];
+      if (sceneConfigurations != nil && sceneConfigurations.count > 0) {
+        return YES;
+      }
+    }
+
+    return NO;
+  }
+
+  return NO;
 }
 
 #if !TARGET_OS_TV

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -200,6 +200,9 @@ RCT_EXPORT_MODULE()
       } else {
         self->_window = [[UIWindow alloc] init];
       }
+
+      self->_window.frame = self->_window.windowScene.coordinateSpace.bounds;
+
 #if !TARGET_OS_TV
       self->_window.windowLevel = UIWindowLevelStatusBar + 1;
 #endif
@@ -240,7 +243,6 @@ RCT_EXPORT_MODULE()
     [NSLayoutConstraint activateConstraints:constraints];
 
     [self->_window layoutIfNeeded];
-    self->_window.frame = CGRectMake(0, 0, mainWindow.frame.size.width, self->_container.frame.size.height);
   });
 }
 
@@ -268,15 +270,15 @@ RCT_EXPORT_MODULE()
     const NSTimeInterval MIN_PRESENTED_TIME = 0.6;
     NSTimeInterval presentedTime = [[NSDate date] timeIntervalSinceDate:self->_showDate];
     NSTimeInterval delay = MAX(0, MIN_PRESENTED_TIME - presentedTime);
-    CGRect windowFrame = self->_window.frame;
+    CGFloat height = self->_container.bounds.size.height;
     [UIView animateWithDuration:0.25
         delay:delay
         options:0
         animations:^{
-          self->_window.frame = CGRectOffset(windowFrame, 0, -windowFrame.size.height);
+          self->_container.transform = CGAffineTransformMakeTranslation(0, -height);
         }
         completion:^(__unused BOOL finished) {
-          self->_window.frame = windowFrame;
+          self->_container.transform = CGAffineTransformIdentity;
           self->_window.hidden = YES;
           self->_window = nil;
           self->_container = nil;

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -192,24 +192,27 @@ static BOOL RCTIsIPhoneNotched()
 static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 {
   RCTAssertMainQueue();
-  UIScreen *mainScreen = UIScreen.mainScreen;
-  CGSize screenSize = mainScreen.bounds.size;
-  UIView *mainWindow = RCTKeyWindow();
+  UIWindow *mainWindow = RCTKeyWindow();
+  UIScreen *screen = mainWindow.screen;
+  if (screen == nil) {
+    screen = UIScreen.screens.firstObject;
+  }
+  CGSize screenSize = screen.bounds.size;
 
   // We fallback to screen size if a key window is not found.
-  CGSize windowSize = mainWindow ? mainWindow.bounds.size : screenSize;
+  CGSize windowSize = mainWindow != nil ? mainWindow.bounds.size : screenSize;
 
   NSDictionary<NSString *, NSNumber *> *dimsWindow = @{
     @"width" : @(windowSize.width),
     @"height" : @(windowSize.height),
-    @"scale" : @(mainScreen.scale),
+    @"scale" : @(screen.scale),
     @"fontScale" : @(fontScale)
   };
 
   NSDictionary<NSString *, NSNumber *> *dimsScreen = @{
     @"width" : @(screenSize.width),
     @"height" : @(screenSize.height),
-    @"scale" : @(mainScreen.scale),
+    @"scale" : @(screen.scale),
     @"fontScale" : @(fontScale)
   };
   return @{@"window" : dimsWindow, @"screen" : dimsScreen};
@@ -230,7 +233,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
   RCTAssert(_moduleRegistry, @"Failed to get exported dimensions: RCTModuleRegistry is nil");
   RCTAccessibilityManager *accessibilityManager =
       (RCTAccessibilityManager *)[_moduleRegistry moduleForName:"AccessibilityManager"];
-  // TOOD(T225745315): For some reason, accessibilityManager is nil in some cases.
+  // TODO(T225745315): For some reason, accessibilityManager is nil in some cases.
   // We default the fontScale to 1.0 in this case. This should be okay: if we assume
   // that accessibilityManager will eventually become available, js will eventually
   // be updated with the correct fontScale.

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -126,6 +126,12 @@ RCT_EXPORT_MODULE()
                                                name:RCTBridgeWillInvalidateModulesNotification
                                              object:nil];
 
+  [self invalidateCachedConstants];
+}
+
+- (void)invalidateCachedConstants
+{
+  RCTAssertMainQueue();
   _constants = @{
     @"Dimensions" : [self _exportedDimensions],
     // Note:
@@ -244,20 +250,24 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)didReceiveNewContentSizeMultiplier
 {
-  __weak __typeof(self) weakSelf = self;
+  [self invalidateCachedConstants];
+  NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
+
   RCTModuleRegistry *moduleRegistry = _moduleRegistry;
   RCTExecuteOnMainQueue(^{
   // Report the event across the bridge.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"didUpdateDimensions"
-                                                                         body:[weakSelf _exportedDimensions]];
+                                                                         body:nextInterfaceDimensions];
 #pragma clang diagnostic pop
   });
 }
 
 - (void)interfaceOrientationDidChange
 {
+  [self invalidateCachedConstants];
+
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   UIWindow *window = RCTKeyWindow();
   UIInterfaceOrientation nextOrientation = window.windowScene.interfaceOrientation;
@@ -279,8 +289,9 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
   if ((isOrientationChanging || isResizingOrChangingToFullscreen) && RCTIsAppActive()) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
     [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"didUpdateDimensions"
-                                                                          body:[self _exportedDimensions]];
+                                                                          body:nextInterfaceDimensions];
     // We only want to track the current _currentInterfaceOrientation and _isFullscreen only
     // when it happens and only when it is published.
     _currentInterfaceOrientation = nextOrientation;
@@ -300,7 +311,8 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)_interfaceFrameDidChange
 {
-  NSDictionary *nextInterfaceDimensions = [self _exportedDimensions];
+  [self invalidateCachedConstants];
+  NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
 
   // update and publish the even only when the app is in active state
   if (!([nextInterfaceDimensions isEqual:_currentInterfaceDimensions]) && RCTIsAppActive()) {

--- a/packages/react-native/React/CoreModules/RCTLogBoxView.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBoxView.mm
@@ -53,10 +53,6 @@
   [super layoutSubviews];
 }
 
-- (void)dealloc
-{
-}
-
 - (void)show
 {
   [self becomeFirstResponder];

--- a/packages/react-native/React/Profiler/RCTProfile.m
+++ b/packages/react-native/React/Profiler/RCTProfile.m
@@ -407,9 +407,7 @@ void RCTProfileUnhookModules(RCTBridge *bridge)
           };
       RCTProfileControlsWindow.hidden = YES;
       dispatch_async(dispatch_get_main_queue(), ^{
-        [[[[RCTSharedApplication() delegate] window] rootViewController] presentViewController:activityViewController
-                                                                                      animated:YES
-                                                                                    completion:nil];
+        [[RCTKeyWindow() rootViewController] presentViewController:activityViewController animated:YES completion:nil];
       });
 #else
       RCTProfileControlsWindow.hidden = NO;

--- a/packages/rn-tester/RCTTest/RCTTestRunner.m
+++ b/packages/rn-tester/RCTTest/RCTTestRunner.m
@@ -183,7 +183,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     }
     batchedBridge = [bridge batchedBridge];
 
-    UIViewController *vc = RCTSharedApplication().delegate.window.rootViewController;
+    UIViewController *vc = RCTKeyWindow().rootViewController;
     vc.view = [UIView new];
 
     RCTTestModule *testModule = [bridge moduleForClass:[RCTTestModule class]];

--- a/packages/rn-tester/RNTester/AppDelegate.h
+++ b/packages/rn-tester/RNTester/AppDelegate.h
@@ -5,22 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// ZERO-I: bare angle includes have no framework spelling, so the SPM zero-I
-// build uses the <React/...> form. rn-tester also builds via CocoaPods, where
-// only the bare form resolves — hence the dual. Single-mode consumers write
-// just the form matching their setup.
-#if __has_include(<React/RCTDefaultReactNativeFactoryDelegate.h>)
-#import <React/RCTDefaultReactNativeFactoryDelegate.h>
-#import <React/RCTReactNativeFactory.h>
-#else
-#import <RCTDefaultReactNativeFactoryDelegate.h>
-#import <RCTReactNativeFactory.h>
-#endif
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
-
-@property (nonatomic, strong, nonnull) UIWindow *window;
-@property (nonatomic, strong, nonnull) RCTReactNativeFactory *reactNativeFactory;
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @end

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -8,42 +8,12 @@
 #import "AppDelegate.h"
 
 #if !TARGET_OS_TV
+#import <React/RCTPushNotificationManager.h>
 #import <UserNotifications/UserNotifications.h>
 #endif
 
-#import <React/RCTBundleURLProvider.h>
-#import <React/RCTDefines.h>
-#import <React/RCTLinkingManager.h>
-#import <ReactCommon/RCTSampleTurboModule.h>
-#import <ReactCommon/RCTTurboModuleManager.h>
-
-#if !TARGET_OS_TV
-#import <React/RCTPushNotificationManager.h>
-#endif
-
-#import <NativeCxxModuleExample/NativeCxxModuleExample.h>
-#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
-#import <RNTMyNativeViewComponentView.h>
-#endif
-
-#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
-#else
-#define USE_OSS_CODEGEN 0
-#endif
-
-#if RCT_DEV_MENU
-#import <React/RCTDevMenu.h>
-#endif
-
-static NSString *kBundlePath = @"js/RNTesterApp.ios";
-
 #if !TARGET_OS_TV
 @interface AppDelegate () <UNUserNotificationCenterDelegate>
-@end
-#else
-@interface AppDelegate ()
 @end
 #endif
 
@@ -51,71 +21,10 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  self.reactNativeFactory = [[RCTReactNativeFactory alloc] initWithDelegate:self releaseLevel:[self releaseLevel]];
-#if USE_OSS_CODEGEN
-  self.dependencyProvider = [RCTAppDependencyProvider new];
-#endif
-
-#if RCT_DEV_MENU
-
-  RCTDevMenuConfiguration *devMenuConfiguration = [[RCTDevMenuConfiguration alloc] initWithDevMenuEnabled:true
-                                                                                      shakeGestureEnabled:true
-                                                                                 keyboardShortcutsEnabled:true];
-  [self.reactNativeFactory setDevMenuConfiguration:devMenuConfiguration];
-
-#endif
-
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-
-  [self.reactNativeFactory startReactNativeWithModuleName:@"RNTesterApp"
-                                                 inWindow:self.window
-                                        initialProperties:[self prepareInitialProps]
-                                            launchOptions:launchOptions];
-
 #if !TARGET_OS_TV
   [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
 #endif
-
   return YES;
-}
-
-- (RCTReleaseLevel)releaseLevel
-{
-  return RCTReleaseLevel::Stable;
-}
-
-- (NSDictionary *)prepareInitialProps
-{
-  NSMutableDictionary *initProps = [NSMutableDictionary new];
-
-  NSString *_routeUri = [[NSUserDefaults standardUserDefaults] stringForKey:@"route"];
-  if (_routeUri) {
-    initProps[@"exampleFromAppetizeParams"] = [NSString stringWithFormat:@"rntester://example/%@Example", _routeUri];
-  }
-
-  return initProps;
-}
-
-- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
-{
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
-}
-
-- (BOOL)application:(UIApplication *)app
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
-{
-  return [RCTLinkingManager application:app openURL:url options:options];
-}
-
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
-{
-  if (name == facebook::react::NativeCxxModuleExample::kModuleName) {
-    return std::make_shared<facebook::react::NativeCxxModuleExample>(jsInvoker);
-  }
-
-  return [super getTurboModule:name jsInvoker:jsInvoker];
 }
 
 #if !TARGET_OS_TV
@@ -163,26 +72,5 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   completionHandler();
 }
 #endif
-
-#pragma mark - RCTComponentViewFactoryComponentProvider
-
-#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
-- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
-{
-  NSMutableDictionary *dict = [super thirdPartyFabricComponents].mutableCopy;
-  if (!dict[@"RNTMyNativeView"]) {
-    dict[@"RNTMyNativeView"] = NSClassFromString(@"RNTMyNativeViewComponentView");
-  }
-  if (!dict[@"SampleNativeComponent"]) {
-    dict[@"SampleNativeComponent"] = NSClassFromString(@"RCTSampleNativeComponentComponentView");
-  }
-  return dict;
-}
-#endif
-
-- (NSURL *)bundleURL
-{
-  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
-}
 
 @end

--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -48,6 +48,23 @@
 	<string>You need to add NSPhotoLibraryUsageDescription key in Info.plist to enable photo library usage, otherwise it is going to *fail silently*!</string>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>RCTUseAssetCatalog</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.h
+++ b/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.h
@@ -8,6 +8,15 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTView.h>
+#import <React/RCTViewManager.h>
+
+@class RCTRootViewFactory;
+
+@interface FlexibleSizeExampleViewManager : RCTViewManager
+
+- (instancetype)initWithRootViewFactory:(RCTRootViewFactory *)rootViewFactory;
+
+@end
 
 @interface FlexibleSizeExampleView : RCTView
 

--- a/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.mm
+++ b/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.mm
@@ -7,29 +7,39 @@
 
 #import "FlexibleSizeExampleView.h"
 
+#if __has_include(<React/RCTRootViewFactory.h>)
+#import <React/RCTRootViewFactory.h>
+#else
+#import <RCTRootViewFactory.h>
+#endif
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
 #import <React/RCTRootViewDelegate.h>
-#import <React/RCTViewManager.h>
 
-#import "AppDelegate.h"
+@interface FlexibleSizeExampleView () <RCTRootViewDelegate>
 
-@interface FlexibleSizeExampleViewManager : RCTViewManager
+- (instancetype)initWithFrame:(CGRect)frame rootViewFactory:(RCTRootViewFactory *)rootViewFactory;
 
 @end
 
-@implementation FlexibleSizeExampleViewManager
+@implementation FlexibleSizeExampleViewManager {
+  RCTRootViewFactory *_rootViewFactory;
+}
 
 RCT_EXPORT_MODULE();
 
-- (UIView *)view
+- (instancetype)initWithRootViewFactory:(RCTRootViewFactory *)rootViewFactory
 {
-  return [FlexibleSizeExampleView new];
+  if ((self = [super init]) != nil) {
+    _rootViewFactory = rootViewFactory;
+  }
+  return self;
 }
 
-@end
-
-@interface FlexibleSizeExampleView () <RCTRootViewDelegate>
+- (UIView *)view
+{
+  return [[FlexibleSizeExampleView alloc] initWithFrame:CGRectZero rootViewFactory:_rootViewFactory];
+}
 
 @end
 
@@ -41,13 +51,15 @@ RCT_EXPORT_MODULE();
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
+  return [self initWithFrame:frame rootViewFactory:nil];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame rootViewFactory:(RCTRootViewFactory *)rootViewFactory
+{
   if ((self = [super initWithFrame:frame])) {
     _sizeUpdated = NO;
 
-    AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-
-    _resizableRootView = (RCTRootView *)[appDelegate.reactNativeFactory.rootViewFactory
-        viewWithModuleName:@"RootViewSizeFlexibilityExampleApp"];
+    _resizableRootView = (RCTRootView *)[rootViewFactory viewWithModuleName:@"RootViewSizeFlexibilityExampleApp"];
 
     [_resizableRootView setSizeFlexibility:RCTRootViewSizeFlexibilityHeight];
 

--- a/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.h
+++ b/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.h
@@ -8,6 +8,15 @@
 #import <UIKit/UIKit.h>
 
 #import <React/RCTView.h>
+#import <React/RCTViewManager.h>
+
+@class RCTRootViewFactory;
+
+@interface UpdatePropertiesExampleViewManager : RCTViewManager
+
+- (instancetype)initWithRootViewFactory:(RCTRootViewFactory *)rootViewFactory;
+
+@end
 
 @interface UpdatePropertiesExampleView : RCTView
 

--- a/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
+++ b/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
@@ -7,22 +7,36 @@
 
 #import "UpdatePropertiesExampleView.h"
 
+#if __has_include(<React/RCTRootViewFactory.h>)
+#import <React/RCTRootViewFactory.h>
+#else
+#import <RCTRootViewFactory.h>
+#endif
 #import <React/RCTRootView.h>
-#import <React/RCTViewManager.h>
 
-#import "AppDelegate.h"
+@interface UpdatePropertiesExampleView ()
 
-@interface UpdatePropertiesExampleViewManager : RCTViewManager
+- (instancetype)initWithFrame:(CGRect)frame rootViewFactory:(RCTRootViewFactory *)rootViewFactory;
 
 @end
 
-@implementation UpdatePropertiesExampleViewManager
+@implementation UpdatePropertiesExampleViewManager {
+  RCTRootViewFactory *_rootViewFactory;
+}
 
 RCT_EXPORT_MODULE();
 
+- (instancetype)initWithRootViewFactory:(RCTRootViewFactory *)rootViewFactory
+{
+  if ((self = [super init]) != nil) {
+    _rootViewFactory = rootViewFactory;
+  }
+  return self;
+}
+
 - (UIView *)view
 {
-  return [UpdatePropertiesExampleView new];
+  return [[UpdatePropertiesExampleView alloc] initWithFrame:CGRectZero rootViewFactory:_rootViewFactory];
 }
 
 @end
@@ -35,15 +49,17 @@ RCT_EXPORT_MODULE();
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
+  return [self initWithFrame:frame rootViewFactory:nil];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame rootViewFactory:(RCTRootViewFactory *)rootViewFactory
+{
   self = [super initWithFrame:frame];
   if (self) {
     _beige = YES;
 
-    AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-
-    _rootView =
-        (RCTRootView *)[appDelegate.reactNativeFactory.rootViewFactory viewWithModuleName:@"SetPropertiesExampleApp"
-                                                                        initialProperties:@{@"color" : @"beige"}];
+    _rootView = (RCTRootView *)[rootViewFactory viewWithModuleName:@"SetPropertiesExampleApp"
+                                                 initialProperties:@{@"color" : @"beige"}];
 
     _button = [UIButton buttonWithType:UIButtonTypeRoundedRect];
     [_button setTitle:@"Native Button" forState:UIControlStateNormal];

--- a/packages/rn-tester/RNTester/SceneDelegate.h
+++ b/packages/rn-tester/RNTester/SceneDelegate.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if __has_include(<React/RCTDefaultReactNativeFactoryDelegate.h>)
+#import <React/RCTDefaultReactNativeFactoryDelegate.h>
+#import <React/RCTReactNativeFactory.h>
+#else
+#import <RCTDefaultReactNativeFactoryDelegate.h>
+#import <RCTReactNativeFactory.h>
+#endif
+#import <UIKit/UIKit.h>
+
+@interface SceneDelegate : RCTDefaultReactNativeFactoryDelegate <UIWindowSceneDelegate>
+
+@property (nonatomic, strong, nullable) UIWindow *window;
+@property (nonatomic, strong, nullable) RCTReactNativeFactory *reactNativeFactory;
+
+- (NSDictionary *)prepareInitialProps;
+
+@end

--- a/packages/rn-tester/RNTester/SceneDelegate.mm
+++ b/packages/rn-tester/RNTester/SceneDelegate.mm
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "SceneDelegate.h"
+
+#import "NativeExampleViews/FlexibleSizeExampleView.h"
+#import "NativeExampleViews/UpdatePropertiesExampleView.h"
+
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTDefines.h>
+#import <React/RCTLinkingManager.h>
+#import <ReactCommon/RCTSampleTurboModule.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <NativeCxxModuleExample/NativeCxxModuleExample.h>
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+#import <RNTMyNativeViewComponentView.h>
+#endif
+
+#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
+#endif
+
+#if RCT_DEV_MENU
+#import <React/RCTDevMenu.h>
+#endif
+
+static NSString *const kBundlePath = @"js/RNTesterApp.ios";
+
+@implementation SceneDelegate
+
+- (NSDictionary *)prepareInitialProps
+{
+  NSMutableDictionary *initProps = [NSMutableDictionary dictionary];
+  NSString *routeUri = [[NSUserDefaults standardUserDefaults] stringForKey:@"route"];
+  if (routeUri != nil) {
+    NSString *example = [NSString stringWithFormat:@"rntester://example/%@Example", routeUri];
+    initProps[@"exampleFromAppetizeParams"] = example;
+  }
+  return [initProps copy];
+}
+
+- (void)scene:(UIScene *)scene
+    willConnectToSession:(UISceneSession *)session
+                 options:(UISceneConnectionOptions *)connectionOptions
+{
+  if (![scene isKindOfClass:[UIWindowScene class]]) {
+    return;
+  }
+
+#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
+  self.dependencyProvider = [[RCTAppDependencyProvider alloc] init];
+#endif
+
+  self.reactNativeFactory = [[RCTReactNativeFactory alloc] initWithDelegate:self releaseLevel:[self releaseLevel]];
+
+  auto *windowScene = (UIWindowScene *)scene;
+  self.window = [[UIWindow alloc] initWithWindowScene:windowScene];
+
+  [self.reactNativeFactory startReactNativeWithModuleName:@"RNTesterApp"
+                                                 inWindow:self.window
+                                        initialProperties:[self prepareInitialProps]
+                                        connectionOptions:connectionOptions];
+
+#if RCT_DEV_MENU
+  RCTDevMenuConfiguration *devMenuConfiguration = [[RCTDevMenuConfiguration alloc] initWithDevMenuEnabled:true
+                                                                                      shakeGestureEnabled:true
+                                                                                 keyboardShortcutsEnabled:true];
+  [self.reactNativeFactory setDevMenuConfiguration:devMenuConfiguration];
+#endif
+}
+
+- (RCTReleaseLevel)releaseLevel
+{
+  return RCTReleaseLevel::Stable;
+}
+
+- (void)scene:(UIScene *)scene openURLContexts:(NSSet<UIOpenURLContext *> *)URLContexts
+{
+  [RCTLinkingManager scene:scene openURLContexts:URLContexts];
+}
+
+- (void)scene:(UIScene *)scene continueUserActivity:(NSUserActivity *)userActivity
+{
+  [RCTLinkingManager scene:scene continueUserActivity:userActivity];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+  return [self bundleURL];
+}
+
+- (NSURL *)bundleURL
+{
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  if (name == facebook::react::NativeCxxModuleExample::kModuleName) {
+    return std::make_shared<facebook::react::NativeCxxModuleExample>(jsInvoker);
+  }
+
+  return [super getTurboModule:name jsInvoker:jsInvoker];
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(__unused RCTBridge *)bridge
+{
+  return @[
+    [[FlexibleSizeExampleViewManager alloc] initWithRootViewFactory:self.reactNativeFactory.rootViewFactory],
+    [[UpdatePropertiesExampleViewManager alloc] initWithRootViewFactory:self.reactNativeFactory.rootViewFactory],
+  ];
+}
+
+#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
+- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
+{
+  NSMutableDictionary *dict = [super thirdPartyFabricComponents].mutableCopy;
+  if (!dict[@"RNTMyNativeView"]) {
+    dict[@"RNTMyNativeView"] = NSClassFromString(@"RNTMyNativeViewComponentView");
+  }
+  if (!dict[@"SampleNativeComponent"]) {
+    dict[@"SampleNativeComponent"] = NSClassFromString(@"RCTSampleNativeComponentComponentView");
+  }
+  return dict;
+}
+#endif
+
+@end

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3F4D148C63BBF774A25488A6 /* libPods-RNTesterIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 93A243F0D4D5C54911E811C4 /* libPods-RNTesterIntegrationTests.a */; };
 		46C0FD761B0B9B1E8662B759 /* libPods-RNTesterUnitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B312B0EEE90BA411618B015 /* libPods-RNTesterUnitTests.a */; };
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
+		79B29C2E2E607A99007612A5 /* SceneDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 79B29C2D2E607A99007612A5 /* SceneDelegate.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
 		832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */; };
 		A975CA6C2C05EADF0043F72A /* RCTNetworkTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A975CA6B2C05EADE0043F72A /* RCTNetworkTaskTests.m */; };
@@ -92,6 +93,8 @@
 		4C706D402EE4AF9BE838CBA9 /* libPods-RNTester.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTester.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		51BC9297B6C3163C14532020 /* Pods-RNTester.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTester.release.xcconfig"; path = "Target Support Files/Pods-RNTester/Pods-RNTester.release.xcconfig"; sourceTree = "<group>"; };
 		5C60EB1B226440DB0018C04F /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = RNTester/AppDelegate.mm; sourceTree = "<group>"; };
+		79B29C2C2E607A99007612A5 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SceneDelegate.h; path = RNTester/SceneDelegate.h; sourceTree = "<group>"; };
+		79B29C2D2E607A99007612A5 /* SceneDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SceneDelegate.mm; path = RNTester/SceneDelegate.mm; sourceTree = "<group>"; };
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftTest.swift; path = RNTester/SwiftTest.swift; sourceTree = "<group>"; };
 		93A243F0D4D5C54911E811C4 /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +211,8 @@
 				E771AEEA22B44E3100EA1189 /* Info.plist */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				5C60EB1B226440DB0018C04F /* AppDelegate.mm */,
+				79B29C2C2E607A99007612A5 /* SceneDelegate.h */,
+				79B29C2D2E607A99007612A5 /* SceneDelegate.mm */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */,
 				2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */,
@@ -729,6 +734,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E62F11842A5C6584000BF1C8 /* UpdatePropertiesExampleView.mm in Sources */,
+				79B29C2E2E607A99007612A5 /* SceneDelegate.mm in Sources */,
 				E62F11832A5C6580000BF1C8 /* FlexibleSizeExampleView.mm in Sources */,
 				832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */,
 				5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */,

--- a/private/helloworld/Gemfile.lock
+++ b/private/helloworld/Gemfile.lock
@@ -98,6 +98,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
+  base64
   benchmark
   bigdecimal
   cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
@@ -105,6 +106,7 @@ DEPENDENCIES
   ffi (>= 1.17.2)
   logger
   mutex_m
+  nkf
   rexml (>= 3.3.9)
   xcodeproj (< 1.26.0)
 

--- a/private/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/private/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -11,9 +11,10 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		6EA01F72FAC10D00AECACF94 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0EC7AB76F90EED035707BA4E /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		C5E681697D864CB241D83EFA /* libPods-HelloWorld-HelloWorldTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A8E5ECDA77F0C61C263AE4C /* libPods-HelloWorld-HelloWorldTests.a */; };
 		CDA0ED1A2D0B2D810079F561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA0ED192D0B2D810079F561 /* AppDelegate.swift */; };
-		D462E9F4436EDF91C8A1FA0A /* Pods_HelloWorld.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */; };
-		D693EA25CB545D6C1C7F8538 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */; };
+		CDA0ED1B2D0B2D810079F562 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA0ED1C2D0B2D810079F562 /* SceneDelegate.swift */; };
+		F139D3B2B0DB3E81C6EC8497 /* libPods-HelloWorld.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E4454510AD252A40B7E239F /* libPods-HelloWorld.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,13 +37,14 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = HelloWorld/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		3B4392A12AC88292D35C810B /* Pods-HelloWorld.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.debug.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.debug.xcconfig"; sourceTree = "<group>"; };
+		3E4454510AD252A40B7E239F /* libPods-HelloWorld.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HelloWorld.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		5709B34CF0A7D63546082F79 /* Pods-HelloWorld.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.release.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-HelloWorld-HelloWorldTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld-HelloWorldTests.debug.xcconfig"; path = "Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests.debug.xcconfig"; sourceTree = "<group>"; };
-		7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld_HelloWorldTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7A8E5ECDA77F0C61C263AE4C /* libPods-HelloWorld-HelloWorldTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-HelloWorld-HelloWorldTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = HelloWorld/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-HelloWorld-HelloWorldTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld-HelloWorldTests.release.xcconfig"; path = "Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests.release.xcconfig"; sourceTree = "<group>"; };
-		B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDA0ED192D0B2D810079F561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		CDA0ED1C2D0B2D810079F562 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -51,7 +53,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D693EA25CB545D6C1C7F8538 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */,
+				C5E681697D864CB241D83EFA /* libPods-HelloWorld-HelloWorldTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +61,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D462E9F4436EDF91C8A1FA0A /* Pods_HelloWorld.framework in Frameworks */,
+				F139D3B2B0DB3E81C6EC8497 /* libPods-HelloWorld.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +94,7 @@
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
 				0EC7AB76F90EED035707BA4E /* PrivacyInfo.xcprivacy */,
 				CDA0ED192D0B2D810079F561 /* AppDelegate.swift */,
+				CDA0ED1C2D0B2D810079F562 /* SceneDelegate.swift */,
 			);
 			name = HelloWorld;
 			sourceTree = "<group>";
@@ -100,8 +103,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */,
-				7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */,
+				3E4454510AD252A40B7E239F /* libPods-HelloWorld.a */,
+				7A8E5ECDA77F0C61C263AE4C /* libPods-HelloWorld-HelloWorldTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -395,6 +398,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDA0ED1A2D0B2D810079F561 /* AppDelegate.swift in Sources */,
+				CDA0ED1B2D0B2D810079F562 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -588,6 +592,10 @@
 				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -595,9 +603,14 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../react-native";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				PODFILE_DIR = "$(SRCROOT)";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../packages/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				USE_HERMES = true;
@@ -668,6 +681,10 @@
 					"\"$(inherited)\"",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -675,9 +692,14 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
-				OTHER_LDFLAGS = "$(inherited)  ";
-				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../react-native";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
+				PODFILE_DIR = "$(SRCROOT)";
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../../../packages/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;

--- a/private/helloworld/ios/HelloWorld/AppDelegate.swift
+++ b/private/helloworld/ios/HelloWorld/AppDelegate.swift
@@ -5,56 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React
-import ReactAppDependencyProvider
-import React_RCTAppDelegate
 import UIKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-  var window: UIWindow?
-
-  var reactNativeDelegate: ReactNativeDelegate?
-  var reactNativeFactory: RCTReactNativeFactory?
-
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    let delegate = ReactNativeDelegate()
-    let factory = RCTReactNativeFactory(delegate: delegate)
-    delegate.dependencyProvider = RCTAppDependencyProvider()
-
-    reactNativeDelegate = delegate
-    reactNativeFactory = factory
-
-    #if DEBUG
-    let devMenuConfiguration = RCTDevMenuConfiguration(
-      devMenuEnabled: true,
-      shakeGestureEnabled: true,
-      keyboardShortcutsEnabled: true
-    )
-    reactNativeFactory?.devMenuConfiguration = devMenuConfiguration
-    #endif
-
-    window = UIWindow(frame: UIScreen.main.bounds)
-
-    factory.startReactNative(
-      withModuleName: "HelloWorld",
-      in: window,
-      launchOptions: launchOptions
-    )
-
-    return true
-  }
-}
-
-class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
-  override func bundleURL() -> URL? {
-    #if DEBUG
-    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
-    #else
-    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
-    #endif
+    true
   }
 }

--- a/private/helloworld/ios/HelloWorld/Info.plist
+++ b/private/helloworld/ios/HelloWorld/Info.plist
@@ -34,6 +34,21 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>RCTUseAssetCatalog</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/private/helloworld/ios/HelloWorld/SceneDelegate.swift
+++ b/private/helloworld/ios/HelloWorld/SceneDelegate.swift
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React
+import ReactAppDependencyProvider
+import React_RCTAppDelegate
+import UIKit
+
+class SceneDelegate: RCTDefaultReactNativeFactoryDelegate, UIWindowSceneDelegate {
+  var window: UIWindow?
+  var reactNativeFactory: RCTReactNativeFactory?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else {
+      return
+    }
+
+    dependencyProvider = RCTAppDependencyProvider()
+    reactNativeFactory = RCTReactNativeFactory(delegate: self)
+    window = UIWindow(windowScene: windowScene)
+
+    reactNativeFactory?.startReactNative(
+      withModuleName: "HelloWorld",
+      in: window,
+      connectionOptions: connectionOptions
+    )
+
+  }
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    RCTLinkingManager.scene(scene, openURLContexts: URLContexts)
+  }
+
+  func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+    RCTLinkingManager.scene(scene, continue: userActivity)
+  }
+
+  override func bundleURL() -> URL? {
+    #if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+    #else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+    #endif
+  }
+}

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -637,8 +637,6 @@ interface RCTAnimatedNode : public NSObject {
 
 interface RCTAppDelegate : public RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate> {
   public @property (assign) BOOL automaticallyLoadReactNativeWindow;
-  public @property (assign) RCTBridge* bridge;
-  public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) NSDictionary* initialProps;
   public @property (strong) NSString* moduleName;
   public @property (strong) RCTReactNativeFactory* reactNativeFactory;
@@ -1365,6 +1363,8 @@ interface RCTLinkingManager : public RCTEventEmitter {
   public virtual static BOOL application:continueUserActivity:restorationHandler:(_Nonnull UIApplication* application, _Nonnull NSUserActivity* userActivity, _Nonnull void(^)(NSArray<id<UIUserActivityRestoring>>* _Nullable) restorationHandler);
   public virtual static BOOL application:openURL:options:(_Nonnull UIApplication* app, _Nonnull NSURL* URL, _Nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id>* options);
   public virtual static BOOL application:openURL:sourceApplication:annotation:(_Nonnull UIApplication* application, _Nonnull NSURL* URL, _Nullable NSString* sourceApplication, _Nonnull id annotation);
+  public virtual static void scene:continueUserActivity:(_Nonnull UIScene* scene, _Nonnull NSUserActivity* userActivity);
+  public virtual static void scene:openURLContexts:(_Nonnull UIScene* scene, _Nonnull NSSet<UIOpenURLContext*>* URLContexts);
 }
 
 interface RCTLoadingProgress : public NSObject {
@@ -1589,14 +1589,16 @@ interface RCTRadialGradient : public NSObject {
 }
 
 interface RCTReactNativeFactory : public NSObject {
+  public @property (assign) RCTBridge* bridge;
   public @property (assign) RCTDevMenuConfiguration* devMenuConfiguration;
-  public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) RCTBundleConfiguration* bundleConfiguration;
   public @property (strong) RCTRootViewFactory* rootViewFactory;
   public @property (weak) id<RCTReactNativeFactoryDelegate> delegate;
   public virtual instancetype initWithDelegate:(id<RCTReactNativeFactoryDelegate> delegate);
   public virtual instancetype initWithDelegate:releaseLevel:(id<RCTReactNativeFactoryDelegate> delegate, RCTReleaseLevel releaseLevel);
   public virtual void startReactNativeWithModuleName:inWindow:(NSString* moduleName, UIWindow* _Nullable window);
+  public virtual void startReactNativeWithModuleName:inWindow:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, UISceneConnectionOptions* _Nullable connectionOptions);
+  public virtual void startReactNativeWithModuleName:inWindow:initialProperties:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, UISceneConnectionOptions* _Nullable connectionOptions);
   public virtual void startReactNativeWithModuleName:inWindow:initialProperties:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, NSDictionary* _Nullable launchOptions);
   public virtual void startReactNativeWithModuleName:inWindow:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable launchOptions);
 }
@@ -1661,9 +1663,7 @@ interface RCTRootView : public UIView {
 }
 
 interface RCTRootViewFactory : public NSObject {
-  public @property (strong) RCTBridge* bridge;
   public @property (strong) RCTHost* reactHost;
-  public @property (strong) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public virtual RCTHost* createReactHost:(NSDictionary* _Nullable launchOptions);
   public virtual RCTHost* createReactHost:bundleConfiguration:devMenuConfiguration:(NSDictionary* _Nullable launchOptions, RCTBundleConfiguration* bundleConfiguration, RCTDevMenuConfiguration* devMenuConfiguration);
   public virtual UIView* _Nonnull viewWithModuleName:(NSString* moduleName);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1363,6 +1363,8 @@ interface RCTLinkingManager : public RCTEventEmitter {
   public virtual static BOOL application:continueUserActivity:restorationHandler:(_Nonnull UIApplication* application, _Nonnull NSUserActivity* userActivity, _Nonnull void(^)(NSArray<id<UIUserActivityRestoring>>* _Nullable) restorationHandler);
   public virtual static BOOL application:openURL:options:(_Nonnull UIApplication* app, _Nonnull NSURL* URL, _Nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id>* options);
   public virtual static BOOL application:openURL:sourceApplication:annotation:(_Nonnull UIApplication* application, _Nonnull NSURL* URL, _Nullable NSString* sourceApplication, _Nonnull id annotation);
+  public virtual static void scene:continueUserActivity:(_Nonnull UIScene* scene, _Nonnull NSUserActivity* userActivity);
+  public virtual static void scene:openURLContexts:(_Nonnull UIScene* scene, _Nonnull NSSet<UIOpenURLContext*>* URLContexts);
 }
 
 interface RCTLoadingProgress : public NSObject {
@@ -1594,6 +1596,8 @@ interface RCTReactNativeFactory : public NSObject {
   public virtual instancetype initWithDelegate:(id<RCTReactNativeFactoryDelegate> delegate);
   public virtual instancetype initWithDelegate:releaseLevel:(id<RCTReactNativeFactoryDelegate> delegate, RCTReleaseLevel releaseLevel);
   public virtual void startReactNativeWithModuleName:inWindow:(NSString* moduleName, UIWindow* _Nullable window);
+  public virtual void startReactNativeWithModuleName:inWindow:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, UISceneConnectionOptions* _Nullable connectionOptions);
+  public virtual void startReactNativeWithModuleName:inWindow:initialProperties:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, UISceneConnectionOptions* _Nullable connectionOptions);
   public virtual void startReactNativeWithModuleName:inWindow:initialProperties:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, NSDictionary* _Nullable launchOptions);
   public virtual void startReactNativeWithModuleName:inWindow:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable launchOptions);
 }

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -637,8 +637,6 @@ interface RCTAnimatedNode : public NSObject {
 
 interface RCTAppDelegate : public RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate> {
   public @property (assign) BOOL automaticallyLoadReactNativeWindow;
-  public @property (assign) RCTBridge* bridge;
-  public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) NSDictionary* initialProps;
   public @property (strong) NSString* moduleName;
   public @property (strong) RCTReactNativeFactory* reactNativeFactory;
@@ -1365,6 +1363,8 @@ interface RCTLinkingManager : public RCTEventEmitter {
   public virtual static BOOL application:continueUserActivity:restorationHandler:(_Nonnull UIApplication* application, _Nonnull NSUserActivity* userActivity, _Nonnull void(^)(NSArray<id<UIUserActivityRestoring>>* _Nullable) restorationHandler);
   public virtual static BOOL application:openURL:options:(_Nonnull UIApplication* app, _Nonnull NSURL* URL, _Nonnull NSDictionary<UIApplicationOpenURLOptionsKey, id>* options);
   public virtual static BOOL application:openURL:sourceApplication:annotation:(_Nonnull UIApplication* application, _Nonnull NSURL* URL, _Nullable NSString* sourceApplication, _Nonnull id annotation);
+  public virtual static void scene:continueUserActivity:(_Nonnull UIScene* scene, _Nonnull NSUserActivity* userActivity);
+  public virtual static void scene:openURLContexts:(_Nonnull UIScene* scene, _Nonnull NSSet<UIOpenURLContext*>* URLContexts);
 }
 
 interface RCTLoadingProgress : public NSObject {
@@ -1589,14 +1589,16 @@ interface RCTRadialGradient : public NSObject {
 }
 
 interface RCTReactNativeFactory : public NSObject {
+  public @property (assign) RCTBridge* bridge;
   public @property (assign) RCTDevMenuConfiguration* devMenuConfiguration;
-  public @property (assign) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public @property (strong) RCTBundleConfiguration* bundleConfiguration;
   public @property (strong) RCTRootViewFactory* rootViewFactory;
   public @property (weak) id<RCTReactNativeFactoryDelegate> delegate;
   public virtual instancetype initWithDelegate:(id<RCTReactNativeFactoryDelegate> delegate);
   public virtual instancetype initWithDelegate:releaseLevel:(id<RCTReactNativeFactoryDelegate> delegate, RCTReleaseLevel releaseLevel);
   public virtual void startReactNativeWithModuleName:inWindow:(NSString* moduleName, UIWindow* _Nullable window);
+  public virtual void startReactNativeWithModuleName:inWindow:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, UISceneConnectionOptions* _Nullable connectionOptions);
+  public virtual void startReactNativeWithModuleName:inWindow:initialProperties:connectionOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, UISceneConnectionOptions* _Nullable connectionOptions);
   public virtual void startReactNativeWithModuleName:inWindow:initialProperties:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable initialProperties, NSDictionary* _Nullable launchOptions);
   public virtual void startReactNativeWithModuleName:inWindow:launchOptions:(NSString* moduleName, UIWindow* _Nullable window, NSDictionary* _Nullable launchOptions);
 }
@@ -1661,9 +1663,7 @@ interface RCTRootView : public UIView {
 }
 
 interface RCTRootViewFactory : public NSObject {
-  public @property (strong) RCTBridge* bridge;
   public @property (strong) RCTHost* reactHost;
-  public @property (strong) RCTSurfacePresenterBridgeAdapter* bridgeAdapter;
   public virtual RCTHost* createReactHost:(NSDictionary* _Nullable launchOptions);
   public virtual RCTHost* createReactHost:bundleConfiguration:devMenuConfiguration:(NSDictionary* _Nullable launchOptions, RCTBundleConfiguration* bundleConfiguration, RCTDevMenuConfiguration* devMenuConfiguration);
   public virtual UIView* _Nonnull viewWithModuleName:(NSString* moduleName);


### PR DESCRIPTION
Summary:

Add SceneDelegate lifecycle support to React Native iOS while retaining the AppDelegate path for backwards compatibility.

Update linking, window resolution, bootstrap APIs, RNTester, HelloWorld, and generated API snapshots for scene-based applications.

Changelog:
[iOS][Added] - Add SceneDelegate lifecycle support

Test Plan:
- `buck2 build --flagfile fbsource//fbobjc/mode/buck2/linux --config fbobjc.react_native_debug=development --flagfile fbsource//fbobjc/mode/iphonesimulator-arm64 --flagfile fbsource//fbobjc/mode/jest-coverage --config xplat.available_platforms=CXX,APPLE --config cxx.default_platform=iphonesimulator-arm64 --config user.sandcastle_build_mode=profile --config user.platform_flavor=iphonesimulator-arm64 //xplat/js/react-native-github/packages/rn-tester:RNTesterIOS`
- `xcodebuild -quiet -workspace RNTesterPods.xcworkspace -scheme RNTester -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `arc lint`
- Evaluate RNTester with the `RNTester` SceneDelegate scheme.
- Evaluate RNTester with the `RNTester (AppDelegate)` legacy scheme.
- Verify HelloWorld bootstrap and deep linking.

Reviewed By: cortinico, javache

Differential Revision: D113758228

Pulled By: cipolleschi
