### PR TITLE
Resolve dynamic border and outline colors against the view trait collection in Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -904,13 +904,21 @@ static void RCTAddContourEffectToLayer(
   [layer removeAllAnimations];
 }
 
-static RCTBorderColors RCTCreateRCTBorderColorsFromBorderColors(BorderColors borderColors)
+// CALayer colors are plain CGColors: converting a dynamic (PlatformColor /
+// DynamicColorIOS) UIColor without an explicit trait collection resolves against
+// UITraitCollection.currentTraitCollection, which tracks the system appearance
+// and ignores any overrideUserInterfaceStyle inherited by the view. Resolve
+// against the view's own trait collection instead, matching the backgroundColor
+// handling in invalidateLayer.
+static RCTBorderColors RCTCreateRCTBorderColorsFromBorderColors(
+    BorderColors borderColors,
+    UITraitCollection *traitCollection)
 {
   return RCTBorderColors{
-      .top = RCTUIColorFromSharedColor(borderColors.top),
-      .left = RCTUIColorFromSharedColor(borderColors.left),
-      .bottom = RCTUIColorFromSharedColor(borderColors.bottom),
-      .right = RCTUIColorFromSharedColor(borderColors.right)};
+      .top = [RCTUIColorFromSharedColor(borderColors.top) resolvedColorWithTraitCollection:traitCollection],
+      .left = [RCTUIColorFromSharedColor(borderColors.left) resolvedColorWithTraitCollection:traitCollection],
+      .bottom = [RCTUIColorFromSharedColor(borderColors.bottom) resolvedColorWithTraitCollection:traitCollection],
+      .right = [RCTUIColorFromSharedColor(borderColors.right) resolvedColorWithTraitCollection:traitCollection]};
 }
 
 static CALayerCornerCurve CornerCurveFromBorderCurve(BorderCurve borderCurve)
@@ -1148,7 +1156,8 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _borderLayer = nil;
 
     layer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
-    UIColor *borderColor = RCTUIColorFromSharedColor(borderMetrics.borderColors.left);
+    UIColor *borderColor = [RCTUIColorFromSharedColor(borderMetrics.borderColors.left)
+        resolvedColorWithTraitCollection:self.traitCollection];
     layer.borderColor = borderColor.CGColor;
     layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft.horizontal;
     layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
@@ -1166,7 +1175,8 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     layer.borderColor = nil;
     layer.cornerRadius = 0;
 
-    RCTBorderColors borderColors = RCTCreateRCTBorderColorsFromBorderColors(borderMetrics.borderColors);
+    RCTBorderColors borderColors =
+        RCTCreateRCTBorderColorsFromBorderColors(borderMetrics.borderColors, self.traitCollection);
 
     RCTAddContourEffectToLayer(
         _borderLayer,
@@ -1195,11 +1205,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     // have to be drawn with Core Graphics, the same way non-solid borders are.
     if (_props->outlineStyle == OutlineStyle::Solid && areBorderRadiiCircular(borderMetrics.borderRadii) &&
         borderMetrics.borderRadii.topLeft.horizontal == 0) {
-      UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
+      UIColor *outlineColor =
+          [RCTUIColorFromSharedColor(_props->outlineColor) resolvedColorWithTraitCollection:self.traitCollection];
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;
     } else {
-      UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
+      UIColor *outlineColor =
+          [RCTUIColorFromSharedColor(_props->outlineColor) resolvedColorWithTraitCollection:self.traitCollection];
 
       RCTAddContourEffectToLayer(
           _outlineLayer,

--- a/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
@@ -281,4 +281,44 @@ static RCTViewComponentView *makeViewWithOutlineStyle(OutlineStyle outlineStyle)
   }
 }
 
+#pragma mark - dynamic border and outline colors
+
+- (void)testDynamicBorderAndOutlineColorsResolveAgainstViewTraitCollection
+{
+  auto dynamicColor = SharedColor(Color(
+      DynamicColor{
+          .lightColor = static_cast<int32_t>(0xFFFF0000u),
+          .darkColor = static_cast<int32_t>(0xFF00FF00u),
+      }));
+  UITraitCollection *lightTraits = [UITraitCollection traitCollectionWithUserInterfaceStyle:UIUserInterfaceStyleLight];
+
+  [lightTraits performAsCurrentTraitCollection:^{
+    RCTViewComponentView *view = [RCTViewComponentView new];
+    view.frame = CGRectMake(0, 0, 100, 100);
+    view.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+    view.clipsToBounds = YES;
+
+    XCTAssertEqual([UITraitCollection currentTraitCollection].userInterfaceStyle, UIUserInterfaceStyleLight);
+    XCTAssertEqual(view.traitCollection.userInterfaceStyle, UIUserInterfaceStyleDark);
+
+    auto props = std::make_shared<ViewProps>();
+    props->yogaStyle.setBorder(facebook::yoga::Edge::All, facebook::yoga::StyleLength::points(4));
+    props->borderColors.all = dynamicColor;
+    props->borderStyles.all = BorderStyle::Solid;
+    props->outlineWidth = 4;
+    props->outlineColor = dynamicColor;
+    props->outlineStyle = OutlineStyle::Solid;
+
+    [view updateProps:props oldProps:ViewShadowNode::defaultSharedProps()];
+    [view finalizeUpdates:RNComponentViewUpdateMaskProps];
+
+    CALayer *outlineLayer = [view valueForKey:@"_outlineLayer"];
+    XCTAssertNotNil(outlineLayer);
+    XCTAssertNotNil((__bridge id)view.layer.borderColor);
+    XCTAssertNotNil((__bridge id)outlineLayer.borderColor);
+    XCTAssertTrue(CGColorEqualToColor(view.layer.borderColor, UIColor.greenColor.CGColor));
+    XCTAssertTrue(CGColorEqualToColor(outlineLayer.borderColor, UIColor.greenColor.CGColor));
+  }];
+}
+
 @end


### PR DESCRIPTION
## Summary

Fixes #57836.

On Fabric, `borderColor` and `outlineColor` set from a dynamic color (`PlatformColor` / `DynamicColorIOS`) are converted to `CGColor` without an explicit trait-collection resolve, so they resolve against `UITraitCollection.currentTraitCollection` — the system appearance. When the app's effective appearance differs from the system (`Appearance.setColorScheme(...)` / `overrideUserInterfaceStyle`), borders render the wrong variant, and views mounted while already attached under the override never get a `traitCollectionDidChange:` to heal them, so the wrong color persists. `backgroundColor` is unaffected because `invalidateLayer` already resolves it against `self.traitCollection`; Paper is unaffected because `RCTView` resolves border colors against the view's trait collection in `displayLayer:`.

This change applies the same treatment to the remaining color conversions in `invalidateLayer`:

- the CoreAnimation border path (`layer.borderColor`),
- `RCTCreateRCTBorderColorsFromBorderColors` (the border-image path), which now takes the view's trait collection,
- both `outlineColor` paths.

Colors resolved with `resolvedColorWithTraitCollection:` are static, so the existing `traitCollectionDidChange:` → `invalidateLayer` hook keeps them correct when the effective appearance changes. `layer.shadowColor` (in `updateProps`) shares the same latent flattening and could get the same treatment in a follow-up.

## Changelog:

[IOS] [FIXED] - Fabric: resolve dynamic (PlatformColor/DynamicColorIOS) border and outline colors against the view's trait collection instead of the system appearance

## Test Plan

Runnable single-file RNTester reproducer for the issue: https://github.com/facebook/react-native/compare/main...JacquesLeupin:react-native:repro/fabric-border-trait-collection-57836 (edits only `RNTesterPlayground.js`). Equivalently, the reproducer from the linked issue as a stock `npx @react-native-community/cli init` app (New Architecture, iOS Simulator with **system Light**): one `DynamicColorIOS({light: red, dark: green})` feeds a fill, a border on the border-image path, and a border on the CoreAnimation path; the app forces dark via `Appearance.setColorScheme('dark')`, then mounts a second set of boxes under the override.

- **Before:** fills turn green, but the borders of views already mounted when the override flips stay red (the light variant) on both border code paths, permanently — the trait-change invalidation re-runs `invalidateLayer`, but the conversion reads the ambient trait state. Recycled views reattached under the override stick the same way (no trait change at all).
- **After (this change applied to the app's `node_modules/react-native` and rebuilt):** every fill and border renders green, including the pre-override views once the trait-change invalidation runs against the view's own trait collection.

Also verified as a patch on a production 0.81.5 New-Architecture app that applies its theme via `overrideUserInterfaceStyle` at launch, where every `PlatformColor` border previously rendered the system variant: borders now follow the app theme across launch-time override, runtime toggles, and recycled list views; `React-RCTFabric` compiles with no new warnings.
