### PR TITLE
Fix PackageList.java generation for dependencies with multiple package instances

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
@@ -64,10 +64,19 @@ abstract class GeneratePackageListTask : DefaultTask() {
    * Extracts the fully qualified class name from an import statement. E.g., "import
    * com.foo.bar.MyClass;" -> "com.foo.bar.MyClass"
    */
-  internal fun extractFqcnFromImport(importStatement: String): String? {
-    val match = Regex("import\\s+([\\w.]+)\\s*;").find(importStatement)
-    return match?.groupValues?.get(1)
-  }
+  internal fun extractFqcnFromImport(importStatement: String): String? =
+      extractFqcsFromImports(importStatement).firstOrNull()
+
+  /**
+   * Extracts the fully qualified class name from every import statement. E.g., "import
+   * com.foo.bar.MyClass;\nimport com.foo.baz.MyOtherClass;" -> ["com.foo.bar.MyClass",
+   * "com.foo.baz.MyOtherClass"]
+   */
+  internal fun extractFqcsFromImports(importStatements: String): List<String> =
+      Regex("import\\s+([\\w.]+)\\s*;")
+          .findAll(importStatements)
+          .map { it.groupValues[1] }
+          .toList()
 
   internal fun composePackageInstance(
       packageName: String,
@@ -87,14 +96,19 @@ abstract class GeneratePackageListTask : DefaultTask() {
           val interpolated = interpolateDynamicValues(packageInstance, packageName)
 
           // Use FQCN to avoid class name collisions between different packages
-          val fqcn = extractFqcnFromImport(interpolateDynamicValues(packageImportPath, packageName))
+          val interpolatedImportPath = interpolateDynamicValues(packageImportPath, packageName)
+          val fqcnByClassName =
+              extractFqcsFromImports(interpolatedImportPath)
+                  .associateBy { it.substringAfterLast('.') }
           val fqcnInstance =
-              if (fqcn != null) {
-                val className = fqcn.substringAfterLast('.')
-                // Replace the short class name with FQCN in the instance
-                interpolated.replace(Regex("\\b${Regex.escape(className)}\\b")) { fqcn }
-              } else {
+              if (fqcnByClassName.isEmpty()) {
                 interpolated
+              } else {
+                val classNamePattern = fqcnByClassName.keys.joinToString("|") { Regex.escape(it) }
+                // Replace every short class name with its FQCN in the instance
+                interpolated.replace(Regex("\\b(?:$classNamePattern)\\b")) { match ->
+                  fqcnByClassName.getValue(match.value)
+                }
               }
 
           // Add comment with package name before each instance

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GeneratePackageListTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GeneratePackageListTaskTest.kt
@@ -84,6 +84,42 @@ class GeneratePackageListTaskTest {
   }
 
   @Test
+  fun composePackageInstance_withMultipleImportsInOneDependency_returnsFqcnForEachInstance() {
+    val task = createTestTask<GeneratePackageListTask>()
+    val packageName = "com.facebook.react"
+
+    val result =
+        task.composePackageInstance(
+            packageName,
+            mapOf(
+                "@react-native/appsflyer" to
+                    ModelAutolinkingDependenciesPlatformAndroidJson(
+                        sourceDir = "./appsflyer/directory",
+                        packageImportPath =
+                            """
+                            import com.appsflyer.reactnative.RNAppsFlyerPackage;
+                            import com.appsflyer.reactnative.PCAppsFlyerPackage;
+                            """
+                                .trimIndent(),
+                        packageInstance =
+                            """
+                            new RNAppsFlyerPackage(),
+                            new PCAppsFlyerPackage()
+                            """
+                                .trimIndent(),
+                        buildTypes = emptyList(),
+                    ),
+            ),
+        )
+
+    assertThat(result)
+        .contains("new com.appsflyer.reactnative.RNAppsFlyerPackage()")
+        .contains("new com.appsflyer.reactnative.PCAppsFlyerPackage()")
+        .doesNotContain("new RNAppsFlyerPackage()")
+        .doesNotContain("new PCAppsFlyerPackage()")
+  }
+
+  @Test
   fun interpolateDynamicValues_withNoBuildConfigOrROccurrencies_doesNothing() {
     val packageName = "com.facebook.react"
     val input = "com.facebook.react.aPackage"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

A dependency that registers **multiple** React packages via `react-native.config.js` (e.g. `react-native-appsflyer`) fails to generate a compiling `PackageList.java`.

```js
// node_modules/react-native-appsflyer/react-native.config.js
dependency: {
  platforms: {
    android: {
      packageImportPath: [
        'import com.appsflyer.reactnative.RNAppsFlyerPackage;',
        'import com.appsflyer.reactnative.PCAppsFlyerPackage;',
      ].join('\n'),
      packageInstance: [
        'new RNAppsFlyerPackage()',
        'new PCAppsFlyerPackage()',
      ].join(',\n'),
    },
  },
},
```

PR #54736 introduced FQCN rewriting to avoid class-name collisions, but `extractFqcnFromImport` uses `Regex(...).find()`, which only returns the **first** import match, and the code rewrites only that single short class name in the instance string. The 2nd+ package instances keep a bare short class name with no import, so the generated `PackageList.java` does not compile:

```java
new com.appsflyer.reactnative.RNAppsFlyerPackage(),
new PCAppsFlyerPackage(),   // cannot find symbol
```

Fixes #55653

This change extracts the FQCN from **every** import line and rewrites **every** bare short class name in the package instance string with its FQCN. Behaviour for the single-package case is unchanged.

## Changelog:

[ANDROID] [FIXED] - Autolink: qualify every package instance in the generated PackageList.java when a dependency registers multiple packages

## Test Plan:

Added a `GeneratePackageListTaskTest` case with a dependency providing two imports and two package instances, asserting the generated string contains **both** FQCNs and no bare `new <ShortName>()` token.

**RED** (before the fix) — the new test fails because the 2nd instance stays bare:

```text
GeneratePackageListTaskTest > composePackageInstance_withMultipleImportsInOneDependency_returnsFqcnForEachInstance FAILED
    java.lang.AssertionError:
    Expecting actual:
      ",
          // @react-native/appsflyer
          new com.appsflyer.reactnative.RNAppsFlyerPackage(),
    new PCAppsFlyerPackage()"
    to contain:
      "new com.appsflyer.reactnative.PCAppsFlyerPackage()"
17 tests completed, 1 failed
```

**GREEN** (after the fix):

```text
> Task :react-native-gradle-plugin:test
BUILD SUCCESSFUL in 10s
```

Full `react-native-gradle-plugin` suite (`./gradlew :react-native-gradle-plugin:test --max-workers=2`): 216 tests, 0 failures, 0 errors — no regressions.
