### PR TITLE
Change default transform profile to 'hermes-stable' #2

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/index.js
+++ b/packages/community-cli-plugin/src/commands/bundle/index.js
@@ -98,8 +98,8 @@ const bundleCommand: CommunityCommand = {
     {
       name: '--unstable-transform-profile <string>',
       description:
-        'Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default',
-      default: 'default',
+        'Experimental, transform JS for a specific JS engine. Currently supported: hermes-stable, hermes-canary, default',
+      default: 'hermes-stable',
     },
     {
       name: '--asset-catalog-dest [string]',


### PR DESCRIPTION

## Summary:

Issue: https://github.com/react/react-native/issues/57174
Initially, this PR was created to fix an issue above: https://github.com/react/react-native/pull/57208

---

But after re-testing it on the latest React Native `0.87.x`. 
I found out that cli  set `unstable_transformProfile` value to `default`  (cli -> metro -> babel -> @rn/babel-preset)

```tsx
function getTransformProfile(caller) {
  return caller?.unstable_transformProfile ?? 'hermes-stable';
                 ^^^ has a 'default' value (from CLI)
}
```

---

So, `isHermesProfile` is always `false` here:

https://github.com/react/react-native/blob/22cfb5caec78cb21b4a66b0ab82b03cc5f99a4dd/packages/react-native-babel-preset/src/configs/main.js#L63

and unnecessary babel plugins has applied 



## Changelog:

[GENERAL] [CHANGED] - Change default transform profile to 'hermes-stable'



## Test Plan:


```java
npx @react-native-community/cli init --pm yarn RN87
cd RN87
open node_modules/@react-native/babel-preset/src/configs/main.js
// add Logs to print (isHermesProfile, transformProfile) vars

// Run build 
./android/gradlew -p android assembleRelease
// Check logs (have to be `isHermesProfile: false, transformProfile: 'default')

// Apply fix
open node_modules/@react-native/community-cli-plugin/dist/commands/bundle/index.js
// Find a `--unstable-transform-profile` option
// And change `default: "default",` => `default: "hermes-stable",`
 
 
 // Run build again
```
