### PR TITLE
Make Blob/File/URL modules Flow strict-local (#57728)

### DIFF
--- a/packages/react-native/Libraries/Blob/File.js
+++ b/packages/react-native/Libraries/Blob/File.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
+
+// flowlint unsafe-getters-setters:off
 
 'use strict';
 

--- a/packages/react-native/Libraries/Blob/FileReader.js
+++ b/packages/react-native/Libraries/Blob/FileReader.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
+
+// flowlint unsafe-getters-setters:off
 
 import type {EventCallback} from '../../src/private/webapis/dom/events/EventTarget';
 import type Blob from './Blob';

--- a/packages/react-native/Libraries/Blob/URL.js
+++ b/packages/react-native/Libraries/Blob/URL.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
+
+// flowlint unsafe-getters-setters:off
 
 import type Blob from './Blob';
 
@@ -79,6 +81,7 @@ export class URL {
   // $FlowFixMe[missing-local-annot]
   constructor(url: string, base?: string | URL) {
     let baseUrl = null;
+    // $FlowFixMe[sketchy-null-string]
     if (!base || validateBaseUrl(url)) {
       this._url = url;
       if (this._url.includes('#')) {
@@ -112,13 +115,14 @@ export class URL {
       if (baseUrl.endsWith('/')) {
         baseUrl = baseUrl.slice(0, baseUrl.length - 1);
       }
-      if (!url.startsWith('/')) {
-        url = `/${url}`;
+      let path = url;
+      if (!path.startsWith('/')) {
+        path = `/${path}`;
       }
-      if (baseUrl.endsWith(url)) {
-        url = '';
+      if (baseUrl.endsWith(path)) {
+        path = '';
       }
-      this._url = `${baseUrl}${url}`;
+      this._url = `${baseUrl}${path}`;
     }
   }
 

--- a/packages/react-native/Libraries/Blob/URLSearchParams.js
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
+
+// flowlint unsafe-getters-setters:off
 
 // Small subset from whatwg-url: https://github.com/jsdom/whatwg-url/tree/master/src
 // The reference code bloat comes from Unicode issues with URLs, so those won't work here.

--- a/packages/react-native/Libraries/Blob/URLSearchParams.js.flow
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js.flow
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
@@ -4,46 +4,47 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   readonly getCurrentBoldTextState: (
     onSuccess: (isBoldTextEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentGrayscaleState: (
     onSuccess: (isGrayscaleEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentInvertColorsState: (
     onSuccess: (isInvertColorsEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentReduceMotionState: (
     onSuccess: (isReduceMotionEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentDarkerSystemColorsState?: (
     onSuccess: (isDarkerSystemColorsEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentPrefersCrossFadeTransitionsState?: (
     onSuccess: (prefersCrossFadeTransitions: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentReduceTransparencyState: (
     onSuccess: (isReduceTransparencyEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly getCurrentVoiceOverState: (
     onSuccess: (isScreenReaderEnabled: boolean) => void,
-    onError: (error: Object) => void,
+    onError: (error: UnsafeObject) => void,
   ) => void;
   readonly setAccessibilityContentSizeMultipliers: (JSMultipliers: {
     readonly extraSmall?: ?number,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeActionSheetManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeActionSheetManager.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -45,7 +46,7 @@ export interface Spec extends TurboModule {
     failureCallback: (error: {
       readonly domain: string,
       readonly code: string,
-      readonly userInfo?: ?Object,
+      readonly userInfo?: ?UnsafeObject,
       readonly message: string,
     }) => void,
     successCallback: (completed: boolean, activityType: ?string) => void,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAlertManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAlertManager.js
@@ -4,18 +4,19 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export type Args = {
   title?: string,
   message?: string,
-  buttons?: Array<Object>, // TODO(T67565166): have a better type
+  buttons?: Array<UnsafeObject>, // TODO(T67565166): have a better type
   type?: string,
   defaultValue?: string,
   cancelButtonKey?: string,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedModule.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import shouldUseTurboAnimatedModule from '../../../../Libraries/Animated/shouldUseTurboAnimatedModule';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
@@ -24,8 +25,8 @@ export type EventMapping = {
 
 // The config has different keys depending on the type of the Node
 // TODO(T54896888): Make these types strict
-export type AnimatedNodeConfig = Object;
-export type AnimatingNodeConfig = Object;
+export type AnimatedNodeConfig = UnsafeObject;
+export type AnimatingNodeConfig = UnsafeObject;
 
 export interface Spec extends TurboModule {
   readonly startOperationBatch: () => void;
@@ -66,7 +67,7 @@ export interface Spec extends TurboModule {
   ) => void;
   readonly connectAnimatedNodeToShadowNodeFamily?: (
     nodeTag: number,
-    shadowNode: Object,
+    shadowNode: UnsafeObject,
   ) => void;
   readonly disconnectAnimatedNodeFromView: (
     nodeTag: number,
@@ -91,7 +92,7 @@ export interface Spec extends TurboModule {
 
   // All of the above in a batched mode
   readonly queueAndExecuteBatchedOperations?: (
-    operationsAndArgs: Array<any>,
+    operationsAndArgs: Array<unknown>,
   ) => void;
 }
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedTurboModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedTurboModule.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import shouldUseTurboAnimatedModule from '../../../../Libraries/Animated/shouldUseTurboAnimatedModule';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
@@ -24,8 +25,8 @@ export type EventMapping = {
 
 // The config has different keys depending on the type of the Node
 // TODO(T54896888): Make these types strict
-export type AnimatedNodeConfig = Object;
-export type AnimatingNodeConfig = Object;
+export type AnimatedNodeConfig = UnsafeObject;
+export type AnimatingNodeConfig = UnsafeObject;
 
 export interface Spec extends TurboModule {
   readonly startOperationBatch: () => void;
@@ -87,7 +88,7 @@ export interface Spec extends TurboModule {
 
   // All of the above in a batched mode
   readonly queueAndExecuteBatchedOperations?: (
-    operationsAndArgs: Array<any>,
+    operationsAndArgs: Array<unknown>,
   ) => void;
 }
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAppState.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAppState.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -22,7 +23,7 @@ export interface Spec extends TurboModule {
   readonly getConstants: () => AppStateConstants;
   readonly getCurrentAppState: (
     success: (appState: AppState) => void,
-    error: (error: Object) => void,
+    error: (error: UnsafeObject) => void,
   ) => void;
 
   // Events

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeBlobModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeBlobModule.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -19,8 +20,11 @@ export interface Spec extends TurboModule {
   readonly addNetworkingHandler: () => void;
   readonly addWebSocketHandler: (id: number) => void;
   readonly removeWebSocketHandler: (id: number) => void;
-  readonly sendOverSocket: (blob: Object, socketID: number) => void;
-  readonly createFromParts: (parts: Array<Object>, withId: string) => void;
+  readonly sendOverSocket: (blob: UnsafeObject, socketID: number) => void;
+  readonly createFromParts: (
+    parts: Array<UnsafeObject>,
+    withId: string,
+  ) => void;
   readonly release: (blobId: string) => void;
 }
 
@@ -46,10 +50,10 @@ if (NativeModule != null) {
     removeWebSocketHandler(id: number): void {
       NativeModule.removeWebSocketHandler(id);
     },
-    sendOverSocket(blob: Object, socketID: number): void {
+    sendOverSocket(blob: UnsafeObject, socketID: number): void {
       NativeModule.sendOverSocket(blob, socketID);
     },
-    createFromParts(parts: Array<Object>, withId: string): void {
+    createFromParts(parts: Array<UnsafeObject>, withId: string): void {
       NativeModule.createFromParts(parts, withId);
     },
     release(blobId: string): void {

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeFileReaderModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeFileReaderModule.js
@@ -4,17 +4,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  readonly readAsDataURL: (data: Object) => Promise<string>;
-  readonly readAsText: (data: Object, encoding: string) => Promise<string>;
+  readonly readAsDataURL: (data: UnsafeObject) => Promise<string>;
+  readonly readAsText: (
+    data: UnsafeObject,
+    encoding: string,
+  ) => Promise<string>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImageLoaderAndroid.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImageLoaderAndroid.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -24,10 +25,10 @@ export interface Spec extends TurboModule {
   readonly getSize: (uri: string) => Promise<ImageSize>;
   readonly getSizeWithHeaders: (
     uri: string,
-    headers: Object,
+    headers: UnsafeObject,
   ) => Promise<ImageSize>;
   readonly prefetchImage: (uri: string, requestId: number) => Promise<boolean>;
-  readonly queryCache: (uris: Array<string>) => Promise<Object>;
+  readonly queryCache: (uris: Array<string>) => Promise<UnsafeObject>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('ImageLoader') as Spec;

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImageLoaderIOS.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImageLoaderIOS.js
@@ -4,12 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {RootTag} from '../../../../Libraries/TurboModule/RCTExport';
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -19,7 +20,7 @@ export interface Spec extends TurboModule {
   readonly getSize: (uri: string) => Promise<ReadonlyArray<number>>;
   readonly getSizeWithHeaders: (
     uri: string,
-    headers: Object,
+    headers: UnsafeObject,
   ) => Promise<{
     width: number,
     height: number,
@@ -31,7 +32,7 @@ export interface Spec extends TurboModule {
     queryRootName: string,
     rootTag: RootTag,
   ) => Promise<boolean>;
-  readonly queryCache: (uris: Array<string>) => Promise<Object>;
+  readonly queryCache: (uris: Array<string>) => Promise<UnsafeObject>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('ImageLoader') as Spec;

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeNetworkingAndroid.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeNetworkingAndroid.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -20,7 +21,7 @@ export interface Spec extends TurboModule {
     url: string,
     requestId: number,
     headers: Array<Header>,
-    data: Object,
+    data: UnsafeObject,
     responseType: string,
     useIncrementalUpdates: boolean,
     timeout: number,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeNetworkingIOS.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeNetworkingIOS.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -17,8 +18,8 @@ export interface Spec extends TurboModule {
     query: {
       method: string,
       url: string,
-      data: Object,
-      headers: Object,
+      data: UnsafeObject,
+      headers: UnsafeObject,
       responseType: string,
       incrementalUpdates: boolean,
       timeout: number,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativePushNotificationManagerIOS.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativePushNotificationManagerIOS.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -21,7 +22,7 @@ type Permissions = {
 type Notification = {
   readonly alertTitle?: ?string,
   readonly alertBody?: ?string,
-  readonly userInfo?: ?Object,
+  readonly userInfo?: ?UnsafeObject,
   /**
    * Identifier for the notification category. See the [Apple documentation](https://developer.apple.com/documentation/usernotifications/declaring_your_actionable_notification_types)
    * for more details.
@@ -85,7 +86,7 @@ export interface Spec extends TurboModule {
   readonly presentLocalNotification: (notification: Notification) => void;
   readonly scheduleLocalNotification: (notification: Notification) => void;
   readonly cancelAllLocalNotifications: () => void;
-  readonly cancelLocalNotifications: (userInfo: Object) => void;
+  readonly cancelLocalNotifications: (userInfo: UnsafeObject) => void;
   readonly getInitialNotification: () => Promise<?Notification>;
   readonly getScheduledLocalNotifications: (
     callback: (notification: Notification) => void,

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeRedBox.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeRedBox.js
@@ -4,16 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  readonly setExtraData: (extraData: Object, forIdentifier: string) => void;
+  readonly setExtraData: (
+    extraData: UnsafeObject,
+    forIdentifier: string,
+  ) => void;
   readonly dismiss: () => void;
 }
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSampleTurboModule.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
@@ -46,21 +46,21 @@ export interface Spec extends TurboModule {
   readonly getEnum?: (arg: EnumInt) => EnumInt;
   readonly getNumber: (arg: number) => number;
   readonly getString: (arg: string) => string;
-  readonly getArray: (arg: Array<any>) => Array<any>;
-  readonly getObject: (arg: Object) => Object;
+  readonly getArray: (arg: Array<unknown>) => Array<unknown>;
+  readonly getObject: (arg: UnsafeObject) => UnsafeObject;
   readonly getUnsafeObject: (arg: UnsafeObject) => UnsafeObject;
   readonly getRootTag: (arg: RootTag) => RootTag;
-  readonly getValue: (x: number, y: string, z: Object) => Object;
+  readonly getValue: (x: number, y: string, z: UnsafeObject) => UnsafeObject;
   readonly getArrayBuffer: (buffer: ArrayBuffer) => ArrayBuffer;
   readonly createNativeBuffer: (size: number) => ArrayBuffer;
   readonly processAsyncBuffer: (payload: ArrayBuffer) => Promise<number>;
   readonly getValueWithCallback: (callback: (value: string) => void) => void;
   readonly getValueWithPromise: (error: boolean) => Promise<string>;
   readonly voidFuncThrows?: () => void;
-  readonly getObjectThrows?: (arg: Object) => Object;
+  readonly getObjectThrows?: (arg: UnsafeObject) => UnsafeObject;
   readonly promiseThrows?: () => Promise<void>;
   readonly voidFuncAssert?: () => void;
-  readonly getObjectAssert?: (arg: Object) => Object;
+  readonly getObjectAssert?: (arg: UnsafeObject) => UnsafeObject;
   readonly promiseAssert?: () => Promise<void>;
 
   // Android-only

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSettingsManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeSettingsManager.js
@@ -4,19 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
   readonly getConstants: () => {
-    settings: Object,
+    settings: UnsafeObject,
   };
-  readonly setValues: (values: Object) => void;
+  readonly setValues: (values: UnsafeObject) => void;
   readonly deleteValues: (values: Array<string>) => void;
 }
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeWebSocketModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeWebSocketModule.js
@@ -4,11 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -17,7 +18,7 @@ export interface Spec extends TurboModule {
     url: string,
     protocols: ?Array<string>,
     options: {
-      headers?: Object,
+      headers?: UnsafeObject,
       unstable_devToolsRequestId?: string,
     },
     socketID: number,

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -2506,7 +2506,7 @@ protocol NativeRedBoxSpec : public NSObjectRCTBridgeModule, public RCTTurboModul
 }
 
 protocol NativeSampleTurboModuleSpec : public NSObjectRCTBridgeModule, public RCTTurboModule {
-  public virtual NSArray<id<NSObject>>* getArray:(NSArray* arg);
+  public virtual NSArray<NSDictionary*>* getArray:(NSArray* arg);
   public virtual NSDictionary* getObject:(NSDictionary* arg);
   public virtual NSDictionary* getObjectAssert:(NSDictionary* arg);
   public virtual NSDictionary* getObjectThrows:(NSDictionary* arg);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -2499,7 +2499,7 @@ protocol NativeRedBoxSpec : public NSObjectRCTBridgeModule, public RCTTurboModul
 }
 
 protocol NativeSampleTurboModuleSpec : public NSObjectRCTBridgeModule, public RCTTurboModule {
-  public virtual NSArray<id<NSObject>>* getArray:(NSArray* arg);
+  public virtual NSArray<NSDictionary*>* getArray:(NSArray* arg);
   public virtual NSDictionary* getObject:(NSDictionary* arg);
   public virtual NSDictionary* getObjectAssert:(NSDictionary* arg);
   public virtual NSDictionary* getObjectThrows:(NSDictionary* arg);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -2506,7 +2506,7 @@ protocol NativeRedBoxSpec : public NSObjectRCTBridgeModule, public RCTTurboModul
 }
 
 protocol NativeSampleTurboModuleSpec : public NSObjectRCTBridgeModule, public RCTTurboModule {
-  public virtual NSArray<id<NSObject>>* getArray:(NSArray* arg);
+  public virtual NSArray<NSDictionary*>* getArray:(NSArray* arg);
   public virtual NSDictionary* getObject:(NSDictionary* arg);
   public virtual NSDictionary* getObjectAssert:(NSDictionary* arg);
   public virtual NSDictionary* getObjectThrows:(NSDictionary* arg);


### PR DESCRIPTION
Summary:

Upgrade the Blob-related modules (`File`, `FileReader`, `URL`, `URLSearchParams`) from `flow` to `flow strict-local`. These expose spec-mandated getters/setters, so they opt out of the `unsafe-getters-setters` lint with a scoped `// flowlint unsafe-getters-setters:off` directive. `URL` also received small behavior-preserving refactors (local variables instead of parameter reassignment, explicit null/empty checks).

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D113763778
