### PR TITLE
Cover `jsinspector-modern/network:jsinspector_network` with Stable API guards (#57962)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <deque>
 #include <memory>
 #include <string>

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -24,4 +24,5 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector_network
         folly_runtime
         glog
-        jsinspector_cdp)
+        jsinspector_cdp
+        react_cxxstableapi)

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <folly/dynamic.h>
 
 #include <string>

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <map>
 #include <string>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "BoundedRequestBuffer.h"
 #include "CdpNetwork.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -48,5 +48,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
+  s.dependency "React-cxxstableapi"
+
   mark_as_react_native_build(s)
 end


### PR DESCRIPTION
Summary:

Marks `jsinspector-modern/network` as a private module under the C++ Stable API by adding `#include <react/cxxstableapi/PrivateGuard.h>` to its four exported headers (`BoundedRequestBuffer.h`, `CdpNetwork.h`, `HttpUtils.h`, `NetworkHandler.h`), and wiring the `React-cxxstableapi` dependency into BUCK and the podspec.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: huntie, cipolleschi

Differential Revision: D116026740


