### PR TITLE
Expose ReactNativeFeatureFlags through react-private-interface

### DIFF
--- a/packages/react-native/src/react-private-interface.js
+++ b/packages/react-native/src/react-private-interface.js
@@ -48,6 +48,7 @@ import type {DangerouslyImpreciseStyleProp} from '../Libraries/StyleSheet/StyleS
 import typeof deepFreezeAndThrowOnMutationInDev from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
 import typeof deepDiffer from '../Libraries/Utilities/differ/deepDiffer';
 import typeof Platform from '../Libraries/Utilities/Platform';
+import typeof * as ReactNativeFeatureFlags from './private/featureflags/ReactNativeFeatureFlags';
 import typeof dispatchNativeEvent from './private/renderer/events/dispatchNativeEvent';
 import typeof CustomEvent from './private/webapis/dom/events/CustomEvent';
 
@@ -68,6 +69,9 @@ module.exports = {
   },
   get RCTEventEmitter(): RCTEventEmitter {
     return require('../Libraries/EventEmitter/RCTEventEmitter').default;
+  },
+  get ReactNativeFeatureFlags(): ReactNativeFeatureFlags {
+    return require('./private/featureflags/ReactNativeFeatureFlags');
   },
   get ReactNativeViewConfigRegistry(): ReactNativeViewConfigRegistry {
     return require('../Libraries/Renderer/shims/ReactNativeViewConfigRegistry');

--- a/packages/react-native/src/react-private-interface.js.flow
+++ b/packages/react-native/src/react-private-interface.js.flow
@@ -23,6 +23,7 @@ export {default as BatchedBridge} from '../Libraries/BatchedBridge/BatchedBridge
 export {default as ExceptionsManager} from '../Libraries/Core/ExceptionsManager';
 export {default as Platform} from '../Libraries/Utilities/Platform';
 export {default as RCTEventEmitter} from '../Libraries/EventEmitter/RCTEventEmitter';
+export * as ReactNativeFeatureFlags from './private/featureflags/ReactNativeFeatureFlags';
 export * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
 export {default as TextInputState} from '../Libraries/Components/TextInput/TextInputState';
 export {default as UIManager} from '../Libraries/ReactNative/UIManager';

--- a/packages/virtualized-lists/Lists/VirtualizeUtils.js
+++ b/packages/virtualized-lists/Lists/VirtualizeUtils.js
@@ -13,7 +13,7 @@
 import type ListMetricsAggregator from './ListMetricsAggregator';
 import type {CellMetricProps} from './ListMetricsAggregator';
 
-import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+import {ReactNativeFeatureFlags} from 'react-native/react-private-interface';
 
 /**
  * Used to find the indices of the frames that overlap the given offsets. Useful for finding the

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -64,7 +64,7 @@ import {
   View,
   findNodeHandle,
 } from 'react-native';
-import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+import {ReactNativeFeatureFlags} from 'react-native/react-private-interface';
 
 export type {ListRenderItemInfo, ListRenderItem, Separators};
 


### PR DESCRIPTION
## Summary:

Fixes #57933.

`@react-native/virtualized-lists` is published separately and imported `ReactNativeFeatureFlags` through `react-native/src/private/featureflags/ReactNativeFeatureFlags`, which is not listed in `react-native`'s `"exports"`. Metro therefore warned and fell back to file-based resolution whenever an app rendered a virtualized list.

Thanks @huntie for the patch and the direction — this PR now applies it instead of the original approach:

- `ReactNativeFeatureFlags` is exposed on the existing private package boundary, `react-native/react-private-interface` (both the runtime getter and the `.js.flow` re-export);
- `VirtualizedList.js` and `VirtualizeUtils.js` import it from there.

No new `src/private/*` subpath is exported, and the feature-flag singleton is unchanged.

Per your review, the `scripts/monorepo-tests/__tests__/check-packages-test.js` and `scripts/shared/monorepoUtils.js` changes have been dropped — the PR is now just the patch above. Happy to look at enabling `@react-native/no-deep-imports` on `virtualized-lists` as a follow-up if that's wanted.

`VirtualizeUtils.js` is included alongside `VirtualizedList.js` because it carried the same runtime deep import. The remaining occurrences are out of scope: the four in `@react-native/jest-preset` are all `import type` and are erased before resolution, and the one in `VirtualizeUtils-test.js` is not shipped (`virtualized-lists` excludes `**/__tests__/**` from `files`).

## Changelog:

[GENERAL] [FIXED] - Fix the Metro package-exports warning caused by `@react-native/virtualized-lists` importing an unexported React Native subpath.

## Test Plan:

No new test is added. The existing `virtualized-lists` suites already cover this route, because `VirtualizeUtils`/`VirtualizedList` read the flags at runtime through the new boundary.

Counterfactual — dropping only the `ReactNativeFeatureFlags` getter and its `import typeof` from `react-private-interface.js`, keeping the two `virtualized-lists` imports:

```text
TypeError: Cannot read properties of undefined (reading 'fixVirtualizeListCollapseWindowSize')

      182 |     let lastWillAddMore;
      183 |
    > 184 |     if (ReactNativeFeatureFlags.fixVirtualizeListCollapseWindowSize()) {
          |                                ^

      at computeWindowedRenderLimits (packages/virtualized-lists/Lists/VirtualizeUtils.js:184:32)
      at Object.<anonymous> (packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js:261:47)

Test Suites: 2 failed, 6 passed, 8 total
Tests:       20 failed, 1 skipped, 151 passed, 172 total
```

Restoring the getter makes it green again.

```text
$ yarn jest packages/virtualized-lists scripts/monorepo-tests packages/react-native/Libraries/ReactPrivate --runInBand
Test Suites: 9 passed, 9 total
Tests:       1 skipped, 176 passed, 177 total
Snapshots:   69 passed, 69 total

$ yarn flow-check
Found 0 errors

$ yarn lint
$ eslint --max-warnings 0 .
Done in 10.23s.
```
