### PR TITLE
fix(iOS): reuse prefetched images

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -666,6 +666,14 @@ static RCTImageLoaderCancellationBlock RCTLoadImageURLFromLoader(
                                                 size:size
                                                scale:scale
                                           resizeMode:resizeMode];
+        if (!image) {
+          // Prefetched images are cached at their original size. Reuse that
+          // entry for subsequent requests, which may specify a concrete size.
+          image = [[strongSelf imageCache] imageForUrl:request.URL.absoluteString
+                                                  size:CGSizeZero
+                                                 scale:1
+                                            resizeMode:RCTResizeModeStretch];
+        }
       }
 
       if (image) {
@@ -1133,6 +1141,11 @@ static RCTImageLoaderCancellationBlock RCTLoadImageURLFromLoader(
         } else {
           results[urlRequest.URL.absoluteString] = @"disk/memory";
         }
+      } else if ([[self imageCache] imageForUrl:urlRequest.URL.absoluteString
+                                           size:CGSizeZero
+                                          scale:1
+                                     resizeMode:RCTResizeModeStretch]) {
+        results[urlRequest.URL.absoluteString] = @"memory";
       }
     }
   }


### PR DESCRIPTION
## Summary:

Fixes #28557.

iOS image prefetch stores decoded images using their original-size cache key. Later image requests often include concrete dimensions, producing a different cache key and causing the prefetched image to be downloaded again.

This change falls back to the original-size cache entry for sized requests and reports prefetched decoded images as available in memory through `Image.queryCache()`.

## Changelog:

[IOS] [FIXED] - Reuse prefetched images for subsequent sized image requests

## Test Plan:

- `git diff --check` — passed.
- Tested with RNTester on an iPhone simulator running iOS 26.5.
- Opened **Image → Image Loading Events**.
- Verified `Image.prefetch()` completed successfully.
- Verified `Image.queryCache()` returned `disk/memory`.
- Verified the prefetched image loaded and rendered at the requested dimensions without unexpected stretching, cropping, or distortion.

Screenshot:

<img width="318" height="604" alt="Screenshot 2026-08-16 at 12 09 30 PM" src="https://github.com/user-attachments/assets/c6db4ce4-d130-47d3-ae64-0a62f5e5385e" />

