### PR TITLE
xplat/js/react-native-github/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm (#57847)

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
+++ b/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
@@ -24,9 +24,10 @@ RCT_EXPORT_MODULE(FileReaderModule)
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_METHOD(
-    readAsText : (NSDictionary<NSString *, id> *)blob encoding : (NSString *)encoding resolve : (RCTPromiseResolveBlock)
-        resolve reject : (RCTPromiseRejectBlock)reject)
+- (void)readAsText:(NSDictionary<NSString *, id> *)blob
+          encoding:(NSString *)encoding
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
   dispatch_async(blobManager.methodQueue, ^{
@@ -54,9 +55,9 @@ RCT_EXPORT_METHOD(
   });
 }
 
-RCT_EXPORT_METHOD(
-    readAsDataURL : (NSDictionary<NSString *, id> *)blob resolve : (RCTPromiseResolveBlock)
-        resolve reject : (RCTPromiseRejectBlock)reject)
+- (void)readAsDataURL:(NSDictionary<NSString *, id> *)blob
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
 {
   RCTBlobManager *blobManager = [_moduleRegistry moduleForName:"BlobModule"];
   dispatch_async(blobManager.methodQueue, ^{


### PR DESCRIPTION
Summary:

...build_codegen_spec built the RCTBlobApple target and I read the generated `protocol NativeFileReaderModuleSpec` from FBReactNativeSpec.h; (2) apply_cast_mod mechanically rewrote both async methods — no FLAG lines emitted; (3) buck_build_verify succeeded; (4) Lint reported no issues.





_____


* Do **NOT** post in the CodemodService Feedback group about this specific diff.
* If you have feedback, comment on the diff and use an appropriate diff action.

This [diff was created](https://www.internalfb.com/intern/sandcastle/job/31525200232184606/) with [CodemodService](https://www.internalfb.com/codemod_service/CodemodConfigDevmateDropRctExportMethod).

Reviewed By: christophpurrer

Differential Revision: D115001596


