### PR TITLE
Define RN_BUILDING for React Native's own CMake, SwiftPM, and Buck targets (#57861)

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -959,6 +959,10 @@ extension Target {
       (REMOVE_LEGACY_MODULE_INTEROP ? [.define("RCT_REMOVE_LEGACY_MODULE_INTEROP", to: "1")] : [])
       + (REMOVE_LEGACY_COMPONENT_INTEROP ? [.define("RCT_REMOVE_LEGACY_COMPONENT_INTEROP", to: "1")] : [])
 
+    // Every target built through this factory is React Native's own, so RN_BUILDING
+    // keeps the react/cxxstableapi guards inert for internal sources. cxxSettings are
+    // per-target and are not inherited by packages that depend on React, so this does
+    // not exempt consumers from the guards.
     let cxxSettings =
       [
         .unsafeFlags(["-std=c++20"]),
@@ -967,6 +971,7 @@ extension Target {
         .define("USE_HERMES", to: "1"),
         .define("RCT_REMOVE_LEGACY_ARCH", to: "1"),
         .define("HERMES_V1_ENABLED", to: "1"),
+        .define("RN_BUILDING", to: "1"),
       ] + legacyInteropDefines + defines + cxxCommonHeaderPaths
 
     return .target(

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -58,6 +58,14 @@ add_react_third_party_ndk_subdir(fast_float)
 add_react_third_party_ndk_subdir(fmt)
 add_react_third_party_ndk_subdir(folly)
 
+# Marks everything added below as React Native's own build, so the
+# react/cxxstableapi guards let internal sources keep including the
+# fine-grained headers they fence off from consumers. Deliberately declared
+# after the third-party subdirectories so it never reaches them, and this
+# project never compiles app or third-party module code (those build against
+# the prefab artifacts through ReactNative-application.cmake).
+add_compile_definitions(RN_BUILDING)
+
 # Common targets
 add_react_common_subdir(yoga)
 add_react_common_subdir(runtimeexecutor)


### PR DESCRIPTION
Summary:

React Native's public C++ headers are gaining guards from `react/cxxstableapi`, which
turn a direct include of a fine-grained header into an error for consumers that opt into
the strict API by defining `RN_STRICT_API`. React Native's own sources keep including
those headers directly, so they are exempted via `RN_BUILDING`.

Unlike CocoaPods, these three build systems each have a single chokepoint:

- CMake: one `add_compile_definitions(RN_BUILDING)` in the ReactAndroid JNI project,
  a directory property inherited by every `add_react_common_subdir` below it. It is
  declared *after* the third-party NDK subdirectories so glog/boost/folly/fmt never see
  it, and this project never compiles app or third-party module code.
- SwiftPM: one `.define` in the shared `Target.reactNativeTarget` factory that every
  React Native target is created through. `cxxSettings` are per-target and are not
  inherited by packages that depend on React.
- Buck: a `_set_rn_building_flag` helper called from the four macros React Native's own
  targets use. It is `preprocessor_flags`, deliberately
  not `exported_preprocessor_flags`, so dependents are not exempted either.

This change is inert on its own: nothing behaves differently unless a consumer defines
`RN_STRICT_API`.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D115051088


