### PR TITLE
fix: make an interrupted React-Core-prebuilt swap recoverable

### DIFF
--- a/packages/react-native/scripts/__tests__/replace-rncore-version-test.js
+++ b/packages/react-native/scripts/__tests__/replace-rncore-version-test.js
@@ -19,6 +19,18 @@ const path = require('node:path');
 const VERSION = '0.87.0-test';
 const SLICE = 'ios-arm64_x86_64-simulator';
 const BINARY = path.join(SLICE, 'React.framework', 'React');
+const SCRIPT = require.resolve('../replace-rncore-version.js');
+const MARKER = path.join('React-Core-prebuilt', '.last_build_configuration');
+
+// Runs the script the way the "[RNCore] Replace React Native Core for the right
+// configuration" build phase does, from Pods/ and through the CLI entry point.
+function runScriptPhase(podsRoot, configuration) {
+  return execFileSync(
+    process.execPath,
+    [SCRIPT, '-c', configuration, '-r', VERSION, '-p', podsRoot],
+    {cwd: podsRoot, encoding: 'utf8'},
+  );
+}
 
 function writeFile(filePath, contents) {
   fs.mkdirSync(path.dirname(filePath), {recursive: true});
@@ -117,6 +129,73 @@ describe('replaceRNCoreConfiguration', () => {
     replaceRNCoreConfiguration('Release', VERSION, podsRoot);
 
     expect(fs.readFileSync(expoModuleMap, 'utf8')).toBe('module React {}\n');
+  });
+
+  // Regression tests for #57598. The marker used to be written only after the
+  // framework had already been replaced, so a build cancelled in between left it
+  // naming a flavor that was no longer on disk. Every later build for that
+  // flavor then took the "nothing to do" path and linked against the other
+  // configuration's core, which fails with undefined C++ symbols and which a
+  // clean does not undo because the pod directory survives it.
+  describe('marker bookkeeping', () => {
+    const marker = () => path.join(podsRoot, MARKER);
+    const binary = () =>
+      fs.readFileSync(path.join(pod, 'React.xcframework', BINARY), 'utf8');
+
+    it('records the configuration when it skips a fresh install', () => {
+      // `pod install` leaves the debug flavor and no marker, so a Debug build
+      // has nothing to swap. It still has to write down what is on disk,
+      // otherwise the state stays implicit and stays unverifiable.
+      expect(fs.existsSync(marker())).toBe(false);
+
+      runScriptPhase(podsRoot, 'Debug');
+
+      expect(fs.readFileSync(marker(), 'utf8')).toBe('Debug');
+      expect(binary()).toBe('binary-Debug');
+    });
+
+    it('invalidates the marker before it touches the framework', () => {
+      fs.writeFileSync(marker(), 'Debug');
+      // Drop the tarball so the Release run fails once it is already under way,
+      // standing in for a build cancelled part way through the swap.
+      fs.rmSync(
+        path.join(
+          podsRoot,
+          'ReactNativeCore-artifacts',
+          `reactnative-core-${VERSION.toLowerCase()}-release.tar.gz`,
+        ),
+      );
+
+      expect(() => runScriptPhase(podsRoot, 'Release')).toThrow();
+
+      // The marker must no longer claim Debug: the framework may already have
+      // been swapped, and a Debug build that trusts it would silently skip.
+      expect(fs.readFileSync(marker(), 'utf8')).not.toBe('Debug');
+    });
+
+    it('replaces the framework when the marker shows an unfinished swap', () => {
+      buildTarball(podsRoot, 'Debug');
+      // A swap that was interrupted: the Release flavor is on disk and the
+      // marker never got its final value.
+      replaceRNCoreConfiguration('Release', VERSION, podsRoot);
+      fs.writeFileSync(marker(), 'in-progress');
+      expect(binary()).toBe('binary-Release');
+
+      runScriptPhase(podsRoot, 'Debug');
+
+      expect(binary()).toBe('binary-Debug');
+      expect(fs.readFileSync(marker(), 'utf8')).toBe('Debug');
+    });
+
+    it('still skips when the marker already matches the configuration', () => {
+      fs.writeFileSync(marker(), 'Release');
+      const before = binary();
+
+      const output = runScriptPhase(podsRoot, 'Release');
+
+      expect(output).toContain('No need to replace React-Core-prebuilt');
+      expect(binary()).toBe(before);
+    });
   });
 
   it('fails when the tarball has no React.xcframework', () => {

--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -18,6 +18,11 @@ const yargs = require('yargs');
 
 const LAST_BUILD_FILENAME = 'React-Core-prebuilt/.last_build_configuration';
 
+// Stored in LAST_BUILD_FILENAME while the framework on disk is being swapped.
+// It is not a valid configuration, so a run that finds it knows the previous
+// swap did not finish and the flavor on disk cannot be trusted.
+const REPLACEMENT_IN_PROGRESS = 'in-progress';
+
 function validateBuildConfiguration(configuration /*: string */) {
   if (!['Debug', 'Release'].includes(configuration)) {
     throw new Error(`Invalid configuration ${configuration}`);
@@ -42,13 +47,24 @@ function shouldReplaceRnCoreConfiguration(configuration /*: string */) {
       );
       return false;
     }
+    // Anything else, including REPLACEMENT_IN_PROGRESS left by a swap that was
+    // cancelled or killed, means the flavor on disk is not the requested one or
+    // is unknown. Replace it.
+    return true;
   }
 
-  // Assumption: if there is no stored last build, we assume that it was build for debug.
-  if (!fileExists && configuration === 'Debug') {
+  // No marker means `pod install` has just laid the pod down and nothing has
+  // swapped it since, because a swap records REPLACEMENT_IN_PROGRESS before it
+  // touches the framework. The podspec source is always the debug tarball (see
+  // resolve_podspec_source in scripts/cocoapods/rncore.rb), so the flavor on
+  // disk is Debug and a Debug build has nothing to do.
+  if (configuration === 'Debug') {
     console.log(
       'No previous build detected, but Debug Configuration. No need to replace React-Core-prebuilt',
     );
+    // Record the assumption rather than leaving it implicit, so the state is
+    // readable and a later run never has to make it again.
+    updateLastBuildConfiguration(configuration);
     return false;
   }
 
@@ -130,6 +146,10 @@ function updateLastBuildConfiguration(configuration /*: string */) {
   fs.writeFileSync(LAST_BUILD_FILENAME, configuration);
 }
 
+function markReplacementInProgress() /*: void */ {
+  fs.writeFileSync(LAST_BUILD_FILENAME, REPLACEMENT_IN_PROGRESS);
+}
+
 function main(
   configuration /*: string */,
   version /*: string */,
@@ -142,6 +162,12 @@ function main(
     return;
   }
 
+  // Invalidate the marker before the framework is touched. A build cancelled
+  // between the swap and the update used to leave the marker naming a flavor
+  // that was no longer on disk, and every later build for that flavor then took
+  // the skip path and linked against the wrong core, which a clean does not
+  // undo. Recording the swap first makes an interrupted run recoverable.
+  markReplacementInProgress();
   replaceRNCoreConfiguration(configuration, version, podsRoot);
   updateLastBuildConfiguration(configuration);
   console.log('Done replacing React Native prebuilt');


### PR DESCRIPTION
## Summary

`replace-rncore-version.js` writes `.last_build_configuration` only after it has already replaced `React.xcframework`, so a build cancelled between those two steps leaves the marker naming a flavor that is no longer on disk, and when the marker is absent entirely the script assumes the on-disk flavor is Debug. Either state makes the next build for that configuration take the "no need to replace" path and link against the other configuration's core, which fails with undefined C++ symbols for `Props`, `DebugStringConvertible` and the Fabric vtables, and nothing corrects it afterwards because the pod directory survives a clean.

This change writes the marker before the framework is touched, using a value that is not a valid configuration, so a later run can tell that the previous swap did not finish and replaces again. The fresh install path now also records the configuration it assumed instead of leaving that state implicit, which is sound because a swap can no longer leave the marker missing.

Fixes #57598.

## Changelog:

[IOS] [FIXED] - Recover React-Core-prebuilt configuration swaps that were interrupted before the marker was updated

## Test Plan

Four new cases in `packages/react-native/scripts/__tests__/replace-rncore-version-test.js`, driven through the real CLI entry point the podspec `[RNCore]` build phase uses, so no new export was needed and the production diff is logic only. Against unmodified upstream two of them fail, one with `ENOENT` on `.last_build_configuration` because the skip path never wrote the marker, and one showing the marker still naming the stale flavor after a failed swap. With the change the file is 8 passed, including all 4 pre-existing tests. `prettier --check` is clean on both files.

The actual iOS link failure needs a prebuilt-core CocoaPods install and an Xcode build, so that was not reproduced locally.
