### PR TITLE
Fix use-after-move of ContextContainer in PointerEventsProcessorTest

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
@@ -44,7 +44,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
         componentDescriptorProviderRegistry.createComponentDescriptorRegistry(
             ComponentDescriptorParameters{
                 .eventDispatcher = eventDispatcher,
-                .contextContainer = std::move(contextContainer),
+                .contextContainer = contextContainer,
                 .flavor = nullptr});
 
     componentDescriptorProviderRegistry.add(


### PR DESCRIPTION
Summary:
The whole `PointerEventsProcessorTest` suite has been aborting in its fixture constructor since the `modernize-use-designated-initializers` codemod moved the `ContextContainer` into `ComponentDescriptorParameters`. The `shared_ptr` is read twice more afterwards — once to construct the `UIManager` and once to construct the `ShadowTree` — so the move left both with a null container and the second read tripped the libstdc++ null-deref assert.

Stop moving out of a `shared_ptr` that is still needed by later statements.

Changelog: [Internal]

Differential Revision: D114730311


