### PR TITLE
Fix asset catalog scale-to-file pairing for assets with non-standard scales

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/assetCatalogIOS-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/assetCatalogIOS-test.js
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {getCatalogImages, getImageSet} from '../assetCatalogIOS';
+
+const path = require('node:path');
+
+jest.dontMock('../assetCatalogIOS');
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+function makeAsset(scales: Array<number>) {
+  return {
+    __packager_asset: true,
+    fileSystemLocation: '/project/img',
+    httpServerLocation: '/assets/img',
+    width: 100,
+    height: 100,
+    scales,
+    files: scales.map(
+      scale => `/project/img/logo${scale === 1 ? '' : `@${scale}x`}.png`,
+    ),
+    hash: 'hash',
+    name: 'logo',
+    type: 'png',
+  };
+}
+
+describe('getCatalogImages', () => {
+  test('pairs each standard scale with its file', () => {
+    const asset = makeAsset([1, 2, 3]);
+    expect(getCatalogImages(asset)).toEqual([
+      {scale: 1, src: '/project/img/logo.png'},
+      {scale: 2, src: '/project/img/logo@2x.png'},
+      {scale: 3, src: '/project/img/logo@3x.png'},
+    ]);
+  });
+
+  test('skips non-standard scales without shifting file pairing', () => {
+    // Regression test: filtering scales without filtering files used to
+    // associate the 2x rendition with the 1.5x file.
+    const asset = makeAsset([1, 1.5, 2, 3]);
+    expect(getCatalogImages(asset)).toEqual([
+      {scale: 1, src: '/project/img/logo.png'},
+      {scale: 2, src: '/project/img/logo@2x.png'},
+      {scale: 3, src: '/project/img/logo@3x.png'},
+    ]);
+  });
+
+  test('maps a fractional-only asset into the nearest valid slot', () => {
+    const asset = makeAsset([1.5]);
+    expect(getCatalogImages(asset)).toEqual([
+      {scale: 2, src: '/project/img/logo@1.5x.png'},
+    ]);
+  });
+
+  test('clamps scales larger than 3x to the 3x slot', () => {
+    const asset = makeAsset([4]);
+    expect(getCatalogImages(asset)).toEqual([
+      {scale: 3, src: '/project/img/logo@4x.png'},
+    ]);
+  });
+
+  test('uses the largest fractional variant when several exist', () => {
+    const asset = makeAsset([1.5, 2.5]);
+    expect(getCatalogImages(asset)).toEqual([
+      {scale: 3, src: '/project/img/logo@2.5x.png'},
+    ]);
+  });
+});
+
+describe('getImageSet', () => {
+  test('builds imageset path and per-scale file entries', () => {
+    const asset = makeAsset([1, 2, 3]);
+    const imageSet = getImageSet('/catalog', asset);
+    expect(imageSet.basePath).toBe(path.join('/catalog', 'img_logo.imageset'));
+    expect(imageSet.files).toEqual([
+      {name: 'img_logo.png', scale: 1, src: '/project/img/logo.png'},
+      {name: 'img_logo@2x.png', scale: 2, src: '/project/img/logo@2x.png'},
+      {name: 'img_logo@3x.png', scale: 3, src: '/project/img/logo@3x.png'},
+    ]);
+  });
+
+  test('names the fallback rendition after its catalog slot', () => {
+    const asset = makeAsset([1.5]);
+    const imageSet = getImageSet('/catalog', asset);
+    expect(imageSet.files).toEqual([
+      {name: 'img_logo@2x.png', scale: 2, src: '/project/img/logo@1.5x.png'},
+    ]);
+  });
+});

--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -10,6 +10,7 @@
 
 import type {AssetData} from 'metro';
 
+import {ALLOWED_SCALES} from './filterPlatformAssetScales';
 import {getAndroidResourceIdentifier} from '@react-native/asset-utils';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -28,20 +29,57 @@ type ImageSet = {
   files: {name: string, src: string, scale: number}[],
 };
 
-export function getImageSet(
-  catalogDir: string,
-  asset: AssetData,
-  scales: ReadonlyArray<number>,
-): ImageSet {
+// Scales an iOS asset catalog imageset can hold. actool silently drops
+// renditions at any other scale (e.g. a fractional @1.5x).
+const CATALOG_SCALES = ALLOWED_SCALES.ios;
+
+type CatalogImage = {scale: number, src: string};
+
+/**
+ * Pairs each catalog-valid scale of the asset with its source file.
+ *
+ * If the asset has no valid scale at all (e.g. only a fractional @1.5x
+ * variant), its closest variant is mapped into the nearest valid slot,
+ * mirroring the "closest larger" fallback filterPlatformAssetScales applies
+ * to loose files, so the imageset always contains at least one rendition
+ * actool will compile.
+ */
+export function getCatalogImages(asset: AssetData): Array<CatalogImage> {
+  const images: Array<CatalogImage> = [];
+  asset.scales.forEach((scale, idx) => {
+    if (CATALOG_SCALES.includes(scale)) {
+      images.push({scale, src: asset.files[idx]});
+    }
+  });
+  if (images.length === 0 && asset.scales.length > 0) {
+    const maxCatalogScale = CATALOG_SCALES[CATALOG_SCALES.length - 1];
+    let idx = asset.scales.findIndex(scale => scale > maxCatalogScale);
+    if (idx === -1) {
+      idx = asset.scales.length - 1;
+    }
+    const scale = Math.min(
+      maxCatalogScale,
+      Math.max(1, Math.ceil(asset.scales[idx])),
+    );
+    console.warn(
+      `warning: Asset "${asset.name}" has no 1x/2x/3x variant; ` +
+        `using its @${asset.scales[idx]}x file as the ${scale}x catalog rendition.`,
+    );
+    images.push({scale, src: asset.files[idx]});
+  }
+  return images;
+}
+
+export function getImageSet(catalogDir: string, asset: AssetData): ImageSet {
   const fileName = getAndroidResourceIdentifier(asset);
   return {
     basePath: path.join(catalogDir, `${fileName}.imageset`),
-    files: scales.map((scale, idx) => {
+    files: getCatalogImages(asset).map(({scale, src}) => {
       const suffix = scale === 1 ? '' : `@${scale}x`;
       return {
         name: `${fileName + suffix}.${asset.type}`,
         scale,
-        src: asset.files[idx],
+        src,
       };
     }),
   };

--- a/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
+++ b/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const ALLOWED_SCALES: {[key: string]: number[]} = {
+export const ALLOWED_SCALES: {[key: string]: number[]} = {
   ios: [1, 2, 3],
 };
 

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -74,12 +74,7 @@ async function saveAssets(
     cleanAssetCatalog(catalogDir);
     for (const asset of assets) {
       if (isCatalogAsset(asset)) {
-        const imageSet = getImageSet(
-          catalogDir,
-          asset,
-          filterPlatformAssetScales(platform, asset.scales),
-        );
-        writeImageSet(imageSet);
+        writeImageSet(getImageSet(catalogDir, asset));
       } else {
         addAssetToCopy(asset);
       }


### PR DESCRIPTION
## Summary:

`saveAssets` filters an asset's scales through `filterPlatformAssetScales`, but `getImageSet` indexes the unfiltered `asset.files`, so an asset with scales `[1, 1.5, 2, 3]` gets the 1.5x file in its 2x catalog slot and the 2x file in its 3x slot: `Assets.car` ships the wrong images. An asset with no standard scale at all (only `@1.5x`, say) produces an imageset actool silently drops from the car, which makes the image unloadable when `RCTUseAssetCatalog` is on, since the catalog runtime has no filesystem fallback (#30129).

Fix, in `assetCatalogIOS.js`:

- Each catalog slot (1x/2x/3x) is paired with its own file.
- An asset with no valid scale maps its closest variant into the nearest valid slot, the same "closest larger" rule loose files already get, and warns in the build log. Every imageset now holds at least one rendition actool will compile.

Related: expo/expo#48525 applies the same fix to Expo CLI's mirrored implementation.

## Changelog:

[IOS] [FIXED] - Asset catalog imagesets paired wrong files for assets with non-standard scales

## Test Plan:

New unit tests in `assetCatalogIOS-test.js`: standard 1x/2x/3x pairing, mixed `[1, 1.5, 2, 3]` (regression for the file shift), fractional-only `[1.5]`, and `[4]` clamping to the 3x slot.

```
yarn jest packages/community-cli-plugin/src/commands/bundle
Tests: 18 passed, 18 total
```


### End-to-end

Bundled a test app through the real pipeline (Metro → `saveAssets` → actool → `assetutil --info` on the compiled `Assets.car`) with two assets: `logo` at scales `[1, 1.5, 2, 3]` (100/150/200/300 px) and `star` with only a `@1.5x` file (150 px).

| Rendition in `Assets.car` | before | after |
|---|---|---|
| `img_logo` 1x | 100 px | 100 px |
| `img_logo` 2x | **150 px (the 1.5x file)** | 200 px |
| `img_logo` 3x | **200 px (the 2x file)** | 300 px |
| `img_star` | **absent (actool dropped the `@1.5x` imageset)** | 150 px in the 2x slot, with a build-log warning |

Running on an iPhone 17 Pro simulator (3x), same app built with the buggy and fixed CLI — the labeled tiles show which file the catalog actually served, and `star` goes from missing to rendering:

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/4ebdbd33-74ec-4731-a2c4-f1a2d9b5838b" width="320" /> | <img src="https://github.com/user-attachments/assets/cd461b0a-5763-4388-8771-1ae6df383817" width="320" /> |

<details>
<summary>Repro app used for the screenshots</summary>

Built `private/helloworld` (Release, simulator) with `RCTUseAssetCatalog` set to `true` in its Info.plist, and these assets in `img/`, where each file is a solid tile with its scale label and pixel size baked into the image so a screenshot shows exactly which file got served: `logo.png` (100px, "1x"), `logo@1.5x.png` (150px, "1.5x"), `logo@2x.png` (200px, "2x"), `logo@3x.png` (300px, "3x"), and `star@1.5x.png` (150px, "STAR") with no other variants.

```js
// index.js
import React from 'react';
import {AppRegistry, Image, Text, View, StyleSheet} from 'react-native';

const styles = StyleSheet.create({
  root: {flex: 1, backgroundColor: '#111', alignItems: 'center', justifyContent: 'center'},
  label: {color: '#fff', fontSize: 16, marginTop: 24, marginBottom: 8, fontWeight: '600'},
  box: {width: 100, height: 100, borderWidth: 2, borderColor: '#666'},
  img: {width: 100, height: 100},
});

const App = () => (
  <View style={styles.root}>
    <Text style={styles.label}>logo.png (has 1x/1.5x/2x/3x)</Text>
    <View style={styles.box}>
      <Image style={styles.img} source={require('./img/logo.png')} />
    </View>
    <Text style={styles.label}>star.png (only @1.5x)</Text>
    <View style={styles.box}>
      <Image style={styles.img} source={require('./img/star.png')} />
    </View>
  </View>
);

AppRegistry.registerComponent('HelloWorld', () => App);
```

On the 3x simulator JS resolves `logo` to the 3x variant, so the tile that renders is the file the catalog's 3x slot actually contains: the 2x-labeled tile before the fix, the 3x tile after. `star` resolves to its only variant (`@1.5x`); before the fix its imageset is dropped by actool and the box renders empty.

</details>



