### PR TITLE
Allow opting into RCT_REMOVE_LEGACY_*_INTEROP on iOS OSS (#57892)

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -11,6 +11,13 @@ import PackageDescription
 
 let BUILD_FROM_SOURCE = false
 
+// Removing the legacy TurboModule and component interop layers is opt-in while those
+// layers are still supported. Both will default to on in a future React Native release.
+let REMOVE_LEGACY_MODULE_INTEROP =
+  ProcessInfo.processInfo.environment["RCT_REMOVE_LEGACY_MODULE_INTEROP"] == "1"
+let REMOVE_LEGACY_COMPONENT_INTEROP =
+  ProcessInfo.processInfo.environment["RCT_REMOVE_LEGACY_COMPONENT_INTEROP"] == "1"
+
 /**
  This is the `Package.swift` file that allows to build React Native core using Swift PM.
  To build React Native, you need to follow these steps:
@@ -948,6 +955,10 @@ extension Target {
         CXXSetting.headerSearchPath(relativeSearchPath(numOfSlash + 1, ".build/headers/React")),
       ]
 
+    let legacyInteropDefines: [CXXSetting] =
+      (REMOVE_LEGACY_MODULE_INTEROP ? [.define("RCT_REMOVE_LEGACY_MODULE_INTEROP", to: "1")] : [])
+      + (REMOVE_LEGACY_COMPONENT_INTEROP ? [.define("RCT_REMOVE_LEGACY_COMPONENT_INTEROP", to: "1")] : [])
+
     let cxxSettings =
       [
         .unsafeFlags(["-std=c++20"]),
@@ -956,7 +967,7 @@ extension Target {
         .define("USE_HERMES", to: "1"),
         .define("RCT_REMOVE_LEGACY_ARCH", to: "1"),
         .define("HERMES_V1_ENABLED", to: "1"),
-      ] + defines + cxxCommonHeaderPaths
+      ] + legacyInteropDefines + defines + cxxCommonHeaderPaths
 
     return .target(
       name: name,

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -35,6 +35,8 @@ class UtilsTests < Test::Unit::TestCase
         XcodebuildMock.reset()
         ENV['RCT_NEW_ARCH_ENABLED'] = '0'
         ENV['USE_FRAMEWORKS'] = nil
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = nil
+        ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = nil
         system_reset_commands
         $RN_PLATFORMS = nil
     end
@@ -466,6 +468,113 @@ class UtilsTests < Test::Unit::TestCase
         end
 
         assert_equal(1, user_project_mock.save_invocation_count)
+    end
+
+    # ============================================ #
+    # Test - Set legacy interop removal flags      #
+    # ============================================ #
+
+    def legacy_interop_installer_mock(user_project_mock)
+        return InstallerMock.new(
+            PodsProjectMock.new([], {"hermes-engine" => {}}),
+            [AggregatedProjectMock.new(user_project_mock)]
+        )
+    end
+
+    def assert_legacy_interop_flags(user_project_mock, module_interop:, component_interop:)
+        user_project_mock.build_configurations.each do |config|
+            ["OTHER_CFLAGS", "OTHER_CPLUSPLUSFLAGS"].each do |key|
+                setting = config.build_settings[key]
+                assert_equal(module_interop, setting.include?("-DRCT_REMOVE_LEGACY_MODULE_INTEROP=1"))
+                assert_equal(component_interop, setting.include?("-DRCT_REMOVE_LEGACY_COMPONENT_INTEROP=1"))
+            end
+        end
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenFlagsAreUnset_doesNotAddFlags
+        # Arrange
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+
+        # Act
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Assert
+        assert_legacy_interop_flags(user_project_mock, module_interop: false, component_interop: false)
+        assert_equal([], Pod::UI.collected_warns)
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenModuleInteropIsEnabled_addsOnlyThatFlag
+        # Arrange
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = '1'
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+
+        # Act
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Assert
+        assert_legacy_interop_flags(user_project_mock, module_interop: true, component_interop: false)
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenComponentInteropIsEnabled_addsOnlyThatFlag
+        # Arrange
+        ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = '1'
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+
+        # Act
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Assert
+        assert_legacy_interop_flags(user_project_mock, module_interop: false, component_interop: true)
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenBothAreEnabled_addsBothFlags
+        # Arrange
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = '1'
+        ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = '1'
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+
+        # Act
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Assert
+        assert_legacy_interop_flags(user_project_mock, module_interop: true, component_interop: true)
+        assert_equal([], Pod::UI.collected_warns)
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenDisabled_removesPreviouslyAddedFlags
+        # Arrange
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = '1'
+        ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = '1'
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Act
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = '0'
+        ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = '0'
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: true)
+
+        # Assert
+        assert_legacy_interop_flags(user_project_mock, module_interop: false, component_interop: false)
+    end
+
+    def test_setLegacyInteropRemovalFlags_whenEnabledWithPrebuiltRNCore_warns
+        # Arrange
+        ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = '1'
+        user_project_mock = prepare_empty_user_project_mock()
+        installer = legacy_interop_installer_mock(user_project_mock)
+
+        # Act
+        ReactNativePodsUtils.set_legacy_interop_removal_flags(installer, build_rncore_from_source: false)
+
+        # Assert
+        assert_equal(1, Pod::UI.collected_warns.length)
+        assert(Pod::UI.collected_warns.first.include?("RCT_REMOVE_LEGACY_MODULE_INTEROP=1"))
+        assert(Pod::UI.collected_warns.first.include?("RCT_USE_PREBUILT_RNCORE=0"))
     end
 
     # ==================================== #

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -16,6 +16,13 @@ class ReactNativePodsUtils
     MAVEN_CENTRAL_REPOSITORY = "https://repo1.maven.org/maven2"
     REACT_NATIVE_MAVEN_MIRROR_REPOSITORY = "https://repo.reactnative.dev/maven2"
 
+    # Opt-in removal of the legacy TurboModule and component interop layers. Both are
+    # off by default and will become the default in a future React Native release.
+    LEGACY_INTEROP_REMOVAL_FLAGS = [
+        'RCT_REMOVE_LEGACY_MODULE_INTEROP',
+        'RCT_REMOVE_LEGACY_COMPONENT_INTEROP',
+    ]
+
     # URI::File.build validates path components as ASCII, so escape the filesystem path first.
     def self.local_file_uri(path)
         URI::File.build(path: URI::DEFAULT_PARSER.escape(path)).to_s
@@ -503,6 +510,23 @@ class ReactNativePodsUtils
                 self.remove_flag_in_config(config, flag, configuration: configuration)
             end
             project.save()
+        end
+    end
+
+    # The macros gate declarations in public headers (RCTBridge.h, RCTBridgeModule.h), so
+    # they are applied to the whole project rather than to React Native's pods alone.
+    def self.set_legacy_interop_removal_flags(installer, build_rncore_from_source:)
+        LEGACY_INTEROP_REMOVAL_FLAGS.each do |flag|
+            if ENV[flag] == '1'
+                self.add_compiler_flag_to_project(installer, "-D#{flag}=1")
+                unless build_rncore_from_source
+                    Pod::UI.warn("#{flag}=1 only prunes your app's headers while using the prebuilt " \
+                        "React.xcframework. Set RCT_USE_PREBUILT_RNCORE=0 to also compile React Native " \
+                        "without the legacy interop layer.")
+                end
+            else
+                self.remove_compiler_flag_from_project(installer, "-D#{flag}=1")
+            end
         end
     end
 

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -118,6 +118,10 @@ def use_react_native! (
   # Make `REMOVE_LEGACY_ARCH` enabled by default. This will build React Native
   # excluding the legacy arch unless the user turns this flag off explicitly.
   ENV['RCT_REMOVE_LEGACY_ARCH'] = ENV['RCT_REMOVE_LEGACY_ARCH'] == '0' ? '0' : '1'
+  # Removing the legacy TurboModule and component interop layers is opt-in while those
+  # layers are still supported. Both will default to 1 in a future React Native release.
+  ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] = ENV['RCT_REMOVE_LEGACY_MODULE_INTEROP'] == '1' ? '1' : '0'
+  ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] = ENV['RCT_REMOVE_LEGACY_COMPONENT_INTEROP'] == '1' ? '1' : '0'
 
   ReactNativePodsUtils.check_minimum_required_xcode()
 
@@ -603,6 +607,11 @@ def react_native_post_install(
   else
     ReactNativePodsUtils.remove_compiler_flag_from_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
   end
+
+  ReactNativePodsUtils.set_legacy_interop_removal_flags(
+    installer,
+    build_rncore_from_source: ReactNativeCoreUtils.build_rncore_from_source()
+  )
 
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)


### PR DESCRIPTION
Summary:

Changelog: [iOS][Added] - Allow consumers to opt into `RCT_REMOVE_LEGACY_MODULE_INTEROP` and `RCT_REMOVE_LEGACY_COMPONENT_INTEROP` from CocoaPods and SwiftPM. Both default to off and will become the default in a future release

OSS iOS consumers had no way to set `-DRCT_REMOVE_LEGACY_MODULE_INTEROP=1` and `-DRCT_REMOVE_LEGACY_COMPONENT_INTEROP=1`.
 This adds that, mirroring the existing
`RCT_REMOVE_LEGACY_ARCH` plumbing:

- `RCT_REMOVE_LEGACY_MODULE_INTEROP=1` / `RCT_REMOVE_LEGACY_COMPONENT_INTEROP=1` before
  `pod install` adds the define project-wide via
  `ReactNativePodsUtils.set_legacy_interop_removal_flags`.
- The same variables gate a matching `.define(...)` in `Package.swift`, so a
  build-from-source React Native compiles without the legacy interop layers too.

Both default to `0`. **They will default to `1` in a future release**, at which point
the env vars become opt-out.

The macros gate declarations in the public `RCTBridge.h` / `RCTBridgeModule.h`, so the
define is applied to the whole project rather than to React Native pods alone. When a
flag is enabled while using the prebuilt `React.xcframework`, `pod install` warns that
only the app-side pruning takes effect.

Reviewed By: cipolleschi

Differential Revision: D115490838


