### PR TITLE
fix: export feature flags for virtualized lists

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -53,6 +53,10 @@
       "types": null,
       "default": "./src/react-private-interface.js"
     },
+    "./src/private/featureflags/ReactNativeFeatureFlags": {
+      "types": null,
+      "default": "./src/private/featureflags/ReactNativeFeatureFlags.js"
+    },
     "./setup-env": "./src/setup-env.js",
     "./unstable-internals-do-not-use": {
       "react-native-unstable-internals": "./src/unstable-internals-do-not-use.d.ts",

--- a/packages/virtualized-lists/Lists/__tests__/package-exports-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/package-exports-test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+test('resolves React Native feature flags through package exports', () => {
+  expect(() =>
+    require.resolve('react-native/src/private/featureflags/ReactNativeFeatureFlags'),
+  ).not.toThrow();
+});


### PR DESCRIPTION
## Summary:

Fixes #57933.

PR #57484 removed the broad `./src/*` export from the `react-native` package. However, the published `@react-native/virtualized-lists` package still imports `ReactNativeFeatureFlags` through an unexported subpath. This causes Metro to emit a package-exports warning when applications render a `FlatList`.

This change exposes only the exact feature-flags subpath required by `VirtualizedList`, without restoring the broad `./src/*` export. It also adds a regression test verifying that the import resolves through the package exports map.

## Changelog:

[General] [Fixed] - Fix Metro package-exports warning when using VirtualizedList

## Test Plan:

- `yarn test package-exports-test --runInBand`
  - 1 test passed.
- `yarn test VirtualizeUtils-test --runInBand`
  - 17 tests passed.
- `yarn lint packages/virtualized-lists/Lists/__tests__/package-exports-test.js`
  - Passed.
- `git diff --check`
  - Passed.
