### PR TITLE
[iOS] Fix keyboard inset state across ScrollView recycling

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -360,9 +360,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   MAP_SCROLL_VIEW_PROP(showsHorizontalScrollIndicator);
   MAP_SCROLL_VIEW_PROP(showsVerticalScrollIndicator);
 
-  if (oldScrollViewProps.automaticallyAdjustKeyboardInsets != newScrollViewProps.automaticallyAdjustKeyboardInsets) {
-    _automaticallyAdjustKeyboardInsets = newScrollViewProps.automaticallyAdjustKeyboardInsets;
-  }
+  _automaticallyAdjustKeyboardInsets = newScrollViewProps.automaticallyAdjustKeyboardInsets;
 
   if (oldScrollViewProps.scrollIndicatorInsets != newScrollViewProps.scrollIndicatorInsets) {
     _scrollView.scrollIndicatorInsets = RCTUIEdgeInsetsFromEdgeInsets(newScrollViewProps.scrollIndicatorInsets);
@@ -702,6 +700,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   // and keeps it as an opt-in behavior.
   _scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
   _shouldUpdateContentInsetAdjustmentBehavior = YES;
+  _automaticallyAdjustKeyboardInsets = NO;
   _isUserTriggeredScrolling = NO;
   CGRect oldFrame = self.frame;
   self.frame = CGRectZero;

--- a/packages/react-native/React/Tests/Mounting/RCTScrollViewComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Mounting/RCTScrollViewComponentViewTests.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTScrollViewComponentView.h>
+#import <XCTest/XCTest.h>
+#import <react/renderer/components/scrollview/ScrollViewProps.h>
+#import <react/renderer/components/scrollview/ScrollViewShadowNode.h>
+
+using namespace facebook::react;
+
+#if TARGET_OS_IOS
+
+static Props::Shared makeScrollViewProps(bool automaticallyAdjustKeyboardInsets)
+{
+  auto props = std::make_shared<ScrollViewProps>();
+  props->automaticallyAdjustKeyboardInsets = automaticallyAdjustKeyboardInsets;
+  return props;
+}
+
+@interface RCTScrollViewComponentView (Tests)
+- (void)_keyboardWillChangeFrame:(NSNotification *)notification;
+@end
+
+@interface RCTScrollViewComponentViewTests : XCTestCase
+@end
+
+@implementation RCTScrollViewComponentViewTests
+
+- (void)testAutomaticallyAdjustKeyboardInsetsAcrossRecycling
+{
+  RCTScrollViewComponentView *view = [[RCTScrollViewComponentView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+  auto props = makeScrollViewProps(true);
+  [view updateProps:props oldProps:ScrollViewShadowNode::defaultSharedProps()];
+
+  NSNotification *notification = [NSNotification
+      notificationWithName:UIKeyboardWillChangeFrameNotification
+                    object:nil
+                  userInfo:@{
+                    UIKeyboardAnimationDurationUserInfoKey : @0,
+                    UIKeyboardAnimationCurveUserInfoKey : @(UIViewAnimationCurveLinear),
+                    UIKeyboardFrameBeginUserInfoKey : [NSValue valueWithCGRect:CGRectMake(0, 100, 100, 50)],
+                    UIKeyboardFrameEndUserInfoKey : [NSValue valueWithCGRect:CGRectMake(0, 50, 100, 50)],
+                  }];
+
+  [view _keyboardWillChangeFrame:notification];
+  XCTAssertEqual(view.scrollView.contentInset.bottom, 50);
+
+  [view prepareForRecycle];
+  [view _keyboardWillChangeFrame:notification];
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(view.scrollView.contentInset, UIEdgeInsetsZero));
+
+  [view updateProps:props oldProps:nullptr];
+  [view _keyboardWillChangeFrame:notification];
+  XCTAssertEqual(view.scrollView.contentInset.bottom, 50);
+}
+
+@end
+
+#endif


### PR DESCRIPTION
## Summary:

Closes #57755.

`RCTScrollViewComponentView` remained subscribed to keyboard notifications while pooled with `_automaticallyAdjustKeyboardInsets` still enabled. A late notification could therefore restore keyboard insets after `prepareForRecycle` had cleared them.

Disarm keyboard inset adjustment during recycling, then always synchronize the flag from the incoming props so a recycled view is correctly re-armed when the next ScrollView opts in.

## Changelog:

[IOS] [FIXED] - Prevent recycled ScrollViews from retaining automatic keyboard inset behavior.

## Test Plan:

- Added `RCTScrollViewComponentViewTests.testAutomaticallyAdjustKeyboardInsetsAcrossRecycling`, covering enabled behavior, ignored keyboard notifications while recycled, and re-enabling after remount.
- `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang-format --dry-run --Werror packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm packages/react-native/React/Tests/Mounting/RCTScrollViewComponentViewTests.mm`
- `git diff --check`

The full native XCTest suite was not run locally because this sparse checkout does not include a bootstrapped RNTester/CocoaPods workspace.