### PR TITLE
fix: resolve image-size to image-size-next (CVE-2025-71329/71330)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "^4.5.6",
     "yaml": "^2.8.3",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.2",
+    "image-size": "npm:image-size-next@2.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5317,12 +5317,11 @@ ignore@^7.0.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-image-size@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.1.1.tgz#ddd67d4dc340e52ac29ce5f546a09f4e29e840ac"
-  integrity sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==
-  dependencies:
-    queue "6.0.2"
+image-size@^1.0.2, "image-size@npm:image-size-next@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/image-size-next/-/image-size-next-2.1.0.tgz#f0c2d5ea995f6beb974b17c02265d924647a360f"
+  integrity sha512-OUXyc22p+zA9CmiJbuYygTcoHbmZ9tFnJ0NX8LcgfewtrKJnfM+zYwsfrNdoKqz9WsSPTR++2yz+Fqz7Rzvvjg==
+
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
## Summary

`metro@^0.87.0` (pulled into this monorepo) depends on **`image-size@^1.0.2`**, which currently resolves to an **archived / unmaintained** package still affected by:

- **CVE-2025-71329** — DoS infinite loop (JXL/HEIF/JP2 zero-size boxes)
- **CVE-2025-71330** — DoS infinite loop (ICNS zero entry length)

This PR adds a Yarn **`resolutions`** entry so nested `image-size` installs resolve to the community MIT drop-in **`image-size-next@2.1.0`** (same public API as `image-size@2.x`, drop-in for Metro’s usage), and updates `yarn.lock` accordingly.

- npm: https://www.npmjs.com/package/image-size-next
- GitHub: https://github.com/lcf2212dev/image-size-next

Not affiliated with the original `image-size` maintainer.

Relates to #57888

## Changelog:

[GENERAL] [SECURITY] - Force resolution of vulnerable `image-size` to maintained `image-size-next@2.1.0` (CVE-2025-71329 / CVE-2025-71330)

## Test Plan:

- Confirmed with Yarn classic 1.22.x that `"resolutions": { "image-size": "npm:image-size-next@2.1.0" }` installs `image-size-next@2.1.0` into the `image-size` slot used by Metro.
- `yarn.lock` updated to the published tarball + integrity for `image-size-next@2.1.0`.
- Recommend CI: full install + existing Metro/asset pipeline tests.

## Notes for reviewers

- Longer-term fix may live in **facebook/metro** (change the direct dependency). This monorepo resolution unblocks RN consumers immediately.
- `npm audit fix` cannot rename packages; an override/resolution is required.

(Replaces closed PR #57894 — fresh branch with signed commit.)