### PR TITLE
perf: Cache normalisedColors output

### DIFF
--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -26,14 +26,17 @@ function normalizeColor(color) {
     return null;
   }
 
-  const cachedColor = cachedColors.get(color);
-  if (cachedColor !== undefined) {
+  if (cachedColors.has(color)) {
+    // Map iteration order follows insertion order, so re-inserting on every
+    // hit keeps the least-recently-used entry first.
+    const cachedColor = cachedColors.get(color);
+    cachedColors.delete(color);
+    cachedColors.set(color, cachedColor);
     return cachedColor;
   }
   const normalizedColor = parseColorString(color);
-  // To avoid CachedColors increasing indefinetly
   if (cachedColors.size >= 1024) {
-    cachedColors.clear();
+    cachedColors.delete(cachedColors.keys().next().value);
   }
   cachedColors.set(color, normalizedColor);
   return normalizedColor;

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -12,6 +12,8 @@
 
 'use strict';
 
+const cachedColors = new Map();
+
 function normalizeColor(color) {
   if (typeof color === 'number') {
     if (color >>> 0 === color && color >= 0 && color <= 0xffffffff) {
@@ -23,6 +25,21 @@ function normalizeColor(color) {
   if (typeof color !== 'string') {
     return null;
   }
+
+  const cachedColor = cachedColors.get(color);
+  if (cachedColor !== undefined) {
+    return cachedColor;
+  }
+  const normalizedColor = parseColorString(color);
+  // To avoid CachedColors increasing indefinetly
+  if (cachedColors.size >= 1024) {
+    cachedColors.clear();
+  }
+  cachedColors.set(color, normalizedColor);
+  return normalizedColor;
+}
+
+function parseColorString(color) {
 
   const matchers = getMatchers();
   let match;

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -40,7 +40,6 @@ function normalizeColor(color) {
 }
 
 function parseColorString(color) {
-
   const matchers = getMatchers();
   let match;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While looking into something I saw this processColor function , for every color we  are calculating normalise Color even though it would have been done earlier.
This is a simple approach. Maybe we can add things like LRU. With some simple scripts(Rendering around 1000 cells) I found around 13% faster .
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL][FIXED] - use cached results for already normalised colors
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Tested in RN tester. 
