### PR TITLE
Add TextInput placeholder screenshot coverage (#57925)

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1201,6 +1201,31 @@ module.exports = [
     },
   },
   {
+    title: 'Placeholder ellipsizing',
+    name: 'placeholderEllipsizing',
+    render: function (): React.Node {
+      const placeholder =
+        'This placeholder is too long to fit on a single line';
+
+      return (
+        <View>
+          <ExampleTextInput
+            multiline={false}
+            placeholder={placeholder}
+            style={{height: 40, width: 200}}
+            testID="textinput-placeholder-singleline"
+          />
+          <ExampleTextInput
+            multiline={true}
+            placeholder={placeholder}
+            style={{height: 60, width: 200}}
+            testID="textinput-placeholder-multiline"
+          />
+        </View>
+      );
+    },
+  },
+  {
     title: 'Clipping',
     name: 'clipping',
     render: function (): React.Node {


### PR DESCRIPTION
Summary:

Add RNTester screenshot coverage for single-line and multiline `TextInput` placeholders on Android and iOS. The test verifies that a long single-line placeholder is ellipsized while a multiline placeholder wraps.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D115731487


