### PR TITLE
fix: remove dead promise polyfill import from polyfillPromise.js

### DIFF
--- a/packages/react-native/Libraries/Core/polyfillPromise.js
+++ b/packages/react-native/Libraries/Core/polyfillPromise.js
@@ -10,29 +10,22 @@
 
 'use strict';
 
-const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
-
 /**
- * Set up Promise. The native Promise implementation throws the following error:
- * ERROR: Event loop not supported.
+ * Set up Promise. Hermes provides a native Promise implementation that
+ * satisfies all requirements of React Native.
  *
  * If you don't need these polyfills, don't use InitializeCore; just directly
  * require the modules you need from InitializeCore for setup.
  */
 
-// If global.Promise is provided by Hermes, we are confident that it can provide
-// all the methods needed by React Native, so we can directly use it.
-if (global?.HermesInternal?.hasPromise?.()) {
-  const HermesPromise = global.Promise;
+// Hermes is the only supported JS engine and always provides Promise natively.
+const HermesPromise = global.Promise;
 
-  if (__DEV__) {
-    if (typeof HermesPromise !== 'function') {
-      console.error('HermesPromise does not exist');
-    }
-    global.HermesInternal?.enablePromiseRejectionTracker?.(
-      require('../promiseRejectionTrackingOptions').default,
-    );
+if (__DEV__) {
+  if (typeof HermesPromise !== 'function') {
+    console.error('HermesPromise does not exist');
   }
-} else {
-  polyfillGlobal('Promise', () => require('../Promise').default);
+  global.HermesInternal?.enablePromiseRejectionTracker?.(
+    require('../promiseRejectionTrackingOptions').default,
+  );
 }


### PR DESCRIPTION
## Summary

Removes the dead `else` branch in `polyfillPromise.js` that imports the `promise` package. Since Hermes is the only supported JS engine and always provides a native Promise, `hasPromise()` is always true and the polyfill path can never execute.

Fixes #57702

## Changelog:

[GENERAL] [REMOVED] - Dead promise polyfill code path in polyfillPromise.js

## Problem

`polyfillPromise.js` conditionally imports the `promise` package (~15KB) via `../Promise` in an `else` branch that can never execute:

```js
if (global?.HermesInternal?.hasPromise?.()) {
  // Always true — Hermes is the only supported engine
} else {
  // Dead code — promise package is bundled but never used
  polyfillGlobal('Promise', () => require('../Promise').default);
}
```

This adds unnecessary weight to every React Native app's JS bundle.

## Changes

- Removed the dead `else` branch
- Removed the unused `polyfillGlobal` import
- Simplified the condition since Hermes is guaranteed
- Preserved the `__DEV__` promise rejection tracking setup

## Test Plan

- The `promise` package is no longer bundled in the JS output
- Promise behavior is unchanged (Hermes native Promise was always used in practice)
- Dev-mode rejection tracking still works via `HermesInternal.enablePromiseRejectionTracker`