### PR TITLE
Fix IllegalStateException in SurfaceMountingManager.removeViewAt (#57860)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -427,10 +427,13 @@ internal constructor(
     val parentView = parentViewState.view
     checkNotNull(parentView) { "Unable to find parentView for tag $parentTag" }
     if (parentView !is ViewGroup) {
-      val message =
-          "Unable to remove a view from a a non-ViewGroup ${parentView.javaClass.simpleName} when removing [$tag] from parent [$parentTag]"
-      FLog.e(TAG, message)
-      throw IllegalStateException(message)
+      ReactSoftExceptionLogger.logSoftException(
+          TAG,
+          ReactNoCrashSoftException(
+              "Unable to remove a view from a non-ViewGroup ${parentView.javaClass.simpleName} when removing [$tag] from parent [$parentTag]"
+          ),
+      )
+      return
     }
 
     if (SHOW_CHANGED_VIEW_HIERARCHIES) {


### PR DESCRIPTION
Summary:

Fix a crash in `SurfaceMountingManager.removeViewAt()` where an `IllegalStateException` is thrown when the parent view is not a `ViewGroup`.

The Fabric differ can emit inconsistent remove instructions that reference a parent whose instantiated view is no longer a `ViewGroup` (e.g. after view recycling). Since a non-`ViewGroup` cannot hold child views, the removal is a semantic no-op.

Replace the hard throw with `ReactSoftExceptionLogger.logSoftException` + early return, matching the defensive pattern already used by peer conditions in the same method (null `parentViewState`, child already removed, wrong index). Also fixes a "a a" typo in the error message.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=6e4f3440-7815-4fc9-a981-f1603aea521b)

Reviewed By: zeyap

Differential Revision: D115211130


