### PR TITLE
Deflake TaskDispatchThreadTest.MultipleDelayedTasksOrder

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/threading/tests/TaskDispatchThreadTests.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/threading/tests/TaskDispatchThreadTests.cpp
@@ -71,11 +71,23 @@ TEST_F(TaskDispatchThreadTest, RunAsyncWithDelay) {
 // Test: Multiple delayed tasks execute in order
 TEST_F(TaskDispatchThreadTest, MultipleDelayedTasksOrder) {
   std::vector<int> results;
+  std::promise<void> secondTaskDone;
+  auto future = secondTaskDone.get_future();
   dispatcher->runAsync(
       [&] { results.push_back(1); }, std::chrono::milliseconds(50));
   dispatcher->runAsync(
-      [&] { results.push_back(2); }, std::chrono::milliseconds(100));
-  std::this_thread::sleep_for(std::chrono::milliseconds(120));
+      [&] {
+        results.push_back(2);
+        secondTaskDone.set_value();
+      },
+      std::chrono::milliseconds(100));
+  // Block until the later task has actually run rather than racing a fixed
+  // sleep against the 100ms deadline. Both tasks run serially on the single
+  // dispatch thread in deadline order, so once the 100ms task completes the
+  // 50ms task is guaranteed to have already run; waiting on the future also
+  // establishes the happens-before needed to read `results` safely.
+  ASSERT_EQ(
+      future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   ASSERT_EQ(results.size(), 2);
   EXPECT_EQ(results[0], 1);
   EXPECT_EQ(results[1], 2);


### PR DESCRIPTION
Summary:
WARNING: Generated by Autopilot (alpha) — review carefully, verify the underlying claim before accepting.
Agent: React Native Oncall Tests Fixer | Trajectory: https://www.internalfb.com/intern/devai/devmate/inspector/0bb8944e-85d4-4a86-ac19-5147b3b0a48f/ | SC job: https://www.internalfb.com/intern/sandcastle/instance/36028799852645402/

---

`TaskDispatchThreadTest/MultipleDelayedTasksOrder` (test_id 562950261618811)
is a timing-sensitive GTest that schedules two delayed tasks (at 50ms and
100ms) and then races a fixed `std::this_thread::sleep_for(120ms)` against
the 100ms deadline before asserting `results.size() == 2`. Only 20ms of slack
covers the later task, so under CI load / emulator scheduling jitter the
second task has not run when the assertion fires, producing the observed
`results.size()` is 0 or 1 failure at line 79. TestX reports a 95.7% simple
flakiness score for this test, and it has a long history of auto-closed
FLAKY issues; it recently surfaced as a hard FAILURE (issue 233255291).

Replace the fixed sleep with deterministic synchronization on the later
task using the same `std::promise`/`future.wait_for` pattern already used by
`RunAsyncWithDelay` in this file. Because both tasks run serially on the
single dispatch thread in deadline order, blocking until the 100ms task
completes guarantees the 50ms task has already run, and waiting on the future
establishes the happens-before needed to read `results` safely.

Differential Revision: D114605936


