### PR TITLE
Cover `react/renderer/dom` with Stable API guards (#57961)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(react_renderer_dom OBJECT ${react_renderer_dom_SRC})
 target_include_directories(react_renderer_dom PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_renderer_dom
+        react_cxxstableapi
         react_renderer_core
         react_renderer_graphics
         rrc_root

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <cstdint>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/dom` as a private target under the three-tier C++ stable API visibility model. `DOM.h` now includes `<react/cxxstableapi/PrivateGuard.h>`. Consumers that opt into `RN_STRICT_API` now get an error if they include `DOM.h` directly; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116013879


