### PR TITLE
Enable Perfetto by default for Android dev builds

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.cpp
@@ -119,6 +119,8 @@ void JavaNativeModule::invoke(
         if (callId != -1) {
           fbsystrace_end_async_flow(TRACE_TAG_REACT, "native", callId);
         }
+#else
+        (void)callId;
 #endif
         invokeMethod(
             wrapper_,


### PR DESCRIPTION
Summary:
Perfetto tracing in `reactperflogger` previously required an explicit build
modifier to turn on, so ordinary Android development builds never had it.

Introduce a shared `if_perfetto(on, off)` helper (`reactperflogger/DEFS.bzl`)
that derives the Perfetto decision from build configuration: on by default for
non-optimized Android builds, while optimized builds still require the explicit
`perfetto` constraint so tracing stays out of release binaries. arvr/Horizon
builds are excluded via `hz_tracing:perfetto-enable` — the same signal
reactperflogger already keys on — because those builds manage Perfetto through
their own `hz_tracing` stack (resolved at the final binary), so a standalone RN
`.so` compiling `WITH_PERFETTO` there fails to link.

The Android `BuildConfig.ENABLE_PERFETTO` runtime gate and the other native
Perfetto consumers are routed through the same helper so the default is
consistent end-to-end. The now-orphaned `enable_perfetto` config_setting is
removed.

Changelog:
[Internal]

Differential Revision: D114210766
