### PR TITLE
fix(Settings): defer Platform lookup to fix circular dependency startup crash (#56967)

### DIFF
--- a/packages/react-native/Libraries/Settings/Settings.js
+++ b/packages/react-native/Libraries/Settings/Settings.js
@@ -8,9 +8,7 @@
  * @format
  */
 
-import Platform from '../Utilities/Platform';
-
-let Settings: {
+type SettingsStatic = {
   get(key: string): any,
   set(settings: Object): void,
   watchKeys(keys: string | Array<string>, callback: () => void): number,
@@ -18,10 +16,37 @@ let Settings: {
   ...
 };
 
-if (Platform.OS === 'ios') {
-  Settings = require('./Settings').default;
-} else {
-  Settings = require('./SettingsFallback').default;
+let SettingsImpl: ?SettingsStatic = null;
+
+function getSettings(): SettingsStatic {
+  if (SettingsImpl != null) {
+    return SettingsImpl;
+  }
+  const Platform = require('../Utilities/Platform').default;
+  if (Platform.OS === 'ios') {
+    SettingsImpl = require('./Settings').default;
+  } else {
+    SettingsImpl = require('./SettingsFallback').default;
+  }
+  return (SettingsImpl: SettingsStatic);
 }
+
+const Settings: SettingsStatic = {
+  get(key: string): any {
+    return getSettings().get(key);
+  },
+
+  set(settings: Object): void {
+    getSettings().set(settings);
+  },
+
+  watchKeys(keys: string | Array<string>, callback: () => void): number {
+    return getSettings().watchKeys(keys, callback);
+  },
+
+  clearWatch(watchId: number): void {
+    getSettings().clearWatch(watchId);
+  },
+};
 
 export default Settings;

--- a/packages/react-native/Libraries/Settings/__tests__/Settings-test.js
+++ b/packages/react-native/Libraries/Settings/__tests__/Settings-test.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+describe('Settings', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('should not throw due to circular dependency during Platform initialization', () => {
+    // Intercept NativePlatformConstantsIOS (which Platform.ios requires during
+    // load) to simulate another module requiring Settings during Platform's
+    // initialization phase.
+    jest.mock('../../Utilities/NativePlatformConstantsIOS', () => {
+      // Accessing Settings while Platform is loading
+      require('../Settings.js');
+      return {
+        getConstants() {
+          return {
+            interfaceIdiom: 'phone',
+            isTesting: true,
+            osVersion: '16.0',
+            systemName: 'iOS',
+          };
+        },
+      };
+    });
+
+    expect(() => {
+      require('../../Utilities/Platform');
+    }).not.toThrow();
+  });
+
+  it('defers accessing Platform until a method is first invoked', () => {
+    let platformAccessCount = 0;
+    jest.doMock('../../Utilities/Platform', () => ({
+      __esModule: true,
+      get default() {
+        platformAccessCount++;
+        return {OS: 'android'};
+      },
+    }));
+
+    const Settings = require('../Settings.js').default;
+    expect(platformAccessCount).toBe(0);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    Settings.get('any');
+    expect(platformAccessCount).toBeGreaterThan(0);
+    warnSpy.mockRestore();
+  });
+
+  it('delegates get/set/watchKeys/clearWatch to the iOS implementation', () => {
+    const setValues = jest.fn();
+    jest.doMock('../../Utilities/Platform', () => ({
+      __esModule: true,
+      default: {OS: 'ios'},
+    }));
+    jest.doMock('../NativeSettingsManager', () => ({
+      __esModule: true,
+      default: {
+        getConstants: () => ({settings: {existing: 'initial'}}),
+        setValues,
+      },
+    }));
+
+    const Settings = require('../Settings.js').default;
+
+    expect(Settings.get('existing')).toBe('initial');
+    Settings.set({added: 'value'});
+    expect(Settings.get('added')).toBe('value');
+    expect(setValues).toHaveBeenCalledWith({added: 'value'});
+
+    const watchId = Settings.watchKeys('key', () => {});
+    expect(typeof watchId).toBe('number');
+    expect(() => Settings.clearWatch(watchId)).not.toThrow();
+  });
+
+  it('uses the fallback implementation on non-iOS platforms', () => {
+    jest.doMock('../../Utilities/Platform', () => ({
+      __esModule: true,
+      default: {OS: 'android'},
+    }));
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const Settings = require('../Settings.js').default;
+
+    expect(Settings.get('foo')).toBeNull();
+    expect(Settings.watchKeys('foo', () => {})).toBe(-1);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary:

Fixes #56967.

`Settings.js` evaluated `Platform.OS` at **module load time** (a top-level `if (Platform.OS === 'ios')` branch after importing `Platform` from `../Utilities/Platform`). When another module required `Settings` while `Platform.ios.js` / `Platform.android.js` was still mid-initialization (circular require — e.g. `NativePlatformConstantsIOS` being loaded by `Platform.ios.js`), the `Platform` export object was not yet populated, so `Platform.OS` dereferenced `undefined` and threw:

```
TypeError: Cannot read properties of undefined (reading 'OS')
  at Object.OS (Libraries/Settings/Settings.js:21:14)
  at require (.../Utilities/Platform.ios.js:13:1)
```

This fix defers the platform lookup: `Platform` is now required lazily inside `getSettings()` on the first method call, instead of at module load. The public API is unchanged (`get` / `set` / `watchKeys` / `clearWatch` still delegate to the iOS implementation on iOS and the fallback implementation elsewhere), matching the existing `Settings.d.ts`.

## Changelog:

[GENERAL] [FIXED] - Defer Platform lookup in Settings.js to fix circular dependency startup crash

## Test Plan:

Added `packages/react-native/Libraries/Settings/__tests__/Settings-test.js` (none existed) with 4 tests:
1. the circular-dependency repro from the issue,
2. lazy Platform access (Platform not touched at module load),
3. iOS delegation (get/set/watchKeys/clearWatch call through to `NativeSettingsManager`),
4. non-iOS fallback behavior.

**RED** — on the unmodified code, the circular-dependency test fails with exactly the reported bug:

```
● Settings › should not throw due to circular dependency during Platform initialization
  expect(received).not.toThrow()
  Error name:    "TypeError"
  Error message: "Cannot read properties of undefined (reading 'OS')"
        > 21 | if (Platform.OS === 'ios') {
             |              ^
  at Object.OS (packages/react-native/Libraries/Settings/Settings.js:21:14)
  at require (.../Libraries/Utilities/Platform.ios.js:13:1)
Test Suites: 1 failed, 1 total
Tests:       2 failed, 2 passed, 4 total
```

**GREEN** — after the fix:

```
PASS packages/react-native/Libraries/Settings/__tests__/Settings-test.js
  Settings
    ✓ should not throw due to circular dependency during Platform initialization
    ✓ defers accessing Platform until a method is first invoked
    ✓ delegates get/set/watchKeys/clearWatch to the iOS implementation
    ✓ uses the fallback implementation on non-iOS platforms
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```

**Regression check** — Settings + Utilities suites (Platform lives in `Libraries/Utilities`):

```
PASS packages/react-native/Libraries/Settings/__tests__/Settings-test.js
PASS packages/react-native/Libraries/Utilities/__tests__/ReactNativeTestTools-test.js
PASS packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
Test Suites: 3 passed, 3 total
Tests:       15 passed, 15 total
```

Also verified: `eslint` on the changed files exits clean (0 errors).
