### PR TITLE
Cover `hermes/inspector-modern:chrome` with Stable API guards (#57978)

### DIFF
--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-oscompat")
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+  s.dependency "React-cxxstableapi"
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -31,4 +31,5 @@ target_link_libraries(hermes_inspector_modern
         hermes-engine::hermesvm
         jsi
         jsinspector
+        react_cxxstableapi
         ${reactnative})

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifdef HERMES_ENABLE_DEBUGGER
 
 #include "HermesRuntimeTargetDelegate.h"

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <hermes/hermes.h>
 
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 
 #include <cxxreact/MessageQueueThread.h>


### PR DESCRIPTION
Summary:

Classifies `hermes/inspector-modern:chrome` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to all three headers in the module and declares the guard dependency in the build config.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116283495


