### PR TITLE
Fix crash when accessibilityRole="tabbar" is used on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
@@ -437,6 +437,7 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
     SPINBUTTON,
     SWITCH,
     TAB,
+    TABBAR,
     TABLIST,
     TIMER,
     LIST,
@@ -491,6 +492,7 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
           RADIOGROUP,
           SCROLLBAR,
           TAB,
+          TABBAR,
           TABLIST,
           TIMER,
           TOOLBAR -> "android.view.View"

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactAccessibilityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactAccessibilityDelegateTest.kt
@@ -348,6 +348,15 @@ class ReactAccessibilityDelegateTest {
   }
 
   @Test
+  fun testAccessibilityRole_fromValue_tabbar_resolvesInsteadOfThrowing() {
+    val role = ReactAccessibilityDelegate.AccessibilityRole.fromValue("tabbar")
+
+    assertThat(role).isEqualTo(ReactAccessibilityDelegate.AccessibilityRole.TABBAR)
+    assertThat(ReactAccessibilityDelegate.AccessibilityRole.getValue(role))
+        .isEqualTo("android.view.View")
+  }
+
+  @Test
   fun testPerformAccessibilityAction_collapseAction_fromAccessibilityActions() {
     val accessibilityActions = JavaOnlyArray()
     val action =


### PR DESCRIPTION
## Summary

Fixes #57890.

`tabbar` is part of the public `AccessibilityRole` union in both Flow and TypeScript, with nothing marking it iOS-only, and on iOS it maps to `UIAccessibilityTraitTabBar`. On Android the `AccessibilityRole` enum has no `TABBAR` entry, so `fromValue()` throws `IllegalArgumentException` from `BaseViewManager.setAccessibilityRole` during `createViewInstance` and the app crashes on mount. It is the only value in the union Android fails to resolve.

This adds `TABBAR` to the enum and maps it to `android.view.View` in `getValue`, next to `TAB` and `TABLIST`, which likewise have no dedicated Android widget. `getValue` is an exhaustive `when` with no `else`, so the second hunk is required for the enum addition to compile.

`setRole` already has an `else` branch, so no `roleDescription` is set for the new value. That looks right to me, since Android has no tab bar concept to announce, but happy to add a string resource if you'd prefer one.

## Changelog:

[ANDROID] [FIXED] - Fix crash when `accessibilityRole="tabbar"` is used on Android

## Test Plan

Added a unit test to `ReactAccessibilityDelegateTest` asserting that `fromValue("tabbar")` resolves to `TABBAR` and maps to `android.view.View` rather than throwing.

Repro from the issue:

```jsx
<View accessibilityRole="tabbar">
  <Text>hello</Text>
</View>
```

Before: crashes on mount on Android with `Invalid accessibility role value: tabbar`.
After: renders as a plain view, matching iOS, where roles without a UIKit trait fall back rather than raising.

I have not run the Android suite locally, relying on CI for that.
