### PR TITLE
Test inline views at reduced font scale (#57913)

### DIFF
--- a/packages/rn-tester/js/components/TextInlineView.js
+++ b/packages/rn-tester/js/components/TextInlineView.js
@@ -26,6 +26,15 @@ function Basic(): React.Node {
   );
 }
 
+function FontScale(): React.Node {
+  return (
+    <RNTesterText testID="inline-view-font-scale">
+      This text contains an inline view{' '}
+      <View style={{width: 80, height: 40, backgroundColor: 'steelblue'}} />
+    </RNTesterText>
+  );
+}
+
 function NestedTexts(): React.Node {
   return (
     <View>
@@ -201,6 +210,7 @@ function ChangeInnerViewSize(): React.Node {
 
 module.exports = {
   Basic,
+  FontScale,
   NestedTexts,
   ClippedByText,
   ChangeImageSize,

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1656,6 +1656,13 @@ const examples = [
     },
   },
   {
+    title: 'Inline view with a reduced font scale',
+    name: 'inlineViewFontScale',
+    render(): React.Node {
+      return <TextInlineView.FontScale />;
+    },
+  },
+  {
     title: 'Inline views with multiple nested texts',
     name: 'inlineViewsMultiple',
     render(): React.Node {


### PR DESCRIPTION
Summary:

Add an RNTester example for inline views and a Jest E2E screenshot test that runs Android with `fontScale=0.85`.

Thread the optional font-scale setting through `ReactNativeCoreE2ESetup` so the test can use the RNTester adapter support from the prerequisite framework diff.


## Changelog
[Internal] -

Reviewed By: christophpurrer

Differential Revision: D115583513


