### PR TITLE
Remove accidental ref callback return values (#57849)

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -563,7 +563,9 @@ class SelectionExample extends React.Component<
             onChangeText={value => this.setState({value})}
             // $FlowFixMe[method-unbinding] added when improving typing for this parameters
             onSelectionChange={this.onSelectionChange.bind(this)}
-            ref={textInput => (this._textInput = textInput)}
+            ref={textInput => {
+              this._textInput = textInput;
+            }}
             selection={this.props.imperative ? undefined : this.state.selection}
             style={this.props.style}
             value={this.state.value}

--- a/packages/rn-tester/js/examples/Timer/TimerExample.js
+++ b/packages/rn-tester/js/examples/Timer/TimerExample.js
@@ -297,7 +297,9 @@ class IntervalExample extends React.Component<
     return (
       <View>
         <TimerTester
-          ref={ref => (this._timerTester = ref)}
+          ref={ref => {
+            this._timerTester = ref;
+          }}
           dt={25}
           type="setInterval"
         />


### PR DESCRIPTION
Summary:

Ref callbacks commonly used expression bodies that returned assignment or collection method results. Use block bodies so these callbacks return `void`, matching React's ref contract.

Changelog:
[Internal] - Make callback refs return `void` explicitly.

Reviewed By: SamChou19815

Differential Revision: D115064073


