### PR TITLE
[Android] Ellipsize single-line TextInput placeholders

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -591,8 +591,6 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     }
     wasMultiline = isMultiline
 
-    // Keep placeholder ellipsize in sync when multiline flips. Single-line inputs should
-    // trail with "…" (matching iOS); multiline placeholders should still wrap.
     updatePlaceholderEllipsize()
 
     // We override the KeyListener so that all keys on the soft input keyboard as well as hardware
@@ -613,12 +611,6 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     updatePlaceholderEllipsize()
   }
 
-  /**
-   * On Android, long hints are clipped without an ellipsis unless [ellipsize] is set. Align with
-   * iOS by ellipsizing trailing placeholders on single-line inputs only.
-   *
-   * See https://github.com/facebook/react-native/issues/29663
-   */
   private fun updatePlaceholderEllipsize() {
     ellipsize =
         if (!isMultiline) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -591,6 +591,10 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     }
     wasMultiline = isMultiline
 
+    // Keep placeholder ellipsize in sync when multiline flips. Single-line inputs should
+    // trail with "…" (matching iOS); multiline placeholders should still wrap.
+    updatePlaceholderEllipsize()
+
     // We override the KeyListener so that all keys on the soft input keyboard as well as hardware
     // keyboards work. Some KeyListeners like DigitsKeyListener will display the keyboard but not
     // accept all input from it
@@ -606,6 +610,22 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
       this.placeholder = placeholder
       hint = placeholder
     }
+    updatePlaceholderEllipsize()
+  }
+
+  /**
+   * On Android, long hints are clipped without an ellipsis unless [ellipsize] is set. Align with
+   * iOS by ellipsizing trailing placeholders on single-line inputs only.
+   *
+   * See https://github.com/facebook/react-native/issues/29663
+   */
+  private fun updatePlaceholderEllipsize() {
+    ellipsize =
+        if (!isMultiline) {
+          TextUtils.TruncateAt.END
+        } else {
+          null
+        }
   }
 
   public fun setFontFamily(fontFamily: String?) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -19,6 +19,7 @@ import android.text.InputType
 import android.text.Layout
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.TextUtils
 import android.util.DisplayMetrics
 import android.view.Gravity
 import android.view.View
@@ -196,9 +197,26 @@ class ReactTextInputPropertyTest {
 
     manager.updateProperties(view, buildStyles("placeholder", "sometext"))
     assertThat(view.hint).isEqualTo("sometext")
+    assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
 
     manager.updateProperties(view, buildStyles("placeholder", null))
     assertThat(view.hint).isNull()
+    assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
+  }
+
+  @Test
+  fun testPlaceholderEllipsizeRespectsMultiline() {
+    manager.updateProperties(view, buildStyles("placeholder", "a very long placeholder string"))
+    assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
+
+    manager.updateProperties(view, buildStyles("multiline", true))
+    // commitStagedInputType is normally called during view updates; apply it for the unit test.
+    view.commitStagedInputType()
+    assertThat(view.ellipsize).isNull()
+
+    manager.updateProperties(view, buildStyles("multiline", false))
+    view.commitStagedInputType()
+    assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -210,7 +210,6 @@ class ReactTextInputPropertyTest {
     assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
 
     manager.updateProperties(view, buildStyles("multiline", true))
-    // commitStagedInputType is normally called during view updates; apply it for the unit test.
     view.commitStagedInputType()
     assertThat(view.ellipsize).isNull()
 


### PR DESCRIPTION
## Summary

On Android, long `TextInput` placeholders are hard-clipped with no trailing ellipsis, while iOS truncates with `…`.

Fixes https://github.com/facebook/react-native/issues/29663 (same class of bug as https://github.com/facebook/react-native/pull/55272; uses a correct multiline bitmask check and clears ellipsize when multiline is enabled).

**Repro:** https://github.com/kosmydel/android-ellipsize-repro

| Before | After |
|--------|--------|
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/583a8323-03ae-4075-a662-a4c92e8fec9e" /> |<img width="400" alt="image" src="https://github.com/user-attachments/assets/ece0f350-2349-4244-b7c8-56acd7d15e91" /> | 

## Changelog

[Android] [Fixed] - Ellipsize long single-line TextInput placeholders to match iOS

## Test Plan

- Unit: `ReactTextInputPropertyTest` — placeholder sets `TruncateAt.END`; toggling `multiline` clears/restores ellipsize
- Manual: https://github.com/kosmydel/android-ellipsize-repro
  - Single-line constrained `TextInput` with a long placeholder → trailing `…`
  - Short placeholder unchanged
  - `multiline={true}` with a long placeholder → still wraps
  - Toggle `multiline` false → true → false → ellipsize restored