### PR TITLE
Restrict ref helper return types

### DIFF
--- a/packages/react-native/Libraries/Utilities/useRefEffect.js
+++ b/packages/react-native/Libraries/Utilities/useRefEffect.js
@@ -10,8 +10,6 @@
 
 import {useCallback, useRef} from 'react';
 
-type CallbackRef<T> = T => unknown;
-
 /**
  * Constructs a callback ref that provides similar semantics as `useEffect`. The
  * supplied `effect` callback will be called with non-null component instances.
@@ -28,7 +26,7 @@ type CallbackRef<T> = T => unknown;
  */
 export default function useRefEffect<TInstance>(
   effect: TInstance => (() => void) | void,
-): CallbackRef<TInstance | null> {
+): React.RefCallback<TInstance> {
   const cleanupRef = useRef<(() => void) | void>(undefined);
   return useCallback(
     (instance: null | TInstance) => {

--- a/packages/react-native/src/private/animated/createAnimatedPropsHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsHook.js
@@ -35,11 +35,10 @@ type ReducedProps<TProps> = {
   collapsable: boolean,
   ...
 };
-type CallbackRef<T> = T => unknown;
 
 export type AnimatedPropsHook = <TProps extends {...}, TInstance>(
   props: TProps,
-) => [ReducedProps<TProps>, CallbackRef<TInstance | null>];
+) => [ReducedProps<TProps>, React.RefCallback<TInstance>];
 
 type UpdateCallback = () => void;
 
@@ -55,7 +54,7 @@ export default function createAnimatedPropsHook(
 
   return function useAnimatedProps<TProps extends {...}, TInstance>(
     props: TProps,
-  ): [ReducedProps<TProps>, CallbackRef<TInstance | null>] {
+  ): [ReducedProps<TProps>, React.RefCallback<TInstance>] {
     const [, scheduleUpdate] = useReducer<number, void>(count => count + 1, 0);
     const onUpdateRef = useRef<UpdateCallback | null>(null);
     const timerRef = useRef<TimeoutID | null>(null);


### PR DESCRIPTION
Summary:
React ref callbacks may return only `void` or a cleanup function. Align shared callback-ref contracts with that behavior so consumers cannot hide incompatible returns behind `unknown`.

Changelog:
[Internal] - Align ref helper types with React's callback contract.

Differential Revision: D115064072
