### PR TITLE
Cover `jsinspector-modern/tracing:profile` with Stable API guards (#57977)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(jsinspector_tracing
         jsi
         jsinspector_network
         oscompat
+        react_cxxstableapi
         react_timing
         react_utils
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <utility>
 
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
+  s.dependency "React-cxxstableapi"
   s.dependency "React-jsi"
   s.dependency "React-oscompat"
   s.dependency "React-timing"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>


### PR DESCRIPTION
Summary:

Classifies `jsinspector-modern/tracing:profile` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its headers directly; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116294338
