### PR TITLE
Fix MVCP anchor selection when z-index reorders children

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-maintainVisibleContentPosition-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-maintainVisibleContentPosition-itest.js
@@ -348,6 +348,134 @@ test('maintainVisibleContentPosition with minIndexForVisible > 0 skips early ite
   expect(logs2.length).toBeGreaterThan(0);
 });
 
+function renderItemWithZIndex(item: Item, height: number = ITEM_HEIGHT) {
+  return (
+    <View
+      key={item.key}
+      nativeID={`item_${item.id}`}
+      style={{height, width: 100, zIndex: -item.id}}>
+      <View
+        nativeID={`inner_${item.id}`}
+        style={{
+          height: height - 2,
+          width: 100 - 2,
+          backgroundColor: '#4CAF50',
+        }}
+      />
+    </View>
+  );
+}
+
+// Trigger: z-index reorders native subviews so hierarchy index != layout order.
+// Expected: MVCP selects the topmost visible anchor by layout position, not hierarchy order.
+test('maintainVisibleContentPosition with zIndex preserves anchor on height change', () => {
+  const root = Fantom.createRoot({
+    viewportWidth: 100,
+    viewportHeight: VIEWPORT_HEIGHT,
+  });
+  const nodeRef = createRef<HostInstance>();
+
+  const items = makeItems(NUM_ITEMS);
+  const anchorId = 8;
+  let anchorHeight = ITEM_HEIGHT;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        ref={nodeRef}
+        style={{height: VIEWPORT_HEIGHT, width: 100}}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}>
+        {items.map(item =>
+          item.id === anchorId
+            ? renderItemWithZIndex(item, anchorHeight)
+            : renderItemWithZIndex(item),
+        )}
+      </ScrollView>,
+    );
+  });
+
+  root.takeMountingManagerLogs();
+
+  Fantom.scrollTo(nodeRef, {
+    x: 0,
+    y: ITEM_HEIGHT * anchorId,
+  });
+
+  root.takeMountingManagerLogs();
+
+  anchorHeight = ITEM_HEIGHT * 2;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        ref={nodeRef}
+        style={{height: VIEWPORT_HEIGHT, width: 100}}
+        maintainVisibleContentPosition={{minIndexForVisible: 0}}>
+        {items.map(item =>
+          item.id === anchorId
+            ? renderItemWithZIndex(item, anchorHeight)
+            : renderItemWithZIndex(item),
+        )}
+      </ScrollView>,
+    );
+  });
+
+  const heightChangeLogs = root.takeMountingManagerLogs();
+  expect(heightChangeLogs.length).toBeGreaterThan(0);
+  expect(heightChangeLogs.some(log => log.includes(`item_${anchorId}`))).toBe(
+    true,
+  );
+});
+
+// Trigger: z-index reorders native subviews when minIndexForVisible > 0.
+// Expected: minIndex skip uses layout order, not native hierarchy order.
+test('maintainVisibleContentPosition with zIndex and minIndexForVisible > 0 skips early items', () => {
+  const root = Fantom.createRoot({
+    viewportWidth: 100,
+    viewportHeight: VIEWPORT_HEIGHT,
+  });
+  const nodeRef = createRef<HostInstance>();
+
+  const items = makeItems(NUM_ITEMS);
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        ref={nodeRef}
+        style={{height: VIEWPORT_HEIGHT, width: 100}}
+        maintainVisibleContentPosition={{minIndexForVisible: 5}}>
+        {items.map(renderItemWithZIndex)}
+      </ScrollView>,
+    );
+  });
+
+  root.takeMountingManagerLogs();
+
+  Fantom.scrollTo(nodeRef, {
+    x: 0,
+    y: ITEM_HEIGHT * 8,
+  });
+
+  root.takeMountingManagerLogs();
+
+  const itemsAfterPrepend = [...makeItems(3, NUM_ITEMS), ...items];
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        ref={nodeRef}
+        style={{height: VIEWPORT_HEIGHT, width: 100}}
+        maintainVisibleContentPosition={{minIndexForVisible: 5}}>
+        {itemsAfterPrepend.map(renderItemWithZIndex)}
+      </ScrollView>,
+    );
+  });
+
+  const prependLogs = root.takeMountingManagerLogs();
+  expect(prependLogs.length).toBeGreaterThan(0);
+  expect(prependLogs.some(log => log.includes('item_8'))).toBe(true);
+});
+
 // Trigger: User actively dragging (touch-scrolling) when data change triggers MVCP.
 // Expected: MVCP correction may compete with user's scroll. Scroll skip guard on `patch/add-scrolling-guard`
 // branch would skip correction during user dragging, but this is NOT merged.

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -1065,23 +1065,60 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   }
 
   BOOL horizontal = _scrollView.contentSize.width > self.frame.size.width;
-  int minIdx = props.maintainVisibleContentPosition.value().minIndexForVisible;
-  for (NSUInteger ii = minIdx; ii < _contentView.subviews.count; ++ii) {
-    // Find the first view that is partially or fully visible.
-    UIView *subview = _contentView.subviews[ii];
-    BOOL hasNewView = NO;
-    if (horizontal) {
-      hasNewView = subview.frame.origin.x + subview.frame.size.width > _scrollView.contentOffset.x;
-    } else {
-      hasNewView = subview.frame.origin.y + subview.frame.size.height > _scrollView.contentOffset.y;
-    }
-    if (hasNewView || ii == _contentView.subviews.count - 1) {
-      _prevFirstVisibleFrame = subview.frame;
-      _firstVisibleView = subview;
-      _firstVisibleViewTag = subview.tag;
-      break;
+  int minIndex = props.maintainVisibleContentPosition.value().minIndexForVisible;
+  NSArray<UIView *> *subviews =
+      minIndex > 0 ? [self _sortedContentSubviewsWithHorizontal:horizontal] : _contentView.subviews;
+  if ((NSUInteger)minIndex >= subviews.count) {
+    return;
+  }
+
+  CGFloat currentScroll = horizontal ? _scrollView.contentOffset.x : _scrollView.contentOffset.y;
+  UIView *firstVisibleView = nil;
+  // We cannot assume that the views will be in position order because of things like z-index
+  // which will change the order of views in their parent. This means we need to iterate through
+  // the full children array and find the view with the smallest position that is bigger than
+  // the scroll position.
+  CGFloat firstVisibleViewPosition = CGFLOAT_MAX;
+  for (NSUInteger index = minIndex; index < subviews.count; ++index) {
+    UIView *subview = subviews[index];
+
+    // Compute the position of the end of the child
+    CGFloat position = horizontal ? subview.frame.origin.x + subview.frame.size.width
+                                  : subview.frame.origin.y + subview.frame.size.height;
+
+    // If the child is partially visible or this is the last child, select it as the anchor.
+    if ((position > currentScroll && position < firstVisibleViewPosition) ||
+        (firstVisibleView == nil && index == subviews.count - 1)) {
+      firstVisibleView = subview;
+      firstVisibleViewPosition = position;
     }
   }
+
+  if (firstVisibleView == nil) {
+    return;
+  }
+
+  _prevFirstVisibleFrame = firstVisibleView.frame;
+  _firstVisibleView = firstVisibleView;
+  _firstVisibleViewTag = firstVisibleView.tag;
+}
+
+/// Returns scroll content subviews sorted by layout position along the scroll axis.
+///
+/// Call this only when minIndexForVisible > 0. In those cases, we need to skip in-order items, and
+/// sorting allows us to do that.
+- (NSArray<UIView *> *)_sortedContentSubviewsWithHorizontal:(BOOL)horizontal
+{
+  NSArray<UIView *> *subviews = _contentView.subviews;
+  return [subviews sortedArrayUsingComparator:^NSComparisonResult(UIView *a, UIView *b) {
+    CGFloat offsetA = horizontal ? CGRectGetMinX(a.frame) : CGRectGetMinY(a.frame);
+    CGFloat offsetB = horizontal ? CGRectGetMinX(b.frame) : CGRectGetMinY(b.frame);
+    if (offsetA != offsetB) {
+      return offsetA < offsetB ? NSOrderedAscending : NSOrderedDescending;
+    }
+    // Stable ordering for ties.
+    return [@([subviews indexOfObject:a]) compare:@([subviews indexOfObject:b])];
+  }];
 }
 
 - (void)_adjustForMaintainVisibleContentPosition
@@ -1116,7 +1153,6 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   std::optional<int> autoscrollThreshold = props.maintainVisibleContentPosition.value().autoscrollToTopThreshold;
   BOOL horizontal = _scrollView.contentSize.width > self.frame.size.width;
-  // TODO: detect and handle/ignore re-ordering
   if (horizontal) {
     CGFloat deltaX = _firstVisibleView.frame.origin.x - _prevFirstVisibleFrame.origin.x;
     if (ABS(deltaX) > 0.5) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
@@ -125,6 +125,24 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
     val scrollView = scrollView ?: return
     val contentView = contentView ?: return
 
+    val children = List(contentView.childCount) { contentView.getChildAt(it) }
+    val subviews =
+        if (config.minIndexForVisible > 0) {
+          // We only need to sort if minIndexForVisible is non-zero. Normally, we just do a full
+          // linear scan and find the earliest item.
+          //
+          // If minIndexForVisible is set though, we have to exclude the first `minIndexForVisible`
+          // items, which requires sorting to do.
+          children.sortedWith(
+              compareBy<View>({ if (horizontal) it.x else it.y }, { contentView.indexOfChild(it) }))
+        } else {
+          children
+        }
+
+    if (config.minIndexForVisible >= subviews.size) {
+      return
+    }
+
     val currentScroll = if (horizontal) scrollView.scrollX else scrollView.scrollY
     var firstVisibleView: View? = null
     // We cannot assume that the views will be in position order because of things like z-index
@@ -132,15 +150,15 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
     // the full children array and find the view with the smallest position that is bigger than
     // the scroll position.
     var firstVisibleViewPosition = Float.MAX_VALUE
-    for (i in config.minIndexForVisible until contentView.childCount) {
-      val child = contentView.getChildAt(i)
+    for (i in config.minIndexForVisible until subviews.size) {
+      val child = subviews[i]
 
       // Compute the position of the end of the child
       val position = if (horizontal) child.x + child.width else child.y + child.height
 
       // If the child is partially visible or this is the last child, select it as the anchor.
       if ((position > currentScroll && position < firstVisibleViewPosition) ||
-          (firstVisibleView == null && i == contentView.childCount - 1)) {
+          (firstVisibleView == null && i == subviews.size - 1)) {
         firstVisibleView = child
         firstVisibleViewPosition = position
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.kt
@@ -83,6 +83,7 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
       return
     }
     isListening = false
+    firstVisibleViewRef = null
     uIManager.removeUIManagerEventListener(this)
   }
 
@@ -125,6 +126,12 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
     val contentView = contentView ?: return
 
     val currentScroll = if (horizontal) scrollView.scrollX else scrollView.scrollY
+    var firstVisibleView: View? = null
+    // We cannot assume that the views will be in position order because of things like z-index
+    // which will change the order of views in their parent. This means we need to iterate through
+    // the full children array and find the view with the smallest position that is bigger than
+    // the scroll position.
+    var firstVisibleViewPosition = Float.MAX_VALUE
     for (i in config.minIndexForVisible until contentView.childCount) {
       val child = contentView.getChildAt(i)
 
@@ -132,14 +139,21 @@ internal class MaintainVisibleScrollPositionHelper<ScrollViewT>(
       val position = if (horizontal) child.x + child.width else child.y + child.height
 
       // If the child is partially visible or this is the last child, select it as the anchor.
-      if (position > currentScroll || i == contentView.childCount - 1) {
-        firstVisibleViewRef = WeakReference(child)
-        val frame = Rect()
-        child.getHitRect(frame)
-        prevFirstVisibleFrame = frame
-        break
+      if ((position > currentScroll && position < firstVisibleViewPosition) ||
+          (firstVisibleView == null && i == contentView.childCount - 1)) {
+        firstVisibleView = child
+        firstVisibleViewPosition = position
       }
     }
+
+    if (firstVisibleView == null) {
+      return
+    }
+
+    firstVisibleViewRef = WeakReference(firstVisibleView)
+    val frame = Rect()
+    firstVisibleView.getHitRect(frame)
+    prevFirstVisibleFrame = frame
   }
 
   // UIManagerListener

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -15,7 +15,7 @@ import RNTesterText from '../../components/RNTesterText';
 import ScrollViewPressableStickyHeaderExample from './ScrollViewPressableStickyHeaderExample';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
-import {cloneElement, useCallback, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {
   Platform,
   RefreshControl,
@@ -62,114 +62,153 @@ class EnableDisableList extends React.Component<{}, {scrollEnabled: boolean}> {
 }
 
 let AppendingListItemCount = 6;
-class AppendingList extends React.Component<
-  {},
-  {items: Array<ExactReactElement_DEPRECATED<Class<Item>>>},
-> {
-  state: {items: Array<ExactReactElement_DEPRECATED<Class<Item>>>} = {
-    items: [...Array(AppendingListItemCount)].map((_, ii) => (
-      <Item msg={`Item ${ii}`} />
-    )),
-  };
-  render(): React.Node {
-    return (
-      <View>
-        <ScrollView
-          automaticallyAdjustContentInsets={false}
-          maintainVisibleContentPosition={{
-            minIndexForVisible: 0,
-            autoscrollToTopThreshold: 10,
+
+type ItemInfo = {
+  id: number,
+  paddingTop?: number,
+  paddingBottom?: number,
+};
+
+function AppendingList(): React.Node {
+  const [changeAtId, setChangeAtId] = useState('1');
+  const [items, setItems] = useState<Array<ItemInfo>>(() =>
+    [...Array(AppendingListItemCount)].map((_, ii) => ({
+      id: ii,
+    })),
+  );
+
+  const renderItem = (item: ItemInfo, horizontal: boolean) => (
+    <Item
+      key={item.id}
+      msg={`Item ${item.id}`}
+      // When changing an item's height, its top position should stay fixed
+      // rather than its bottom. This used to not be the case with negative
+      // zIndex.
+      zIndex={-item.id}
+      style={
+        horizontal
+          ? {
+              paddingLeft: item.paddingTop,
+              paddingRight: item.paddingBottom,
+            }
+          : {
+              paddingTop: item.paddingTop,
+              paddingBottom: item.paddingBottom,
+            }
+      }
+    />
+  );
+
+  return (
+    <View>
+      <ScrollView
+        automaticallyAdjustContentInsets={false}
+        maintainVisibleContentPosition={{
+          minIndexForVisible: 0,
+          autoscrollToTopThreshold: 10,
+        }}
+        nestedScrollEnabled
+        style={styles.scrollView}>
+        {items.map(item => renderItem(item, false))}
+      </ScrollView>
+      <ScrollView
+        horizontal={true}
+        automaticallyAdjustContentInsets={false}
+        maintainVisibleContentPosition={{
+          minIndexForVisible: 1,
+          autoscrollToTopThreshold: 10,
+        }}
+        style={[styles.scrollView, styles.horizontalScrollView]}>
+        {items.map(item => renderItem(item, true))}
+      </ScrollView>
+      <View style={styles.row}>
+        <Button
+          label="Add to top"
+          onPress={() => {
+            setItems(prevItems => {
+              const idx = AppendingListItemCount++;
+              return [{id: idx, paddingTop: idx * 5}, ...prevItems];
+            });
           }}
-          nestedScrollEnabled
-          style={styles.scrollView}>
-          {this.state.items.map(item =>
-            // $FlowFixMe[prop-missing] React.Element internal inspection
-            cloneElement(item, {key: item.props.msg}),
-          )}
-        </ScrollView>
-        <ScrollView
-          horizontal={true}
-          automaticallyAdjustContentInsets={false}
-          maintainVisibleContentPosition={{
-            minIndexForVisible: 1,
-            autoscrollToTopThreshold: 10,
+        />
+        <Button
+          label="Remove top"
+          onPress={() => {
+            setItems(prevItems => prevItems.slice(1));
           }}
-          style={[styles.scrollView, styles.horizontalScrollView]}>
-          {this.state.items.map(item =>
-            // $FlowFixMe[prop-missing] React.Element internal inspection
-            cloneElement(item, {key: item.props.msg, style: null}),
-          )}
-        </ScrollView>
-        <View style={styles.row}>
-          <Button
-            label="Add to top"
-            onPress={() => {
-              this.setState(state => {
-                const idx = AppendingListItemCount++;
-                return {
-                  items: [
-                    <Item style={{paddingTop: idx * 5}} msg={`Item ${idx}`} />,
-                  ].concat(state.items),
-                };
-              });
-            }}
-          />
-          <Button
-            label="Remove top"
-            onPress={() => {
-              this.setState(state => ({
-                items: state.items.slice(1),
-              }));
-            }}
-          />
-          <Button
-            label="Change height top"
-            onPress={() => {
-              this.setState(state => ({
-                items: [
-                  cloneElement(state.items[0], {
-                    style: {paddingBottom: Math.random() * 40},
-                  }),
-                ].concat(state.items.slice(1)),
-              }));
-            }}
-          />
-        </View>
-        <View style={styles.row}>
-          <Button
-            label="Add to end"
-            onPress={() => {
-              this.setState(state => ({
-                items: state.items.concat(
-                  <Item msg={`Item ${AppendingListItemCount++}`} />,
-                ),
-              }));
-            }}
-          />
-          <Button
-            label="Remove end"
-            onPress={() => {
-              this.setState(state => ({
-                items: state.items.slice(0, -1),
-              }));
-            }}
-          />
-          <Button
-            label="Change height end"
-            onPress={() => {
-              this.setState(state => ({
-                items: state.items.slice(0, -1).concat(
-                  cloneElement(state.items[state.items.length - 1], {
-                    style: {paddingBottom: Math.random() * 40},
-                  }),
-                ),
-              }));
-            }}
-          />
-        </View>
+        />
+        <Button
+          label="Change height top"
+          onPress={() => {
+            setItems(prevItems => {
+              if (prevItems.length === 0) {
+                return prevItems;
+              }
+              const [first, ...rest] = prevItems;
+              return [{...first, paddingBottom: Math.random() * 40}, ...rest];
+            });
+          }}
+        />
       </View>
-    );
-  }
+      <View style={styles.row}>
+        <Button
+          label="Add to end"
+          onPress={() => {
+            setItems(prevItems => {
+              const idx = AppendingListItemCount++;
+              return [...prevItems, {id: idx}];
+            });
+          }}
+        />
+        <Button
+          label="Remove end"
+          onPress={() => {
+            setItems(prevItems => prevItems.slice(0, -1));
+          }}
+        />
+        <Button
+          label="Change height end"
+          onPress={() => {
+            setItems(prevItems => {
+              if (prevItems.length === 0) {
+                return prevItems;
+              }
+              const last = prevItems[prevItems.length - 1];
+              return [
+                ...prevItems.slice(0, -1),
+                {...last, paddingBottom: Math.random() * 40},
+              ];
+            });
+          }}
+        />
+      </View>
+      <View style={styles.row}>
+        <TextInput
+          keyboardType="number-pad"
+          onChangeText={setChangeAtId}
+          placeholder="Id"
+          style={styles.indexInput}
+          value={changeAtId}
+        />
+        <Button
+          label="Change height at id"
+          onPress={() => {
+            const id = parseInt(changeAtId, 10);
+            if (Number.isNaN(id)) {
+              return;
+            }
+            setItems(prevItems =>
+              prevItems.map(item =>
+                item.id === id
+                  ? {...item, paddingBottom: Math.random() * 40}
+                  : item,
+              ),
+            );
+          }}
+        />
+      </View>
+    </View>
+  );
 }
 
 function CenterContentList(): React.Node {
@@ -436,7 +475,9 @@ const examples: Array<RNTesterModuleExample> = [
     title: '<ScrollView> smooth bi-directional content loading\n',
     description:
       'The `maintainVisibleContentPosition` prop allows insertions to either end of the content ' +
-      'without causing the visible content to jump. Re-ordering is not supported.',
+      'without causing the visible content to jump. Re-ordering is not supported. Items use ' +
+      'inverted z-index values so Fabric may reorder native children; the anchor should still ' +
+      'be the topmost visible item, not whichever child happens to appear first in the hierarchy.',
     render() {
       return <AppendingList />;
     },
@@ -1477,10 +1518,12 @@ function ChildrenWithTouchEventsOverflowingContainerHorizontal() {
 class Item extends React.PureComponent<{
   msg?: string,
   style?: ViewStyleProp,
+  zIndex?: number,
 }> {
   render(): $FlowFixMe {
     return (
-      <View style={[styles.item, this.props.style]}>
+      <View
+        style={[styles.item, this.props.style, {zIndex: this.props.zIndex}]}>
         <Text>{this.props.msg}</Text>
       </View>
     );
@@ -1536,6 +1579,17 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: 'row',
     justifyContent: 'space-around',
+  },
+  indexInput: {
+    alignSelf: 'center',
+    backgroundColor: '#ffffff',
+    borderColor: '#cccccc',
+    borderRadius: 3,
+    borderWidth: 1,
+    flex: 1,
+    margin: 5,
+    padding: 5,
+    textAlign: 'center',
   },
   item: {
     margin: 5,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

### Motivation

At Wanderlog, we use a FlatList with negative zIndex so earlier items' bottom shadows can cover later items (by default, later items cover earlier items).

When `maintainVisibleContentPosition` is enabled, the native helper selects the scroll anchor by scanning content children and picking the first one whose end position exceeds the current scroll offset. Fabric can reorder native children when views use `zIndex`, so hierarchy order no longer matches layout order. On both iOS and Android, the helper can then anchor to the wrong item, and scroll corrections keep the bottom edge of the visible content fixed instead of the top.

When `minIndexForVisible > 0`, skipping early items also needs to follow layout order rather than native hierarchy order.

### Fix

**iOS and Android:** Scan all eligible children and select the topmost visible anchor (the smallest end position still below the scroll offset). When `minIndexForVisible > 0`, sort children by layout position before applying the skip. Also clear the cached anchor when the helper stops listening.

Ported from the approach in #46247, adapted for the current Kotlin helper and Fabric iOS scroll view, and simplified.

## Changelog:

[GENERAL] [FIXED] - Fix `maintainVisibleContentPosition` anchoring to the wrong child when z-index reorders Fabric children

## Test Plan:

**Automated Android tests**

```
yarn install
cd packages/rn-tester
yarn start
yarn android
maestro test .maestro/flatlist-horizontal-inverted-maintainvisible.yml -e APP_ID=com.facebook.react.uiapp
```

**Automated Fantom tests**

```
yarn install
yarn fantom ScrollView-maintainVisibleContentPosition-itest
```

**Manual test on iOS and Android using RNTester:**

1. Open **ScrollView** → **smooth bi-directional content loading**
2. Add a few items and scroll so there are items above and below the current item
3. Use **Change height at id** to change the height of an item in the middle
4. Verify the top edge of that item stays in place, rather than the bottom edge jumping

### Android

| Before (maintained position relative to bottom) | After (correctly maintains position relative to top) |
| --- | --- |
| <img width="300" alt="Before edited" src="https://github.com/user-attachments/assets/de21122e-1fec-4937-a07d-b93253d83c17" /> | <img width="300" alt="After edited" src="https://github.com/user-attachments/assets/159cf12a-3936-459b-ba74-5e843bba14f0" /> |

### iOS

| Before (maintained position relative to bottom) | After (correctly maintains position relative to top) |
| --- | --- |
| <img width="413" height="890" alt="MVCP before" src="https://github.com/user-attachments/assets/b3f85a72-6b96-4223-866a-6c7df3c65499" /> | <img width="413" height="890" alt="MVCP after" src="https://github.com/user-attachments/assets/c50a3c56-a49d-468f-9c8b-289639d1be50" /> |