### PR TITLE
fix(virtualized-lists): invalidate content length on orientation change

### DIFF
--- a/packages/virtualized-lists/Lists/ListMetricsAggregator.js
+++ b/packages/virtualized-lists/Lists/ListMetricsAggregator.js
@@ -319,6 +319,7 @@ export default class ListMetricsAggregator {
     if (orientation.horizontal !== this._orientation.horizontal) {
       this._cellMetrics.clear();
       this._averageCellLength = 0;
+      this._contentLength = null;
       this._highestMeasuredCellIndex = 0;
       this._measuredCellsLength = 0;
       this._measuredCellsCount = 0;

--- a/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js
@@ -986,6 +986,43 @@ describe('ListMetricsAggregator', () => {
     expect(listMetrics.getContentLength()).toBe(25);
   });
 
+  it('invalidates content length when list orientation changes', () => {
+    const listMetrics = new ListMetricsAggregator();
+    const verticalOrientation = {horizontal: false, rtl: false};
+    const horizontalOrientation = {horizontal: true, rtl: false};
+    const horizontalRtlOrientation = {horizontal: true, rtl: true};
+    const cellLayout = {height: 50, width: 100, x: 0, y: 0};
+
+    listMetrics.notifyListContentLayout({
+      layout: {height: 800, width: 400},
+      orientation: verticalOrientation,
+    });
+    expect(listMetrics.hasContentLength()).toBe(true);
+
+    listMetrics.notifyCellLayout({
+      cellIndex: 0,
+      cellKey: '0',
+      orientation: horizontalOrientation,
+      layout: cellLayout,
+    });
+    expect(listMetrics.hasContentLength()).toBe(false);
+
+    expect(() =>
+      listMetrics.notifyCellLayout({
+        cellIndex: 0,
+        cellKey: '0',
+        orientation: horizontalRtlOrientation,
+        layout: cellLayout,
+      }),
+    ).toThrow();
+
+    listMetrics.notifyListContentLayout({
+      layout: {height: 50, width: 500},
+      orientation: horizontalRtlOrientation,
+    });
+    expect(listMetrics.getContentLength()).toBe(500);
+  });
+
   it('requires contentLength to resolve RTL metrics', () => {
     const listMetrics = new ListMetricsAggregator();
     const orientation = {horizontal: true, rtl: true};


### PR DESCRIPTION
## Summary

When a list changes between vertical and horizontal layouts, `ListMetricsAggregator` resets its cell measurements but keeps `_contentLength`. That value belongs to the old scrolling axis. In horizontal RTL mode, it can then be used to calculate a cell offset before the new content layout is observed.

This clears `_contentLength` during horizontal orientation changes so RTL calculations wait for the new content length. The reset was present in the original orientation invalidation logic and was removed when bottom-up layout support was removed.

## Changelog:

[GENERAL] [FIXED] - Invalidate list content length when orientation changes.

## Test Plan:

- Added regression coverage for vertical to horizontal content length invalidation.
- Verified horizontal RTL metrics throw until new content layout is observed.
- Ran `yarn jest packages/virtualized-lists/Lists/__tests__/ListMetricsAggregator-test.js --runInBand`.
- Ran Prettier and targeted ESLint checks.