### PR TITLE
Fix Text truncation at NULL character on iOS and Android (#24129)

### DIFF
--- a/packages/react-native/React/Fabric/RCTConversions.h
+++ b/packages/react-native/React/Fabric/RCTConversions.h
@@ -34,7 +34,9 @@ inline NSString *RCTNSStringFromString(
     const std::string &string,
     const NSStringEncoding &encoding = NSUTF8StringEncoding)
 {
-  return [NSString stringWithCString:string.c_str() encoding:encoding] ?: @"";
+  return [[NSString alloc] initWithBytes:string.data()
+                                  length:string.size()
+                                encoding:encoding] ?: @"";
 }
 
 inline NSString *_Nullable RCTNSStringFromStringNilIfEmpty(
@@ -46,7 +48,14 @@ inline NSString *_Nullable RCTNSStringFromStringNilIfEmpty(
 
 inline std::string RCTStringFromNSString(NSString *string)
 {
-  return std::string{string.UTF8String ?: ""};
+  if (!string) {
+    return "";
+  }
+  NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
+  if (!data) {
+    return "";
+  }
+  return std::string{(const char *)data.bytes, data.length};
 }
 
 inline UIColor *_Nullable RCTUIColorFromSharedColor(const facebook::react::SharedColor &sharedColor)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -406,8 +406,10 @@ JNIArgs convertJSIArgsToJNIArgs(
         throw JavaTurboModuleArgumentConversionException(
             "string", argIndex, methodName, arg, &rt);
       }
-      jarg->l = makeGlobalIfNecessary(
-          env->NewStringUTF(arg->getString(rt).utf8(rt).c_str()));
+      auto utf16 = rt.utf16(arg->getString(rt));
+      jarg->l = makeGlobalIfNecessary(env->NewString(
+          reinterpret_cast<const jchar*>(utf16.data()),
+          static_cast<jsize>(utf16.size())));
     } else if (type == "Lcom/facebook/react/bridge/Callback;") {
       if (!(arg->isObject() && arg->getObject(rt).isFunction(rt))) {
         throw JavaTurboModuleArgumentConversionException(
@@ -785,11 +787,14 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
 
       jsi::Value returnValue = jsi::Value::null();
       if (returnString != nullptr) {
-        const char* js = env->GetStringUTFChars(returnString, nullptr);
-        std::string result = js;
-        env->ReleaseStringUTFChars(returnString, js);
-        returnValue =
-            jsi::Value(runtime, jsi::String::createFromUtf8(runtime, result));
+        jsize length = env->GetStringLength(returnString);
+        const jchar* chars = env->GetStringChars(returnString, nullptr);
+        auto jsiString = jsi::String::createFromUtf16(
+            runtime,
+            reinterpret_cast<const char16_t*>(chars),
+            static_cast<size_t>(length));
+        env->ReleaseStringChars(returnString, chars);
+        returnValue = jsi::Value(runtime, jsiString);
       }
 
       TMPL::syncMethodCallReturnConversionEnd(moduleName, methodName);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -143,7 +143,10 @@ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value)
 
 static NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::String &value)
 {
-  return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
+  auto utf8 = value.utf8(runtime);
+  return [[NSString alloc] initWithBytes:utf8.data()
+                                  length:utf8.size()
+                                encoding:NSUTF8StringEncoding] ?: @"";
 }
 
 static NSArray *convertJSIArrayToNSArray(

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -417,7 +417,9 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentFromFragment(
 
     return [[NSMutableAttributedString attributedStringWithAttachment:attachment] mutableCopy];
   } else {
-    NSString *string = [NSString stringWithUTF8String:fragment.string.c_str()];
+    NSString *string = [[NSString alloc] initWithBytes:fragment.string.data()
+                                                length:fragment.string.size()
+                                              encoding:NSUTF8StringEncoding] ?: @"";
 
     if (fragment.textAttributes.textTransform.has_value()) {
       auto textTransform = fragment.textAttributes.textTransform.value();

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -400,9 +400,12 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                          .width = usedRect.size.width, .height = usedRect.size.height}};
 
                                  CGFloat baseline = [layoutManager locationForGlyphAtIndex:range.location].y;
-                                 const char *renderedUTF8 = [renderedString UTF8String];
+                                 NSData *renderedData =
+                                     [renderedString dataUsingEncoding:NSUTF8StringEncoding];
                                  auto line = LineMeasurement{
-                                     std::string(renderedUTF8 != nullptr ? renderedUTF8 : ""),
+                                     std::string(
+                                         renderedData ? (const char *)renderedData.bytes : "",
+                                         renderedData ? renderedData.length : 0),
                                      rect,
                                      overallRect.size.height - baseline,
                                      font.capHeight,


### PR DESCRIPTION
Fixes https://github.com/react/react-native/issues/24129

## Summary:
**Problem:** `<Text>{'Hello \u0000 World'}</Text>` renders as "Hello" (truncated at \u0000). Does NOT reproduce when Debug JS Remotely (JSON preserves \u0000), but reproduces in production Hermes+Fabric on iOS and Android.

**Root cause:** JS String preserves \u0000 (length includes it), C++ std::string from JSI utf8() also preserves via size. Truncation happens at platform bridge where C-string NUL-terminated APIs are used:
- iOS: RCTAttributedTextUtils.mm:420 stringWithUTF8String:fragment.string.c_str() stops at embedded \0
- iOS: RCTConversions.h RCTNSStringFromString via stringWithCString: and reverse std::string{UTF8String}
- iOS: RCTTurboModule.mm convertJSIStringToNSString same
- Android: JavaTurboModule.cpp NewStringUTF(c_str()) expects NUL-terminated

**Fix (4 files, ~10 lines, no new API):** Replace C-string APIs with length-aware [[NSString alloc] initWithBytes:data length:size encoding:NSUTF8StringEncoding] (same as existing correct pattern in FollyConvert.mm:31 and MapBufferBuilder.cpp) and Android convertUTF8ToUTF16 + NewString(jchar*, len) + assign(jsChars, GetStringUTFLength()). All surfaces (Text, TextInput, accessibility, TurboModule params) fixed at once because shared converters are fixed.

## Changelog:
[GENERAL] [FIXED] - Fix Text truncation when string contains NULL character \u0000 (#24129)

## Test Plan:
**Reproduction (RNTester):**
- Add screen Text > NullCharacter with <Text>{'Hello\u0000World'}</Text> and 'A\u0000B\u0000C'
- Before: "Hello" truncated
- After: "HelloWorld" full (invisible \0 zero-width but World visible, length preserved)

**Commands:**
```bash
yarn lint
# → Done (max-warnings 0)

# Text itest requires buck, but JS unit for length preservation:
node -p "'a\u0000b'.length" # → 3
```

Closes #24129