### PR TITLE
Fix radial-gradient position being dropped after an explicit size

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-itest.js
@@ -999,6 +999,22 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toEqual('radial-gradient');
   });
 
+  it('should handle radial gradient with explicit size and position', () => {
+    const input = 'radial-gradient(circle 100px at 25% 75%, red, blue)';
+    const result = processBackgroundImage(input);
+    expect(result[0].shape).toEqual('circle');
+    expect(result[0].size).toEqual({x: 100, y: 100});
+    expect(result[0].position).toEqual({left: '25%', top: '75%'});
+  });
+
+  it('should handle radial gradient with two explicit sizes and position', () => {
+    const input = 'radial-gradient(50px 100px at left bottom, red, blue)';
+    const result = processBackgroundImage(input);
+    expect(result[0].shape).toEqual('ellipse');
+    expect(result[0].size).toEqual({x: 50, y: 100});
+    expect(result[0].position).toEqual({left: '0%', top: '100%'});
+  });
+
   // 1. position syntax: [ left | center | right | top | bottom | <length-percentage> ]
   it('should handle radial gradient position length syntax', () => {
     const input = 'radial-gradient(circle at 20px, red, blue)';

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -348,6 +348,11 @@ function parseRadialGradientCSSString(
         size = {x: sizeX, y: sizeY};
       } else {
         hasExplicitSingleSize = true;
+        // The token after the size is not a second size value (e.g. 'at' or a
+        // shape keyword). Put it back so the loop can process it, otherwise
+        // the position would be silently dropped and its values re-parsed as
+        // a new size.
+        firstPartTokens.unshift(token);
       }
     } else if (tokenTrimmed === 'at') {
       let top: string | number;


### PR DESCRIPTION
## Summary:

`processBackgroundImage` silently drops the `at <position>` clause of a radial gradient whenever it follows an explicit size, and then re-parses the position values as a new size that overrides the declared one.

In the explicit-size branch of `parseRadialGradientCSSString`, the parser shifts the next token to look for a second size value. When that token is not a length/percentage it is discarded instead of being put back — so for `radial-gradient(circle 100px at 25% 75%, red, blue)` the `at` token is swallowed, the loop then treats `25%` and `75%` as a new `<size>`, and the gradient parses as:

```js
// before
{shape: 'circle', size: {x: '25%', y: '75%'}, position: {top: '50%', left: '50%'}}
// after (matches web)
{shape: 'circle', size: {x: 100, y: 100}, position: {left: '25%', top: '75%'}}
```

The bug was invisible in tests because the only existing test for this syntax uses `at center`, which is indistinguishable from the default position.

The fix is to unshift the peeked token back so the main loop processes it (this also fixes `<size> <shape>` orderings like `100px ellipse`, where the shape keyword was previously swallowed too). The structured C++ parser in `react/renderer/css/CSSBackgroundImage.h` is not affected — this is specific to the JS tokenizer.

## Changelog:

[GENERAL] [FIXED] - Fix radial-gradient `at <position>` being ignored (and corrupting the size) when it follows an explicit size

## Test Plan:

Added two Fantom tests in `processBackgroundImage-itest.js` covering `circle 100px at 25% 75%` (single explicit size + position) and `50px 100px at left bottom` (two sizes + keyword position).

Verified the parse output for a matrix of radial gradient strings against Chrome's accepted/computed values (all match after the fix, including the untouched `circle 100px at center` case covered by the existing test):

| input | before | after |
| --- | --- | --- |
| `circle 100px at 25% 75%` | size `{25%, 75%}`, position center | size `{100, 100}`, position `{left 25%, top 75%}` |
| `50px 100px at left bottom` | unaffected | unaffected |
| `circle 100px at center` | ✓ (masked the bug) | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
