### PR TITLE
[IOS][FIXED] - Keep the quotes on header search paths

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/rndependencies-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/rndependencies-test.rb
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "test/unit"
+require "shellwords"
+require_relative "../rndependencies.rb"
+require_relative "./test_utils/SpecMock.rb"
+
+class RNDependenciesTests < Test::Unit::TestCase
+
+    # A pod that exports a Swift compatibility header ships this path, and the
+    # directory name contains spaces.
+    SWIFT_HEADER = "${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift Compatibility Header"
+
+    def teardown
+        ReactNativeDependenciesUtils.class_variable_set(:@@build_from_source, true)
+    end
+
+    # Xcode joins an array setting with spaces, then splits it back on
+    # whitespace while honouring quotes. This is what the compiler ends up with.
+    def resolved_paths(xcconfig)
+        value = xcconfig["HEADER_SEARCH_PATHS"]
+        Shellwords.shellsplit(value.is_a?(Array) ? value.join(" ") : value)
+    end
+
+    # ================================== #
+    # TEST - append_header_search_paths  #
+    # ================================== #
+
+    def test_appendHeaderSearchPaths_whenUnset_quotesTheAddedPaths
+        xcconfig = {}
+
+        ReactNativeDependenciesUtils.append_header_search_paths(xcconfig, ["$(PODS_ROOT)/glog"])
+
+        assert_equal(["\"$(PODS_ROOT)/glog\""], xcconfig["HEADER_SEARCH_PATHS"])
+    end
+
+    def test_appendHeaderSearchPaths_whenStringHasQuotedPathWithSpaces_keepsItIntact
+        xcconfig = {"HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/DoubleConversion\" \"#{SWIFT_HEADER}\""}
+
+        ReactNativeDependenciesUtils.append_header_search_paths(xcconfig, ["$(PODS_ROOT)/glog"])
+
+        assert_equal(["$(PODS_ROOT)/DoubleConversion", SWIFT_HEADER, "$(PODS_ROOT)/glog"], resolved_paths(xcconfig))
+    end
+
+    def test_appendHeaderSearchPaths_whenArrayHasQuotedPathWithSpaces_keepsItIntact
+        xcconfig = {"HEADER_SEARCH_PATHS" => ["\"$(PODS_ROOT)/DoubleConversion\"", "\"#{SWIFT_HEADER}\""]}
+
+        ReactNativeDependenciesUtils.append_header_search_paths(xcconfig, ["$(PODS_ROOT)/glog"])
+
+        assert_equal(["$(PODS_ROOT)/DoubleConversion", SWIFT_HEADER, "$(PODS_ROOT)/glog"], resolved_paths(xcconfig))
+    end
+
+    def test_appendHeaderSearchPaths_whenCalledTwice_doesNotDuplicateEntries
+        xcconfig = {"HEADER_SEARCH_PATHS" => "\"#{SWIFT_HEADER}\""}
+
+        ReactNativeDependenciesUtils.append_header_search_paths(xcconfig, ["$(PODS_ROOT)/glog"])
+        ReactNativeDependenciesUtils.append_header_search_paths(xcconfig, ["$(PODS_ROOT)/glog"])
+
+        assert_equal([SWIFT_HEADER, "$(PODS_ROOT)/glog"], resolved_paths(xcconfig))
+    end
+
+    # ======================================= #
+    # TEST - add_rn_third_party_dependencies  #
+    # ======================================= #
+
+    def test_addRNThirdPartyDependencies_whenBuildingFromSource_keepsQuotedPathWithSpaces
+        spec = SpecMock.new
+        spec.pod_target_xcconfig = {"HEADER_SEARCH_PATHS" => "\"#{SWIFT_HEADER}\""}
+
+        add_rn_third_party_dependencies(spec)
+
+        paths = resolved_paths(spec.pod_target_xcconfig)
+        assert_equal(SWIFT_HEADER, paths.first)
+        assert(paths.include?("$(PODS_ROOT)/RCT-Folly"))
+    end
+
+    def test_addRNThirdPartyDependencies_whenUsingPrebuiltDeps_keepsQuotedPathWithSpaces
+        ReactNativeDependenciesUtils.class_variable_set(:@@build_from_source, false)
+        spec = SpecMock.new
+        spec.pod_target_xcconfig = {"HEADER_SEARCH_PATHS" => "\"#{SWIFT_HEADER}\""}
+
+        add_rn_third_party_dependencies(spec)
+
+        assert_equal([SWIFT_HEADER, "$(PODS_ROOT)/ReactNativeDependencies/Headers"], resolved_paths(spec.pod_target_xcconfig))
+    end
+end

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -6,7 +6,6 @@
 require "json"
 require 'net/http'
 require 'rexml/document'
-require 'shellwords'
 
 require_relative './utils.rb'
 
@@ -34,38 +33,26 @@ def add_rn_third_party_dependencies(s)
             s.dependency "RCT-Folly/Fabric"
         end
 
-        header_search_paths = current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] || []
-
-        if header_search_paths.is_a?(String)
-            header_search_paths = Shellwords.shellsplit(header_search_paths)
-        end
-
-        header_search_paths << "$(PODS_ROOT)/glog"
-        header_search_paths << "$(PODS_ROOT)/boost"
-        header_search_paths << "$(PODS_ROOT)/DoubleConversion"
-        header_search_paths << "$(PODS_ROOT)/fast_float/include"
-        header_search_paths << "$(PODS_ROOT)/fmt/include"
-        header_search_paths << "$(PODS_ROOT)/SocketRocket"
-        header_search_paths << "$(PODS_ROOT)/RCT-Folly"
-
-        # uniq so a second call on the same spec can't duplicate entries.
-        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq.map { |path| path =~ /\s/ ? "\"#{path}\"" : path }
+        ReactNativeDependenciesUtils.append_header_search_paths(current_pod_target_xcconfig, [
+            "$(PODS_ROOT)/glog",
+            "$(PODS_ROOT)/boost",
+            "$(PODS_ROOT)/DoubleConversion",
+            "$(PODS_ROOT)/fast_float/include",
+            "$(PODS_ROOT)/fmt/include",
+            "$(PODS_ROOT)/SocketRocket",
+            "$(PODS_ROOT)/RCT-Folly",
+        ])
     else
         # Prebuilt-deps mode: this pod SELF-SERVES the third-party headers from its
         # own xcframework (incl. SocketRocket - sole supplier in this mode). See
         # scripts/cocoapods/__docs__/prebuilt-deps.md for the full contract.
         s.dependency "ReactNativeDependencies"
 
-        header_search_paths = current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] || []
-        if header_search_paths.is_a?(String)
-            header_search_paths = Shellwords.shellsplit(header_search_paths)
-        end
         # Artifact headers are flattened into the pod-local Headers/ by the podspec
         # prepare_command (see __docs__/prebuilt-deps.md).
-        header_search_paths << "$(PODS_ROOT)/ReactNativeDependencies/Headers"
-
-        # uniq so a second call on the same spec can't duplicate entries.
-        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq.map { |path| path =~ /\s/ ? "\"#{path}\"" : path }
+        ReactNativeDependenciesUtils.append_header_search_paths(current_pod_target_xcconfig, [
+            "$(PODS_ROOT)/ReactNativeDependencies/Headers",
+        ])
     end
 
     s.pod_target_xcconfig = current_pod_target_xcconfig
@@ -145,6 +132,25 @@ class ReactNativeDependenciesUtils
             end
             rndeps_log("Building from source: #{@@build_from_source}")
             rndeps_log("Source: #{self.resolve_podspec_source()}")
+        end
+    end
+
+    # Xcode splits HEADER_SEARCH_PATHS on whitespace, so every path we add is
+    # quoted - PODS_ROOT can expand to a directory with spaces in its name.
+    # Paths already in the xcconfig are left untouched: they carry the podspec
+    # author's own quoting, and re-quoting them would break it.
+    def self.append_header_search_paths(xcconfig, paths)
+        quoted = paths.map { |path| "\"#{path}\"" }
+        existing = xcconfig["HEADER_SEARCH_PATHS"]
+
+        # reject so a second call on the same spec can't duplicate entries.
+        case existing
+        when nil
+            xcconfig["HEADER_SEARCH_PATHS"] = quoted
+        when Array
+            xcconfig["HEADER_SEARCH_PATHS"] = existing + quoted.reject { |path| existing.include?(path) }
+        else
+            xcconfig["HEADER_SEARCH_PATHS"] = ([existing] + quoted.reject { |path| existing.include?(path) }).join(" ")
         end
     end
 

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -49,7 +49,7 @@ def add_rn_third_party_dependencies(s)
         header_search_paths << "$(PODS_ROOT)/RCT-Folly"
 
         # uniq so a second call on the same spec can't duplicate entries.
-        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq.map { |path| path =~ /\s/ ? "\"#{path}\"" : path }
     else
         # Prebuilt-deps mode: this pod SELF-SERVES the third-party headers from its
         # own xcframework (incl. SocketRocket - sole supplier in this mode). See
@@ -65,7 +65,7 @@ def add_rn_third_party_dependencies(s)
         header_search_paths << "$(PODS_ROOT)/ReactNativeDependencies/Headers"
 
         # uniq so a second call on the same spec can't duplicate entries.
-        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths.uniq.map { |path| path =~ /\s/ ? "\"#{path}\"" : path }
     end
 
     s.pod_target_xcconfig = current_pod_target_xcconfig


### PR DESCRIPTION
## Summary:

a regression from https://github.com/react/react-native/commit/a8156acf8bbc9ee15901cf0d8935d73454768aa7 and breaks react-native nightly build at expo: https://github.com/expo/expo/actions/runs/31990917142/job/95274214849

the `shellsplit` will stripe quotes and break paths with spaces like `Swift Compatibility Header`. this pr tries to re-quote.

here's small demo script

```ruby
require 'shellwords'

# What main does today: shellsplit the existing value, append, write it back.
def main_behaviour(existing, add)
  paths = existing || []
  paths = Shellwords.shellsplit(paths) if paths.is_a?(String)
  (paths + add).uniq
end

# What this PR does: quote only the paths we add, never touch what is there.
def this_pr(existing, add)
  quoted = add.map { |path| "\"#{path}\"" }
  case existing
  when nil
    quoted
  when Array
    existing + quoted.reject { |path| existing.include?(path) }
  else
    ([existing] + quoted.reject { |path| existing.include?(path) }).join(" ")
  end
end

# Xcode joins an Array setting with spaces, then splits it on whitespace while
# honouring quotes. This is what the compiler ends up with.
def as_xcode_reads_it(value)
  Shellwords.shellsplit(value.is_a?(Array) ? value.join(" ") : value)
end

ADD = ['$(PODS_ROOT)/ReactNativeDependencies/Headers']

# A pod that exports a Swift compatibility header. The directory name has
# spaces, so the podspec quotes it. Podspecs write this as a String or as an
# Array, and both forms reach add_rn_third_party_dependencies.
SWIFT_HEADER = '${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift Compatibility Header'

CASES = {
  'String' => "\"$(PODS_ROOT)/DoubleConversion\" \"#{SWIFT_HEADER}\"",
  'Array'  => ['"$(PODS_ROOT)/DoubleConversion"', "\"#{SWIFT_HEADER}\""],
}

CASES.each do |label, existing|
  puts "#{label} HEADER_SEARCH_PATHS"
  { 'main' => method(:main_behaviour), 'this PR' => method(:this_pr) }.each do |name, fn|
    paths = as_xcode_reads_it(fn.call(existing, ADD))
    verdict = paths.include?(SWIFT_HEADER) ? 'ok' : 'BROKEN'
    puts "  #{name.ljust(7)} -> #{paths.size} paths, #{verdict}: #{paths.inspect}"
  end
  puts
end
```

output

```
String HEADER_SEARCH_PATHS
  main    -> 5 paths, BROKEN: ["$(PODS_ROOT)/DoubleConversion", "${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift", "Compatibility", "Header", "$(PODS_ROOT)/ReactNativeDependencies/Headers"]
  this PR -> 3 paths, ok: ["$(PODS_ROOT)/DoubleConversion", "${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift Compatibility Header", "$(PODS_ROOT)/ReactNativeDependencies/Headers"]

Array HEADER_SEARCH_PATHS
  main    -> 3 paths, ok: ["$(PODS_ROOT)/DoubleConversion", "${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift Compatibility Header", "$(PODS_ROOT)/ReactNativeDependencies/Headers"]
  this PR -> 3 paths, ok: ["$(PODS_ROOT)/DoubleConversion", "${PODS_CONFIGURATION_BUILD_DIR}/MyPod/Swift Compatibility Header", "$(PODS_ROOT)/ReactNativeDependencies/Headers"]

```

## Changelog:

[IOS][FIXED] - Keep the quotes on header search paths containing spaces in `add_rn_third_party_dependencies`

## Test Plan:

apply the patch on create-expo-nightly and the ios build should pass https://github.com/expo/expo/pull/49023