### PR TITLE
fix(android): avoid double-counting upload progress

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
@@ -59,7 +59,7 @@ internal class ProgressRequestBody(
 
           @Throws(IOException::class)
           override fun write(data: ByteArray, offset: Int, byteCount: Int) {
-            super.write(data, offset, byteCount)
+            out.write(data, offset, byteCount)
             count += byteCount.toLong()
             sendProgressUpdate()
           }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressRequestBodyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressRequestBodyTest.kt
@@ -11,7 +11,7 @@
 package com.facebook.react.modules.network
 
 import okhttp3.MediaType
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -24,7 +24,7 @@ class ProgressRequestBodyTest {
     val progressUpdates = mutableListOf<ProgressUpdate>()
     val requestBody =
         ProgressRequestBody(
-            RequestBody.create(checkNotNull(MediaType.parse("application/octet-stream")), content),
+            content.toRequestBody(checkNotNull(MediaType.parse("application/octet-stream"))),
             ProgressListener { bytesWritten, contentLength, done ->
               progressUpdates.add(ProgressUpdate(bytesWritten, contentLength, done))
             },

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressRequestBodyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressRequestBodyTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Conflicting okhttp versions
+@file:Suppress("DEPRECATION_ERROR")
+
+package com.facebook.react.modules.network
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.Buffer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProgressRequestBodyTest {
+
+  @Test
+  fun testBulkWritesDoNotDoubleCountProgress() {
+    val content = ByteArray(8 * 1024) { it.toByte() }
+    val progressUpdates = mutableListOf<ProgressUpdate>()
+    val requestBody =
+        ProgressRequestBody(
+            RequestBody.create(checkNotNull(MediaType.parse("application/octet-stream")), content),
+            ProgressListener { bytesWritten, contentLength, done ->
+              progressUpdates.add(ProgressUpdate(bytesWritten, contentLength, done))
+            },
+        )
+    val output = Buffer()
+
+    requestBody.writeTo(output)
+
+    assertThat(output.readByteArray()).isEqualTo(content)
+    assertThat(progressUpdates).isNotEmpty()
+    assertThat(progressUpdates.maxOf { it.bytesWritten }).isEqualTo(content.size.toLong())
+    assertThat(progressUpdates.last())
+        .isEqualTo(ProgressUpdate(content.size.toLong(), content.size.toLong(), true))
+  }
+
+  private data class ProgressUpdate(
+      val bytesWritten: Long,
+      val contentLength: Long,
+      val done: Boolean,
+  )
+}


### PR DESCRIPTION
## Summary

`ProgressRequestBody` wraps its sink in `FilterOutputStream`. On Android, the bulk `write` implementation can dispatch through `write(Int)` for every byte. The bulk override then increments the counter again, so upload progress can report more bytes than the request length.

This changes the bulk write to delegate directly to the wrapped stream before incrementing the counter once. The old `CountingOutputStream` implementation used the same direct delegation.

## Changelog:

[ANDROID] [FIXED] - Avoid double-counting upload progress for bulk writes.

## Test plan

- Added a regression test for an 8 KiB bulk write.
- Verified the payload is unchanged.
- Verified progress never exceeds the content length and finishes with `done = true`.
- Ran the full `com.facebook.react.modules.network.*` unit-test package.
- Ran `ReactAndroid:ktfmtCheck`.