### PR TITLE
Build universal RNTester APK for Maestro Cloud

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -364,6 +364,8 @@ jobs:
         GRADLE_OPTS: '-Dorg.gradle.daemon=false'
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        # Maestro Cloud Android devices require an APK containing arm64-v8a.
+        ORG_GRADLE_PROJECT_enableUniversalApk: 'true'
         REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
@@ -406,14 +408,14 @@ jobs:
         run: |
           test -n "$MAESTRO_CLOUD_API_KEY"
           test -n "$MAESTRO_CLOUD_PROJECT_ID"
-          test -f /tmp/rntester-android/app-x86-release.apk
+          test -f /tmp/rntester-android/app-universal-release.apk
           test -z "$(find packages/rn-tester/.maestro -type l -print -quit)"
       - name: Run flows on Maestro Cloud
         uses: mobile-dev-inc/action-maestro-cloud@5759506b4ec7ee0a1ece4b7e6574bba2b282f241 # v3.0.1
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
           project-id: ${{ secrets.MAESTRO_CLOUD_PROJECT_ID }}
-          app-file: /tmp/rntester-android/app-x86-release.apk
+          app-file: /tmp/rntester-android/app-universal-release.apk
           workspace: packages/rn-tester/.maestro
           branch: ${{ github.head_ref || github.ref_name }}
           name: RNTester Android - ${{ github.event.pull_request.title || github.event.head_commit.message }}

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -120,7 +120,8 @@ android {
   splits {
     abi {
       isEnable = true
-      isUniversalApk = false
+      isUniversalApk =
+          providers.gradleProperty("enableUniversalApk").getOrElse("false").toBoolean()
       reset()
       include(*reactNativeArchitectures().toTypedArray())
     }


### PR DESCRIPTION
Summary:
- package a universal RNTester APK in the Test All Android build
- upload that APK to Maestro Cloud so it includes the required arm64-v8a ABI
- preserve the existing x86 split APK used by local emulator E2E tests

The Maestro Cloud Android job currently reaches the upload step but rejects app-x86-release.apk because Cloud Android devices require arm64-v8a.

Changelog:
[Internal] [Fixed] - Build an arm64-compatible RNTester APK for Maestro Cloud Android tests.

Test Plan:
- node_modules/.bin/prettier --check .github/workflows/test-all.yml — passed
- ruby -ryaml -e "YAML.load_file(%q{.github/workflows/test-all.yml}, aliases: true); puts %q{Workflow YAML parsed successfully}" — passed
- git diff --check — passed
- Test All CI will validate universal APK generation and the Maestro Cloud upload