### PR TITLE
Cover `oscompat` with Stable API guards (#57960)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
@@ -10,6 +10,7 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <jsinspector-modern/InspectorFlags.h>
+#include <oscompat/OSCompat.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/networking/NetworkReporter.h>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -11,7 +11,6 @@
 #include "RuntimeSamplingProfile.h"
 #include "TracingMode.h"
 
-#include <oscompat/OSCompat.h>
 #include <react/timing/primitives.h>
 
 #include <vector>

--- a/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
@@ -12,4 +12,7 @@ file(GLOB oscompat_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(oscompat OBJECT ${oscompat_SRC})
 
 target_include_directories(oscompat PUBLIC .)
+
+target_link_libraries(oscompat
+        react_cxxstableapi)
 target_compile_reactnative_options(oscompat PRIVATE)

--- a/packages/react-native/ReactCommon/oscompat/OSCompat.h
+++ b/packages/react-native/ReactCommon/oscompat/OSCompat.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <cstdint>
 
 namespace facebook::react::oscompat {

--- a/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
+++ b/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
@@ -16,6 +16,12 @@ else
   source[:tag] = "v#{version}"
 end
 
+header_search_paths = []
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/..\"" # ReactCommon, for <react/cxxstableapi/...>
+end
+
 Pod::Spec.new do |s|
   s.name                   = "React-oscompat"
   s.version                = version
@@ -26,8 +32,10 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = podspec_sources("*.{cpp,h}", "*.{h}")
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => header_search_paths.join(' ') }
   s.header_dir             = "oscompat"
+
+  s.dependency "React-cxxstableapi"
 
   mark_as_react_native_build(s)
 end


### PR DESCRIPTION
Summary:

`oscompat` is an implementation detail with no stability guarantee, so `OSCompat.h` now includes `<react/cxxstableapi/PrivateGuard.h>`, making it a hard error to include from outside React Native's own build under `RN_STRICT_API`. The guard is inert without that macro, so nothing changes for existing consumers. Buck, CMake and podspec wiring is added for the new dependency.

That surfaced a leak: `jsinspector-modern/tracing/TraceRecordingState.h` included `<oscompat/OSCompat.h>` without using it, exposing the now-private header through `HostTarget.h`, `InstanceTarget.h`, `RuntimeTarget.h`, `RuntimeAgent.h` and `HostTargetTraceRecording.h`. The unused include is removed, `NetworkReporterTest.cpp` relied on that transitive path and now includes the header directly, and `oscompat` moves to `deps` on the tracing target to match.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116012538


