### PR TITLE
Fix missing ViewStyle properties on legacy TypeScript ImageStyle

### DIFF
--- a/packages/react-native/__typetests__/stylesheet-image-style.tsx
+++ b/packages/react-native/__typetests__/stylesheet-image-style.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import * as React from 'react';
+// @ts-ignore
+import {Image, StyleSheet, type ImageStyle} from 'react-native';
+
+// `ImageStyle` must accept every `ViewStyle` property. This matches the Flow
+// definition of `____ImageStyle_InternalCore`, which spreads
+// `____ViewStyle_Internal`, and the generated strict API, which declares
+// `Omit<____ViewStyle_Internal, 'overflow'> & {...}`.
+const viewStyleProperties: ImageStyle = {
+  backgroundImage: 'linear-gradient(to right, red, blue)',
+  borderCurve: 'continuous',
+  boxShadow: '0 0 10px red',
+  cursor: 'pointer',
+  elevation: 4,
+  filter: 'brightness(0.5)',
+  isolation: 'isolate',
+  mixBlendMode: 'multiply',
+  outlineColor: 'red',
+  outlineOffset: 2,
+  outlineStyle: 'dashed',
+  outlineWidth: 1,
+  pointerEvents: 'none',
+};
+
+// Image-specific properties remain available.
+const imageStyleProperties: ImageStyle = {
+  objectFit: 'contain',
+  overlayColor: 'red',
+  resizeMode: 'cover',
+  tintColor: 'blue',
+};
+
+// Unlike `ViewStyle`, `overflow` on `ImageStyle` is narrowed to
+// 'visible' | 'hidden' — 'scroll' is not accepted.
+const overflowVisible: ImageStyle = {overflow: 'visible'};
+const overflowHidden: ImageStyle = {overflow: 'hidden'};
+// @ts-expect-error - 'scroll' is not a valid `overflow` value for `ImageStyle`
+const overflowScroll: ImageStyle = {overflow: 'scroll'};
+
+// Unknown properties are still rejected.
+// @ts-expect-error - 'notAStyleProperty' does not exist on `ImageStyle`
+const unknownProperty: ImageStyle = {notAStyleProperty: 1};
+
+const styles = StyleSheet.create({
+  image: {
+    boxShadow: '0 0 10px red',
+    filter: 'brightness(0.5)',
+    resizeMode: 'cover',
+  } as ImageStyle,
+});
+
+export function App() {
+  return (
+    <>
+      <Image
+        source={{uri: 'https://reactnative.dev/img/logo-og.png'}}
+        style={styles.image}
+      />
+      {/* The user-visible path: writing `ViewStyle` properties inline on `<Image>`. */}
+      <Image
+        source={{uri: 'https://reactnative.dev/img/logo-og.png'}}
+        style={{filter: 'brightness(0.5)', mixBlendMode: 'multiply'}}
+      />
+    </>
+  );
+}
+
+export {
+  imageStyleProperties,
+  overflowHidden,
+  overflowScroll,
+  overflowVisible,
+  unknownProperty,
+  viewStyleProperties,
+};

--- a/packages/react-native/types_DEPRECATED/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/types_DEPRECATED/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -638,20 +638,10 @@ export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle {
  * Image style
  * @see https://reactnative.dev/docs/image#style
  */
-export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
+export interface ImageStyle extends Omit<ViewStyle, 'overflow'> {
   resizeMode?: ImageResizeMode | undefined;
-  backfaceVisibility?: 'visible' | 'hidden' | undefined;
-  borderBottomLeftRadius?: AnimatableNumericValue | string | undefined;
-  borderBottomRightRadius?: AnimatableNumericValue | string | undefined;
-  backgroundColor?: ColorValue | undefined;
-  borderColor?: ColorValue | undefined;
-  borderRadius?: AnimatableNumericValue | string | undefined;
-  borderTopLeftRadius?: AnimatableNumericValue | string | undefined;
-  borderTopRightRadius?: AnimatableNumericValue | string | undefined;
   overflow?: 'visible' | 'hidden' | undefined;
   overlayColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
-  opacity?: AnimatableNumericValue | undefined;
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none' | undefined;
-  cursor?: CursorValue | undefined;
 }


### PR DESCRIPTION
## Summary:

Fixes #52957

The hand-written (legacy) TypeScript `ImageStyle` interface redeclares a small subset of `ViewStyle`'s properties instead of extending it. As a result, style properties added to `ViewStyle` over time — `filter`, `boxShadow`, `mixBlendMode`, `outlineColor`/`outlineOffset`/`outlineStyle`/`outlineWidth`, `pointerEvents`, `elevation`, `isolation`, `borderCurve`, `backgroundImage`, the logical border-radius/border-color properties, and the `experimental_background*` set — are rejected on `<Image>` styles, even though they are supported at runtime.

### This is a divergence between three sources of truth, not a design choice

| Source | Definition | Includes `ViewStyle` props? |
| --- | --- | --- |
| **Flow (authoritative)** — `Libraries/StyleSheet/StyleSheetTypes.js:1052` | `____ImageStyle_InternalCore = Readonly<{...$Exact<____ViewStyle_Internal>, resizeMode?, objectFit?, tintColor?, overlayColor?, overflow?}>` | Yes — spreads `____ViewStyle_Internal` |
| **Generated strict API** — `ReactNativeApi.d.ts:619` | `____ImageStyle_InternalCore = Readonly<Omit<____ViewStyle_Internal, "overflow"> & {...}>` | Yes |
| **Legacy hand-written TS** — `types_DEPRECATED/Libraries/StyleSheet/StyleSheetTypes.d.ts:641` | `interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle` | **No — the sole outlier** |

This matches @huntie's diagnosis in [#52957](https://github.com/react/react-native/issues/52957#issuecomment-3154647539): the bug is in the manual types only, and the `react-native-strict-api` opt-in is already correct.

### Scope: `ImageStyle` only — the `TextStyle` half of the report is already fixed on `main`

The issue title says "`ImageStyle` **and** `TextStyle`", but only `ImageStyle` is affected today. `StyleSheetTypes.d.ts:562` already reads `export interface TextStyle extends TextStyleIOS, TextStyleAndroid, ViewStyle`, so `TextStyle` inherits everything. I verified this with a `tsc` probe against the legacy types: a `TextStyle` object literal containing `filter`, `boxShadow`, `mixBlendMode`, `outlineColor`, and `isolation` typechecks cleanly on unmodified `main`. Keeping this PR scoped to `ImageStyle` is deliberate.

### How `overflow` is handled

`ImageStyle` cannot simply `extend ViewStyle`: `ViewStyle` inherits `overflow?: 'visible' | 'hidden' | 'scroll'` from `FlexStyle`, while both Flow and the strict API deliberately narrow it to `'visible' | 'hidden'` for images. This PR mirrors the strict API exactly — `extends Omit<ViewStyle, 'overflow'>`, then redeclares the narrowed `overflow`. There is a type test asserting `'scroll'` is still rejected.

The nine other properties removed from the interface body are now inherited from `ViewStyle`. I confirmed each one keeps a byte-identical type via `Exact<>` type-level assertions (see Test Plan), so this is a pure widening with no change to any previously-valid style.

## Changelog:

[GENERAL] [FIXED] - Add missing `ViewStyle` properties (`filter`, `boxShadow`, `mixBlendMode`, `outlineColor`, `pointerEvents`, and others) to the legacy TypeScript `ImageStyle` type

## Test Plan:

Added `packages/react-native/__typetests__/stylesheet-image-style.tsx`, which runs under **both** `tsconfig.legacy.json` (hand-written types) and `tsconfig.json` (generated strict API), so the two stay aligned.

**Counterfactual — the test fails without the fix.** With only the interface change reverted (test file kept):

```
$ yarn test-typescript-legacy
packages/react-native/__typetests__/stylesheet-image-style.tsx(19,3): error TS2353: Object literal may only specify known properties, and 'backgroundImage' does not exist in type 'ImageStyle'.
packages/react-native/__typetests__/stylesheet-image-style.tsx(71,9): error TS2769: No overload matches this call.
error Command failed with exit code 2.
```

Restoring the fix:

```
$ yarn test-typescript-legacy
Done in 0.78s.
```

**User-visible path verified.** The second error above is the real-world symptom — `<Image style={{filter: 'brightness(0.5)', mixBlendMode: 'multiply'}} />`, i.e. an app author writing `ViewStyle` properties inline on an `Image`. (`filter` produces a confusing message because `StyleProp<ImageStyle>` may be an array, so TS matches it against `Array.prototype.filter`.) The type test covers both this JSX path and direct `ImageStyle` annotations.

**Each property from the issue report, individually, before the fix** (`const s: ImageStyle = {<prop>}` compiled with `tsc -p tsconfig.legacy.json`):

```
filter        -> error TS2353: ... 'filter' does not exist in type 'ImageStyle'.
boxShadow     -> error TS2353: ... 'boxShadow' does not exist in type 'ImageStyle'.
mixBlendMode  -> error TS2353: ... 'mixBlendMode' does not exist in type 'ImageStyle'.
outlineColor  -> error TS2353: ... 'outlineColor' does not exist in type 'ImageStyle'.
pointerEvents -> error TS2353: ... 'pointerEvents' does not exist in type 'ImageStyle'.
```

All pass after the fix.

**No regression for existing consumers.** Type-level `Exact<A, B>` assertions confirm every property removed from the interface body resolves to an identical type through inheritance, and that `overflow`/`resizeMode` are unchanged — all 12 pass:

`backfaceVisibility`, `borderBottomLeftRadius`, `borderBottomRightRadius`, `backgroundColor`, `borderColor`, `borderRadius`, `borderTopLeftRadius`, `borderTopRightRadius`, `opacity`, `cursor`, `overflow`, `resizeMode`.

**Full gates, all green:**

| Command | Result |
| --- | --- |
| `yarn test-typescript-legacy` | Pass (`Done in 0.78s`) |
| `yarn test-generated-typescript` | Pass (`Done in 0.84s`) |
| `yarn test` | 218 suites / 5585 passed, 1 skipped, 1666 snapshots — 0 failures |
| `yarn eslint --max-warnings 0 <changed files>` | Clean |
| `prettier --check <changed files>` | Clean |
| `yarn build-types` | API snapshot regenerates **byte-identical** — `git status` clean, confirming the strict API is untouched |
