### PR TITLE
fix(iOS): preserve RefreshControl haptics after remount

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -120,7 +120,9 @@ using namespace facebook::react;
   if (_recycled || newConcreteProps.refreshing != oldConcreteProps.refreshing) {
     if (newConcreteProps.refreshing) {
       [self beginRefreshingProgrammatically];
-    } else {
+    } else if (!_recycled) {
+      // A newly initialized UIRefreshControl is already idle. Calling endRefreshing before it is attached to the
+      // scroll view prevents pull-to-refresh haptics from being restored after the component view is recycled.
       [_refreshControl endRefreshing];
     }
   }


### PR DESCRIPTION
## Summary

Fixes #57843.

When a `RCTPullToRefreshViewComponentView` is recycled, it creates a new `UIRefreshControl`. This control is already idle, but the recycled-props path calls `endRefreshing` before it is attached to the scroll view.

Avoid that unnecessary state transition while preserving normal refreshing prop updates.

## Changelog:

[iOS] [FIXED] - Preserve pull-to-refresh haptics after RefreshControl remounts

## Test Plan

1. Run the reproducer from #57843 on a physical iPhone.
2. Pull to refresh and confirm haptic feedback occurs.
3. Remount the RefreshControl.
4. Pull to refresh again.
5. Confirm haptic feedback still occurs after the remount.