### PR TITLE
Enforce the ArrayBuffer borrow contract for Java TurboModules (#57982)

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -282,8 +282,8 @@ function translateFunctionParamToJavaType(
       imports.add('com.facebook.react.bridge.Callback');
       return wrapOptional('Callback', isRequired);
     case 'ArrayBufferTypeAnnotation':
-      imports.add('java.nio.ByteBuffer');
-      return wrapOptional('ByteBuffer', isRequired);
+      imports.add('com.facebook.react.bridge.ArrayBuffer');
+      return wrapOptional('ArrayBuffer', isRequired);
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));
@@ -379,8 +379,8 @@ function translateFunctionReturnTypeToJavaType(
       imports.add('com.facebook.react.bridge.WritableArray');
       return wrapOptional('WritableArray', isRequired);
     case 'ArrayBufferTypeAnnotation':
-      imports.add('java.nio.ByteBuffer');
-      return wrapOptional('ByteBuffer', isRequired);
+      imports.add('com.facebook.react.bridge.ArrayBuffer');
+      return wrapOptional('ArrayBuffer', isRequired);
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(createErrorMessage(realTypeAnnotation.type));

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -311,7 +311,7 @@ function translateParamTypeToJniType(
     case 'FunctionTypeAnnotation':
       return 'Lcom/facebook/react/bridge/Callback;';
     case 'ArrayBufferTypeAnnotation':
-      return 'Ljava/nio/ByteBuffer;';
+      return 'Lcom/facebook/react/bridge/ArrayBuffer;';
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(
@@ -397,7 +397,7 @@ function translateReturnTypeToJniType(
     case 'ArrayTypeAnnotation':
       return 'Lcom/facebook/react/bridge/WritableArray;';
     case 'ArrayBufferTypeAnnotation':
-      return 'Ljava/nio/ByteBuffer;';
+      return 'Lcom/facebook/react/bridge/ArrayBuffer;';
     default:
       realTypeAnnotation.type as 'MixedTypeAnnotation';
       throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
@@ -58,11 +58,11 @@ Map {
 package com.facebook.fbreact.specs;
 
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.ArrayBuffer;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import java.nio.ByteBuffer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -80,15 +80,15 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip
-  public abstract ByteBuffer getArrayBuffer();
+  public abstract ArrayBuffer getArrayBuffer();
 
   @ReactMethod
   @DoNotStrip
-  public abstract void voidArrayBuffer(ByteBuffer arg);
+  public abstract void voidArrayBuffer(ArrayBuffer arg);
 
   @ReactMethod
   @DoNotStrip
-  public abstract void voidNullableArrayBuffer(@Nullable ByteBuffer arg);
+  public abstract void voidNullableArrayBuffer(@Nullable ArrayBuffer arg);
 }
 ",
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
@@ -53,17 +53,17 @@ namespace facebook::react {
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getArrayBuffer(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
   static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, ArrayBufferKind, \\"getArrayBuffer\\", \\"()Ljava/nio/ByteBuffer;\\", args, count, cachedMethodId);
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, ArrayBufferKind, \\"getArrayBuffer\\", \\"()Lcom/facebook/react/bridge/ArrayBuffer;\\", args, count, cachedMethodId);
 }
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidArrayBuffer(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
   static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, VoidKind, \\"voidArrayBuffer\\", \\"(Ljava/nio/ByteBuffer;)V\\", args, count, cachedMethodId);
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, VoidKind, \\"voidArrayBuffer\\", \\"(Lcom/facebook/react/bridge/ArrayBuffer;)V\\", args, count, cachedMethodId);
 }
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidNullableArrayBuffer(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
   static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, VoidKind, \\"voidNullableArrayBuffer\\", \\"(Ljava/nio/ByteBuffer;)V\\", args, count, cachedMethodId);
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, VoidKind, \\"voidNullableArrayBuffer\\", \\"(Lcom/facebook/react/bridge/ArrayBuffer;)V\\", args, count, cachedMethodId);
 }
 
 NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const JavaTurboModule::InitParams &params)

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -537,6 +537,28 @@ public final class com/facebook/react/bridge/Arguments {
 	public static final fun toList (Lcom/facebook/react/bridge/ReadableArray;)Ljava/util/ArrayList;
 }
 
+public final class com/facebook/react/bridge/ArrayBuffer : com/facebook/jni/HybridClassBase {
+	public static final field Companion Lcom/facebook/react/bridge/ArrayBuffer$Companion;
+	public fun <init> (I)V
+	public synthetic fun <init> (Ljava/nio/ByteBuffer;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun arrayBufferWithCopiedBytes (Lcom/facebook/react/bridge/ArrayBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+	public static final fun arrayBufferWithCopiedBytes (Ljava/nio/ByteBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+	public static final fun arrayBufferWithCopiedBytes ([B)Lcom/facebook/react/bridge/ArrayBuffer;
+	public static final fun arrayBufferWithLength (I)Lcom/facebook/react/bridge/ArrayBuffer;
+	public static final fun arrayBufferWithOwnedBytes (Ljava/nio/ByteBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+	public final fun getBytes ()Ljava/nio/ByteBuffer;
+	public final fun getSize ()I
+	public final fun isOwningBytes ()Z
+}
+
+public final class com/facebook/react/bridge/ArrayBuffer$Companion {
+	public final fun arrayBufferWithCopiedBytes (Lcom/facebook/react/bridge/ArrayBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+	public final fun arrayBufferWithCopiedBytes (Ljava/nio/ByteBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+	public final fun arrayBufferWithCopiedBytes ([B)Lcom/facebook/react/bridge/ArrayBuffer;
+	public final fun arrayBufferWithLength (I)Lcom/facebook/react/bridge/ArrayBuffer;
+	public final fun arrayBufferWithOwnedBytes (Ljava/nio/ByteBuffer;)Lcom/facebook/react/bridge/ArrayBuffer;
+}
+
 public final class com/facebook/react/bridge/AssertionException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ArrayBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ArrayBuffer.kt
@@ -14,11 +14,16 @@ import java.nio.ByteBuffer
 /**
  * A fixed-length byte buffer for TurboModule `ArrayBuffer` arguments and return values.
  *
+ * Returning an owning [ArrayBuffer] to JS produces a *new* JS `ArrayBuffer` object over the same
+ * bytes, so a module that mutates an argument in place and returns it gives JS a different object
+ * that aliases the memory it passed in. Returning a non-owning [ArrayBuffer] gives JS a copy.
+ *
  * @property isOwningBytes:
  * - `true` — safe to retain and return to JS. Synchronize externally if JS may touch the same
  *   memory concurrently.
- * - `false` — bytes are borrowed from a JS `ArrayBuffer` for the current synchronous call only.
- *   Copy with [arrayBufferWithCopiedBytes] to keep them.
+ * - `false` — the bytes are borrowed from a JS `ArrayBuffer` and are only valid until the method
+ *   that received this [ArrayBuffer] returns. After that, [bytes] and [size] throw. Copy with
+ *   [arrayBufferWithCopiedBytes] to keep them.
  */
 @DoNotStrip
 public class ArrayBuffer : HybridClassBase {
@@ -39,13 +44,49 @@ public class ArrayBuffer : HybridClassBase {
     initHybrid(buffer, isOwningBytes)
   }
 
+  /**
+   * The bytes as a direct [ByteBuffer]. The buffer is shared, not a copy: its position and limit
+   * belong to the caller, so duplicate it rather than relying on where a previous reader left it.
+   *
+   * Reading this property is the only access path that is checked against revocation, and the
+   * returned [ByteBuffer] is not. Its address cannot be cleared once handed out, so a [ByteBuffer]
+   * kept past the method that received a non-owning [ArrayBuffer] reads freed or relocated memory
+   * with no exception to warn you. Do not store it, and do not let it outlive the [ArrayBuffer] it
+   * came from: retain the [ArrayBuffer] and read [bytes] again, or copy the bytes with
+   * [arrayBufferWithCopiedBytes].
+   *
+   * @throws IllegalStateException if the bytes were borrowed and the method that received this
+   *   [ArrayBuffer] has already returned. See [isOwningBytes].
+   */
   public val bytes: ByteBuffer
-    get() = buffer
+    get() {
+      checkBytesValid()
+      return buffer
+    }
 
+  /**
+   * The capacity of the buffer in bytes, independent of the position and limit of [bytes].
+   *
+   * @throws IllegalStateException if the bytes were borrowed and the method that received this
+   *   [ArrayBuffer] has already returned. See [isOwningBytes].
+   */
   public val size: Int
-    get() = buffer.capacity()
+    get() {
+      checkBytesValid()
+      return buffer.capacity()
+    }
+
+  private fun checkBytesValid() {
+    check(isBytesValid()) {
+      "ArrayBuffer: the bytes of a non-owning ArrayBuffer were accessed after the method " +
+          "that received it returned. Copy them with " +
+          "ArrayBuffer.arrayBufferWithCopiedBytes() to use them later."
+    }
+  }
 
   private external fun initHybrid(buffer: ByteBuffer, isOwningBytes: Boolean)
+
+  private external fun isBytesValid(): Boolean
 
   public companion object {
     init {
@@ -69,7 +110,11 @@ public class ArrayBuffer : HybridClassBase {
       return buffer
     }
 
-    /** @param source remaining bytes are copied into a new owning buffer */
+    /**
+     * @param source the bytes between its position and limit are copied into a new owning buffer.
+     *   Pass a buffer positioned at 0 with the limit at its capacity to copy all of it. The
+     *   position and limit of `source` are left unchanged.
+     */
     @JvmStatic
     @DoNotStrip
     public fun arrayBufferWithCopiedBytes(source: ByteBuffer): ArrayBuffer {
@@ -83,8 +128,9 @@ public class ArrayBuffer : HybridClassBase {
     }
 
     /**
-     * @param source copied into a new owning buffer. Use to keep bytes from a non-owning argument
-     *   after the call returns.
+     * @param source all [size] bytes are copied into a new owning buffer, regardless of the
+     *   position and limit of its [bytes]. Use to keep bytes from a non-owning argument after the
+     *   call returns.
      */
     @JvmStatic
     @DoNotStrip
@@ -102,8 +148,12 @@ public class ArrayBuffer : HybridClassBase {
     }
 
     /**
-     * @param buffer direct [ByteBuffer] to alias without copying. The caller must keep it valid for
-     *   as long as this [ArrayBuffer] lives.
+     * Aliases an existing direct [ByteBuffer] without copying. The resulting [ArrayBuffer] reports
+     * [isOwningBytes] as `true`, so it may be retained and returned to JS — but it does not own the
+     * memory: the caller must keep `buffer` and whatever backs it valid for as long as the
+     * [ArrayBuffer], and any JS `ArrayBuffer` derived from it, is reachable.
+     *
+     * @param buffer direct [ByteBuffer] to alias without copying
      */
     @JvmStatic
     @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ArrayBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ArrayBuffer.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import com.facebook.jni.HybridClassBase
+import com.facebook.proguard.annotations.DoNotStrip
+import java.nio.ByteBuffer
+
+/**
+ * A fixed-length byte buffer for TurboModule `ArrayBuffer` arguments and return values.
+ *
+ * @property isOwningBytes:
+ * - `true` — safe to retain and return to JS. Synchronize externally if JS may touch the same
+ *   memory concurrently.
+ * - `false` — bytes are borrowed from a JS `ArrayBuffer` for the current synchronous call only.
+ *   Copy with [arrayBufferWithCopiedBytes] to keep them.
+ */
+@DoNotStrip
+public class ArrayBuffer : HybridClassBase {
+
+  private val buffer: ByteBuffer
+
+  /** Whether this buffer owns its bytes. See the class documentation. */
+  public val isOwningBytes: Boolean
+
+  @DoNotStrip
+  private constructor(buffer: ByteBuffer, isOwningBytes: Boolean) : super() {
+    this.buffer = buffer
+    this.isOwningBytes = isOwningBytes
+  }
+
+  /** @param size number of zero-filled bytes to allocate */
+  public constructor(size: Int) : this(allocateDirect(size), true) {
+    initHybrid(buffer, isOwningBytes)
+  }
+
+  public val bytes: ByteBuffer
+    get() = buffer
+
+  public val size: Int
+    get() = buffer.capacity()
+
+  private external fun initHybrid(buffer: ByteBuffer, isOwningBytes: Boolean)
+
+  public companion object {
+    init {
+      ReactNativeJniCommonSoLoader.staticInit()
+    }
+
+    /** @param size number of zero-filled bytes to allocate. Same as `ArrayBuffer(size)`. */
+    @JvmStatic
+    @DoNotStrip
+    public fun arrayBufferWithLength(size: Int): ArrayBuffer = ArrayBuffer(size)
+
+    /** @param bytes copied into a new owning buffer */
+    @JvmStatic
+    @DoNotStrip
+    public fun arrayBufferWithCopiedBytes(bytes: ByteArray): ArrayBuffer {
+      val buffer = ArrayBuffer(bytes.size)
+      if (bytes.isNotEmpty()) {
+        buffer.bytes.put(bytes)
+        buffer.bytes.rewind()
+      }
+      return buffer
+    }
+
+    /** @param source remaining bytes are copied into a new owning buffer */
+    @JvmStatic
+    @DoNotStrip
+    public fun arrayBufferWithCopiedBytes(source: ByteBuffer): ArrayBuffer {
+      val length = source.remaining()
+      val buffer = ArrayBuffer(length)
+      if (length > 0) {
+        buffer.bytes.put(source.duplicate())
+        buffer.bytes.rewind()
+      }
+      return buffer
+    }
+
+    /**
+     * @param source copied into a new owning buffer. Use to keep bytes from a non-owning argument
+     *   after the call returns.
+     */
+    @JvmStatic
+    @DoNotStrip
+    public fun arrayBufferWithCopiedBytes(source: ArrayBuffer): ArrayBuffer {
+      val length = source.size
+      val buffer = ArrayBuffer(length)
+      if (length > 0) {
+        val src = source.bytes.duplicate()
+        src.position(0)
+        src.limit(length)
+        buffer.bytes.put(src)
+        buffer.bytes.rewind()
+      }
+      return buffer
+    }
+
+    /**
+     * @param buffer direct [ByteBuffer] to alias without copying. The caller must keep it valid for
+     *   as long as this [ArrayBuffer] lives.
+     */
+    @JvmStatic
+    @DoNotStrip
+    public fun arrayBufferWithOwnedBytes(buffer: ByteBuffer): ArrayBuffer {
+      require(buffer.isDirect) { "arrayBufferWithOwnedBytes requires a direct ByteBuffer" }
+      return ArrayBuffer(buffer, true).apply { initHybrid(buffer, isOwningBytes) }
+    }
+
+    private fun allocateDirect(size: Int): ByteBuffer {
+      require(size >= 0) { "ArrayBuffer size must not be negative, got $size" }
+      return ByteBuffer.allocateDirect(size)
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -23,6 +23,7 @@ include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-ut
 add_library(
         reactnativejni_common
         OBJECT
+          JArrayBuffer.cpp
           JDynamicNative.cpp
           JReactMarker.cpp
           NativeArray.cpp

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library(
 target_merge_so(reactnativejni_common)
 target_include_directories(reactnativejni_common PUBLIC ../../)
 
-target_link_libraries(reactnativejni_common fbjni folly_runtime react_cxxreact rrc_view)
+target_link_libraries(reactnativejni_common fbjni folly_runtime react_bridging react_cxxreact rrc_view)
 target_compile_reactnative_options(reactnativejni_common PRIVATE)
 target_compile_options(reactnativejni_common PRIVATE -Wno-unused-lambda-capture)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JArrayBuffer.h"
+
+#include <cstring>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "JByteBufferMutableBuffer.h"
+
+namespace facebook::react {
+
+namespace {
+
+// Holds a copy of bytes borrowed from a JS ArrayBuffer.
+class OwnedBytesBuffer final : public jsi::MutableBuffer {
+ public:
+  explicit OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept
+      : bytes_(std::move(bytes)) {}
+
+  size_t size() const override {
+    return bytes_.size();
+  }
+
+  uint8_t* data() override {
+    return bytes_.data();
+  }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+
+} // namespace
+
+void JArrayBuffer::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("initHybrid", JArrayBuffer::initHybrid),
+  });
+}
+
+void JArrayBuffer::initHybrid(
+    jni::alias_ref<jhybridobject> jobj,
+    jni::alias_ref<jni::JByteBuffer> buffer,
+    jboolean owningBytes) {
+  setCxxInstance(
+      jobj,
+      std::make_shared<JByteBufferMutableBuffer>(buffer),
+      owningBytes != JNI_FALSE);
+}
+
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::create(
+    jni::local_ref<jni::JByteBuffer> byteBuffer,
+    std::shared_ptr<jsi::MutableBuffer> buffer,
+    bool owningBytes) {
+  auto cxxPart = std::make_unique<JArrayBuffer>(std::move(buffer), owningBytes);
+  auto javaPart = newObjectJavaArgs(byteBuffer, owningBytes);
+  setNativePointer(javaPart, std::move(cxxPart));
+  return javaPart;
+}
+
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwning(
+    std::shared_ptr<jsi::MutableBuffer> buffer) {
+  // NewDirectByteBuffer rejects a null address, which is what an empty
+  // jsi::ArrayBuffer reports, so empty buffers get an allocation of their own.
+  if (buffer->size() == 0) {
+    return create(jni::JByteBuffer::allocateDirect(0), std::move(buffer), true);
+  }
+
+  auto byteBuffer = jni::JByteBuffer::wrapBytes(buffer->data(), buffer->size());
+  return create(std::move(byteBuffer), std::move(buffer), true);
+}
+
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createUnowned(
+    void* bytes,
+    size_t size) {
+  // NewDirectByteBuffer rejects a null address, which is what an empty
+  // jsi::ArrayBuffer reports, so empty buffers get an allocation of their own.
+  auto byteBuffer = size == 0
+      ? jni::JByteBuffer::allocateDirect(0)
+      : jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(bytes), size);
+  auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
+  return create(std::move(byteBuffer), std::move(buffer), false);
+}
+
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwned(
+    const void* bytes,
+    size_t size) {
+  auto byteBuffer = jni::JByteBuffer::allocateDirect(static_cast<jint>(size));
+  if (size > 0 && bytes != nullptr) {
+    // @lint-ignore CLANGSECURITY facebook-security-vulnerable-memcpy
+    std::memcpy(byteBuffer->getDirectBytes(), bytes, size);
+  }
+
+  auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
+  return create(std::move(byteBuffer), std::move(buffer), true);
+}
+
+std::shared_ptr<jsi::MutableBuffer> JArrayBuffer::toJSBuffer(
+    jni::alias_ref<javaobject> arrayBuffer) {
+  auto* self = arrayBuffer->cthis();
+  if (self->owningBytes_) {
+    return self->buffer_;
+  }
+
+  // Borrowed bytes still belong to the inbound JS ArrayBuffer; copy them before
+  // handing a new buffer back to JS.
+  auto bytes = std::span<uint8_t>(self->buffer_->data(), self->buffer_->size());
+  return std::make_shared<OwnedBytesBuffer>(
+      std::vector<uint8_t>(bytes.begin(), bytes.end()));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
@@ -9,8 +9,11 @@
 
 #include <cstring>
 #include <span>
+#include <stdexcept>
 #include <utility>
 #include <vector>
+
+#include <react/bridging/ArrayBuffer.h>
 
 #include "JByteBufferMutableBuffer.h"
 
@@ -18,29 +21,17 @@ namespace facebook::react {
 
 namespace {
 
-// Holds a copy of bytes borrowed from a JS ArrayBuffer.
-class OwnedBytesBuffer final : public jsi::MutableBuffer {
- public:
-  explicit OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept
-      : bytes_(std::move(bytes)) {}
-
-  size_t size() const override {
-    return bytes_.size();
-  }
-
-  uint8_t* data() override {
-    return bytes_.data();
-  }
-
- private:
-  std::vector<uint8_t> bytes_;
-};
+const char* const kRevokedBorrowMessage =
+    "com.facebook.react.bridge.ArrayBuffer: the bytes of a non-owning ArrayBuffer "
+    "were accessed after the method that received it returned. Copy them with "
+    "ArrayBuffer.arrayBufferWithCopiedBytes() to use them later.";
 
 } // namespace
 
 void JArrayBuffer::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JArrayBuffer::initHybrid),
+      makeNativeMethod("isBytesValid", JArrayBuffer::isBytesValid),
   });
 }
 
@@ -52,6 +43,23 @@ void JArrayBuffer::initHybrid(
       jobj,
       std::make_shared<JByteBufferMutableBuffer>(buffer),
       owningBytes != JNI_FALSE);
+}
+
+jboolean JArrayBuffer::isBytesValid() {
+  return hasBytes() ? JNI_TRUE : JNI_FALSE;
+}
+
+void JArrayBuffer::invalidate() noexcept {
+  if (!owningBytes_) {
+    buffer_.reset();
+  }
+}
+
+const std::shared_ptr<jsi::MutableBuffer>& JArrayBuffer::mutableBuffer() const {
+  if (!hasBytes()) {
+    throw std::runtime_error(kRevokedBorrowMessage);
+  }
+  return buffer_;
 }
 
 jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::create(
@@ -66,12 +74,6 @@ jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::create(
 
 jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwning(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
-  // NewDirectByteBuffer rejects a null address, which is what an empty
-  // jsi::ArrayBuffer reports, so empty buffers get an allocation of their own.
-  if (buffer->size() == 0) {
-    return create(jni::JByteBuffer::allocateDirect(0), std::move(buffer), true);
-  }
-
   auto byteBuffer = jni::JByteBuffer::wrapBytes(buffer->data(), buffer->size());
   return create(std::move(byteBuffer), std::move(buffer), true);
 }
@@ -79,11 +81,8 @@ jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwning(
 jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createUnowned(
     void* bytes,
     size_t size) {
-  // NewDirectByteBuffer rejects a null address, which is what an empty
-  // jsi::ArrayBuffer reports, so empty buffers get an allocation of their own.
-  auto byteBuffer = size == 0
-      ? jni::JByteBuffer::allocateDirect(0)
-      : jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(bytes), size);
+  auto byteBuffer =
+      jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(bytes), size);
   auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
   return create(std::move(byteBuffer), std::move(buffer), false);
 }
@@ -102,16 +101,28 @@ jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwned(
 }
 
 std::shared_ptr<jsi::MutableBuffer> JArrayBuffer::toJSBuffer(
+    jsi::Runtime& runtime,
     jni::alias_ref<javaobject> arrayBuffer) {
   auto* self = arrayBuffer->cthis();
+  // create() runs the Kotlin constructor before setNativePointer, so a Java
+  // ArrayBuffer without a C++ peer is reachable if either step throws.
+  if (self == nullptr) {
+    throw jsi::JSError(
+        runtime, "com.facebook.react.bridge.ArrayBuffer has no native peer.");
+  }
+  if (!self->hasBytes()) {
+    throw jsi::JSError(runtime, kRevokedBorrowMessage);
+  }
+
+  const auto& buffer = self->mutableBuffer();
   if (self->owningBytes_) {
-    return self->buffer_;
+    return buffer;
   }
 
   // Borrowed bytes still belong to the inbound JS ArrayBuffer; copy them before
   // handing a new buffer back to JS.
-  auto bytes = std::span<uint8_t>(self->buffer_->data(), self->buffer_->size());
-  return std::make_shared<OwnedBytesBuffer>(
+  auto bytes = std::span<uint8_t>(buffer->data(), buffer->size());
+  return std::make_shared<detail::OwnedBytesBuffer>(
       std::vector<uint8_t>(bytes.begin(), bytes.end()));
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include <fbjni/ByteBuffer.h>
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+// JNI side of com.facebook.react.bridge.ArrayBuffer.
+//
+// When owningBytes_ is true, the module may retain the buffer and return it to
+// JS without copying. When false, the bytes were borrowed from a JS-heap
+// ArrayBuffer for a synchronous call only.
+class JArrayBuffer : public jni::HybridClass<JArrayBuffer> {
+ public:
+  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/bridge/ArrayBuffer;";
+
+  static void registerNatives();
+
+  // JS ArrayBuffer with a native MutableBuffer (tryGetMutableBuffer). Retain
+  // the owner so the bytes stay valid after the call.
+  static jni::local_ref<javaobject> createOwning(std::shared_ptr<jsi::MutableBuffer> buffer);
+
+  // JS-heap bytes passed to a synchronous call. Zero-copy for the call only;
+  // do not retain the result.
+  static jni::local_ref<javaobject> createUnowned(void *bytes, size_t size);
+
+  // Copy JS-heap bytes into a new owned buffer. Used for async/promise calls
+  // and anywhere the module needs its own copy of the data.
+  static jni::local_ref<javaobject> createOwned(const void *bytes, size_t size);
+
+  // Convert a module return value for rt.createArrayBuffer. Owning buffers pass
+  // through; borrowed ones are copied because createArrayBuffer needs its own
+  // backing store.
+  static std::shared_ptr<jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+
+  JArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer, bool owningBytes) noexcept
+      : buffer_(std::move(buffer)), owningBytes_(owningBytes)
+  {
+  }
+
+ private:
+  friend HybridBase;
+
+  static void
+  initHybrid(jni::alias_ref<jhybridobject> jobj, jni::alias_ref<jni::JByteBuffer> buffer, jboolean owningBytes);
+
+  static jni::local_ref<javaobject>
+  create(jni::local_ref<jni::JByteBuffer> byteBuffer, std::shared_ptr<jsi::MutableBuffer> buffer, bool owningBytes);
+
+  std::shared_ptr<jsi::MutableBuffer> buffer_;
+  bool owningBytes_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
@@ -40,8 +40,31 @@ class JArrayBuffer : public jni::HybridClass<JArrayBuffer> {
 
   // Convert a module return value for rt.createArrayBuffer. Owning buffers pass
   // through; borrowed ones are copied because createArrayBuffer needs its own
-  // backing store.
-  static std::shared_ptr<jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  // backing store. Raises a jsi::JSError if the buffer has no native peer or
+  // its borrow has been revoked.
+  static std::shared_ptr<jsi::MutableBuffer> toJSBuffer(jsi::Runtime &runtime, jni::alias_ref<javaobject> arrayBuffer);
+
+  // Revokes access to borrowed bytes. Called when the call frame that lent the
+  // bytes unwinds, so a module that retained a non-owning ArrayBuffer gets an
+  // exception instead of reading memory the JS heap has moved or freed. Owning
+  // buffers are unaffected.
+  void invalidate() noexcept;
+
+  // The bytes this buffer was created over. Throws if a borrow has since been
+  // revoked by invalidate().
+  const std::shared_ptr<jsi::MutableBuffer> &mutableBuffer() const;
+
+  // Whether the bytes are still reachable, i.e. this is an owning buffer or a
+  // borrow that invalidate() has not revoked.
+  bool hasBytes() const noexcept
+  {
+    return buffer_ != nullptr;
+  }
+
+  bool isOwningBytes() const noexcept
+  {
+    return owningBytes_;
+  }
 
   JArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer, bool owningBytes) noexcept
       : buffer_(std::move(buffer)), owningBytes_(owningBytes)
@@ -53,6 +76,8 @@ class JArrayBuffer : public jni::HybridClass<JArrayBuffer> {
 
   static void
   initHybrid(jni::alias_ref<jhybridobject> jobj, jni::alias_ref<jni::JByteBuffer> buffer, jboolean owningBytes);
+
+  jboolean isBytesValid();
 
   static jni::local_ref<javaobject>
   create(jni::local_ref<jni::JByteBuffer> byteBuffer, std::shared_ptr<jsi::MutableBuffer> buffer, bool owningBytes);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JByteBufferMutableBuffer.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JByteBufferMutableBuffer.h
@@ -45,6 +45,12 @@ class JByteBufferMutableBuffer final : public jsi::MutableBuffer {
   }
   uint8_t *data() override
   {
+    // GetDirectBufferAddress may report null for a zero-capacity direct buffer,
+    // which getDirectBytes turns into an exception. An empty buffer has no bytes
+    // to address, so report that directly instead.
+    if (byteBuffer_->getDirectSize() == 0) {
+      return nullptr;
+    }
     return byteBuffer_->getDirectBytes();
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <fbjni/fbjni.h>
+#include "JArrayBuffer.h"
 #include "JCallback.h"
 #include "JDynamicNative.h"
 #include "JReactMarker.h"
@@ -18,6 +19,7 @@ namespace facebook::react {
 
 extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   return facebook::jni::initialize(vm, [] {
+    JArrayBuffer::registerNatives();
     JCxxCallbackImpl::registerNatives();
     JDynamicNative::registerNatives();
     JReactMarker::registerNatives();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/test/JArrayBufferTest.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/test/JArrayBufferTest.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/jni/JArrayBuffer.h>
+#include <react/jni/JByteBufferMutableBuffer.h>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+namespace facebook::react {
+
+namespace {
+
+class TestBuffer final : public jsi::MutableBuffer {
+ public:
+  explicit TestBuffer(std::vector<uint8_t> bytes) noexcept
+      : bytes_(std::move(bytes)) {}
+
+  size_t size() const override {
+    return bytes_.size();
+  }
+
+  uint8_t* data() override {
+    return bytes_.data();
+  }
+
+ private:
+  std::vector<uint8_t> bytes_;
+};
+
+} // namespace
+
+/*
+ * The static factories and toJSBuffer all need a live JavaVM, so the coverage
+ * available host-side is the ownership state machine itself: which buffers
+ * invalidate() may revoke, and whether mutableBuffer() reports a revoked borrow
+ * instead of handing out a dangling pointer. The JNI section at the bottom of
+ * this file covers the direct-ByteBuffer adapter on device.
+ */
+
+TEST(JArrayBufferTest, owningBufferExposesItsBytes) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  JArrayBuffer arrayBuffer{buffer, true};
+
+  EXPECT_TRUE(arrayBuffer.isOwningBytes());
+  EXPECT_EQ(arrayBuffer.mutableBuffer(), buffer);
+}
+
+TEST(JArrayBufferTest, borrowedBufferExposesItsBytesBeforeInvalidation) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  JArrayBuffer arrayBuffer{buffer, false};
+
+  EXPECT_FALSE(arrayBuffer.isOwningBytes());
+  EXPECT_EQ(arrayBuffer.mutableBuffer(), buffer);
+}
+
+/*
+ * Bug this catches: without the revocation, a module that stored a non-owning
+ * ArrayBuffer keeps a direct ByteBuffer over JS-heap bytes that the call frame
+ * no longer keeps alive, and every later read silently returns whatever now
+ * occupies that memory.
+ */
+TEST(JArrayBufferTest, invalidateRevokesABorrow) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  JArrayBuffer arrayBuffer{buffer, false};
+
+  arrayBuffer.invalidate();
+
+  EXPECT_THROW(arrayBuffer.mutableBuffer(), std::runtime_error);
+}
+
+TEST(JArrayBufferTest, invalidateLeavesAnOwningBufferUsable) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  JArrayBuffer arrayBuffer{buffer, true};
+
+  arrayBuffer.invalidate();
+
+  EXPECT_EQ(arrayBuffer.mutableBuffer(), buffer);
+}
+
+TEST(JArrayBufferTest, invalidateIsIdempotent) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  JArrayBuffer arrayBuffer{buffer, false};
+
+  arrayBuffer.invalidate();
+  arrayBuffer.invalidate();
+
+  EXPECT_THROW(arrayBuffer.mutableBuffer(), std::runtime_error);
+}
+
+// Revoking a borrow must drop the last reference this object holds, so an
+// aliasing adapter (and the JNI global ref inside it) is torn down with the
+// call frame rather than at the whim of the Java GC.
+TEST(JArrayBufferTest, invalidateReleasesTheBorrowedBuffer) {
+  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  std::weak_ptr<jsi::MutableBuffer> weakBuffer = buffer;
+  JArrayBuffer arrayBuffer{std::move(buffer), false};
+
+  arrayBuffer.invalidate();
+
+  EXPECT_TRUE(weakBuffer.expired());
+}
+
+#ifdef __ANDROID__
+
+/*
+ * JByteBufferMutableBuffer is the adapter every ArrayBuffer is built on, and it
+ * is pure JNI: size() and data() read a direct java.nio.ByteBuffer. That needs
+ * a live JavaVM, so it is only reachable in the on-device variant of this
+ * target.
+ *
+ * The Kotlin peer itself is not testable here — this APK carries no RN Java
+ * classes — so ArrayBuffer.kt stays covered by the Robolectric test.
+ */
+
+TEST(JByteBufferMutableBufferTest, exposesTheAddressAndSizeOfADirectBuffer) {
+  auto byteBuffer = jni::JByteBuffer::allocateDirect(4);
+  auto* bytes = byteBuffer->getDirectBytes();
+  const uint8_t expected[] = {1, 2, 3, 4};
+  std::memcpy(bytes, expected, sizeof(expected));
+
+  JByteBufferMutableBuffer buffer{byteBuffer};
+
+  EXPECT_EQ(buffer.size(), sizeof(expected));
+  EXPECT_EQ(buffer.data(), bytes);
+  EXPECT_EQ(std::memcmp(buffer.data(), expected, sizeof(expected)), 0);
+}
+
+TEST(JByteBufferMutableBufferTest, aliasesWrappedBytesWithoutCopying) {
+  uint8_t bytes[] = {1, 2, 3, 4};
+  auto byteBuffer = jni::JByteBuffer::wrapBytes(bytes, sizeof(bytes));
+
+  JByteBufferMutableBuffer buffer{byteBuffer};
+
+  EXPECT_EQ(buffer.data(), bytes);
+  EXPECT_EQ(buffer.size(), sizeof(bytes));
+}
+
+/*
+ * Bug this catches: GetDirectBufferAddress reports null for a zero-capacity
+ * direct buffer, and getDirectBytes turns that into a JNI exception. Without
+ * the short-circuit in data(), a zero-length ArrayBuffer — which JS can hand a
+ * TurboModule at any time — throws out of a path that has no business failing.
+ */
+TEST(JByteBufferMutableBufferTest, reportsNoDataForAnEmptyBuffer) {
+  auto byteBuffer = jni::JByteBuffer::allocateDirect(0);
+
+  JByteBufferMutableBuffer buffer{byteBuffer};
+
+  EXPECT_EQ(buffer.size(), 0u);
+  EXPECT_EQ(buffer.data(), nullptr);
+}
+
+#endif // __ANDROID__
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ArrayBufferTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ArrayBufferTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import com.facebook.testutils.shadows.ShadowArrayBuffer
+import com.facebook.testutils.shadows.ShadowNativeLoader
+import com.facebook.testutils.shadows.ShadowSoLoader
+import java.nio.ByteBuffer
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(
+    shadows = [ShadowSoLoader::class, ShadowNativeLoader::class, ShadowArrayBuffer::class],
+)
+class ArrayBufferTest {
+
+  @Test
+  fun constructorAllocatesZeroFilledBytes() {
+    val buffer = ArrayBuffer(4)
+
+    assertThat(buffer.size).isEqualTo(4)
+    assertThat(buffer.bytes.isDirect).isTrue()
+    assertThat(bytesOf(buffer)).containsExactly(0, 0, 0, 0)
+    assertThat(buffer.isOwningBytes).isTrue()
+  }
+
+  @Test
+  fun constructorAcceptsZeroLength() {
+    val buffer = ArrayBuffer(0)
+
+    assertThat(buffer.size).isEqualTo(0)
+    assertThat(buffer.bytes.capacity()).isEqualTo(0)
+  }
+
+  @Test
+  fun constructorRejectsNegativeSize() {
+    assertThatThrownBy { ArrayBuffer(-1) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("must not be negative")
+  }
+
+  @Test
+  fun arrayBufferWithLengthMatchesConstructor() {
+    val buffer = ArrayBuffer.arrayBufferWithLength(3)
+
+    assertThat(buffer.size).isEqualTo(3)
+    assertThat(buffer.isOwningBytes).isTrue()
+  }
+
+  @Test
+  fun sizeIsCapacityAndIgnoresPositionAndLimit() {
+    val buffer = ArrayBuffer(4)
+    buffer.bytes.position(1)
+    buffer.bytes.limit(2)
+
+    assertThat(buffer.size).isEqualTo(4)
+  }
+
+  @Test
+  fun bytesReturnsTheSameSharedBuffer() {
+    val buffer = ArrayBuffer(2)
+
+    assertThat(buffer.bytes).isSameAs(buffer.bytes)
+  }
+
+  @Test
+  fun copiesByteArray() {
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(byteArrayOf(1, 2, 3))
+
+    assertThat(buffer.size).isEqualTo(3)
+    assertThat(bytesOf(buffer)).containsExactly(1, 2, 3)
+    assertThat(buffer.isOwningBytes).isTrue()
+  }
+
+  @Test
+  fun copiesEmptyByteArray() {
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(ByteArray(0))
+
+    assertThat(buffer.size).isEqualTo(0)
+  }
+
+  @Test
+  fun copiesRemainingBytesOfByteBuffer() {
+    val source = ByteBuffer.allocateDirect(5)
+    source.put(byteArrayOf(1, 2, 3, 4, 5))
+    source.position(1)
+    source.limit(4)
+
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(source)
+
+    assertThat(buffer.size).isEqualTo(3)
+    assertThat(bytesOf(buffer)).containsExactly(2, 3, 4)
+    // The source position and limit are left untouched.
+    assertThat(source.position()).isEqualTo(1)
+    assertThat(source.limit()).isEqualTo(4)
+  }
+
+  @Test
+  fun copiesFromNonDirectByteBuffer() {
+    val source = ByteBuffer.wrap(byteArrayOf(7, 8))
+
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(source)
+
+    assertThat(bytesOf(buffer)).containsExactly(7, 8)
+    assertThat(buffer.bytes.isDirect).isTrue()
+  }
+
+  @Test
+  fun copiesAllBytesOfArrayBufferRegardlessOfPositionAndLimit() {
+    val source = ArrayBuffer.arrayBufferWithCopiedBytes(byteArrayOf(1, 2, 3, 4))
+    source.bytes.position(2)
+    source.bytes.limit(3)
+
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(source)
+
+    assertThat(buffer.size).isEqualTo(4)
+    assertThat(bytesOf(buffer)).containsExactly(1, 2, 3, 4)
+  }
+
+  @Test
+  fun copyOfArrayBufferDoesNotAliasTheSource() {
+    val source = ArrayBuffer.arrayBufferWithCopiedBytes(byteArrayOf(1, 2))
+
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(source)
+    source.bytes.put(0, 9)
+
+    assertThat(bytesOf(buffer)).containsExactly(1, 2)
+  }
+
+  @Test
+  fun copiesZeroLengthArrayBuffer() {
+    val buffer = ArrayBuffer.arrayBufferWithCopiedBytes(ArrayBuffer(0))
+
+    assertThat(buffer.size).isEqualTo(0)
+  }
+
+  @Test
+  fun aliasesOwnedDirectByteBuffer() {
+    val source = ByteBuffer.allocateDirect(2)
+    source.put(byteArrayOf(1, 2))
+
+    val buffer = ArrayBuffer.arrayBufferWithOwnedBytes(source)
+    source.put(0, 9)
+
+    assertThat(buffer.bytes).isSameAs(source)
+    assertThat(buffer.bytes.get(0)).isEqualTo(9.toByte())
+    assertThat(buffer.isOwningBytes).isTrue()
+  }
+
+  @Test
+  fun arrayBufferWithOwnedBytesRejectsNonDirectByteBuffer() {
+    assertThatThrownBy {
+          ArrayBuffer.arrayBufferWithOwnedBytes(ByteBuffer.wrap(byteArrayOf(1, 2)))
+        }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessageContaining("requires a direct ByteBuffer")
+  }
+
+  /**
+   * Once the native peer revokes a borrow — which it does when the method that received a
+   * non-owning [ArrayBuffer] returns — reading the bytes must fail loudly instead of touching freed
+   * memory.
+   */
+  @Test
+  fun accessingBytesAfterTheBorrowIsRevokedThrows() {
+    val buffer = ArrayBuffer(4)
+    ShadowArrayBuffer.invalidate(buffer)
+
+    assertThatThrownBy { buffer.bytes }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessageContaining("non-owning ArrayBuffer")
+    assertThatThrownBy { buffer.size }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessageContaining("non-owning ArrayBuffer")
+  }
+
+  private fun bytesOf(buffer: ArrayBuffer): ByteArray {
+    val view = buffer.bytes.duplicate()
+    view.position(0)
+    view.limit(buffer.size)
+    val bytes = ByteArray(view.remaining())
+    view.get(bytes)
+    return bytes
+  }
+}

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArrayBuffer.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArrayBuffer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.testutils.shadows
+
+import com.facebook.react.bridge.ArrayBuffer
+import java.nio.ByteBuffer
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadow.api.Shadow
+
+/**
+ * Stands in for the C++ peer of [ArrayBuffer], which Robolectric cannot load. Tracks the
+ * borrow-validity flag the peer owns so the Kotlin-side ownership contract can be tested.
+ */
+@Implements(ArrayBuffer::class)
+open class ShadowArrayBuffer {
+
+  private var bytesValid = true
+
+  // The parameters are unused but must stay: Robolectric matches a shadow method to the native one
+  // by signature.
+  @Suppress("UNUSED_PARAMETER")
+  @Implementation
+  fun initHybrid(buffer: ByteBuffer, isOwningBytes: Boolean) = Unit
+
+  @Implementation fun isBytesValid(): Boolean = bytesValid
+
+  companion object {
+    /** Simulates the native peer revoking a borrow when the call frame that lent the bytes ends. */
+    @JvmStatic
+    fun invalidate(arrayBuffer: ArrayBuffer) {
+      (Shadow.extract(arrayBuffer) as ShadowArrayBuffer).bytesValid = false
+    }
+  }
+}

--- a/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.h
+++ b/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.h
@@ -140,15 +140,6 @@ class AsyncArrayBuffer {
     return buffer_;
   }
 
- private:
-  explicit AsyncArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer) noexcept : buffer_{std::move(buffer)} {}
-
-  static AsyncArrayBuffer copyBytes(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
-  {
-    auto bytes = std::span(buffer.data(rt), buffer.size(rt));
-    return wrap(std::vector<uint8_t>(bytes.begin(), bytes.end()));
-  }
-
   // Best-effort detached check. jsi::ArrayBuffer::detached relies on the JS-level
   // `detached` property, which some runtimes (e.g. Hermes) don't implement and
   // signal by throwing. In that case we silently skip the check rather than
@@ -164,6 +155,15 @@ class AsyncArrayBuffer {
     if (detached) {
       throw jsi::JSError(rt, std::string(callerName) + ": ArrayBuffer is detached");
     }
+  }
+
+ private:
+  explicit AsyncArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer) noexcept : buffer_{std::move(buffer)} {}
+
+  static AsyncArrayBuffer copyBytes(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
+  {
+    auto bytes = std::span(buffer.data(rt), buffer.size(rt));
+    return wrap(std::vector<uint8_t>(bytes.begin(), bytes.end()));
   }
 
   std::shared_ptr<jsi::MutableBuffer> buffer_;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -63,6 +63,12 @@ JavaTurboModule::~JavaTurboModule() {
 
 namespace {
 
+// A method whose result is delivered synchronously, so JS-heap bytes passed as
+// arguments stay valid for the duration of the call.
+bool isSyncMethod(TurboModuleMethodValueKind valueKind) {
+  return valueKind != VoidKind && valueKind != PromiseKind;
+}
+
 struct JNIArgs {
   JNIArgs(size_t count) : args(count) {}
   JNIArgs(const JNIArgs&) = delete;
@@ -73,8 +79,19 @@ struct JNIArgs {
 
   std::vector<jvalue> args;
   std::vector<jobject> globalRefs;
+  // ArrayBuffers aliasing JS-heap bytes lent for this call only. Local refs are
+  // enough because bytes are only lent on the synchronous path, where this
+  // JNIArgs is destroyed in the same native frame that created the refs.
+  std::vector<jni::local_ref<JArrayBuffer::javaobject>> borrowedBuffers;
 
   ~JNIArgs() {
+    // Revoke the borrows before the call frame that lent the bytes unwinds, so
+    // a module that retained one cannot read freed or relocated memory. Runs on
+    // the throw path too.
+    for (auto& borrowedBuffer : borrowedBuffers) {
+      borrowedBuffer->cthis()->invalidate();
+    }
+
     JNIEnv* env = jni::Environment::current();
     for (auto globalRef : globalRefs) {
       env->DeleteGlobalRef(globalRef);
@@ -315,10 +332,10 @@ JNIArgs convertJSIArgsToJNIArgs(
   auto& jargs = jniArgs.args;
   auto& globalRefs = jniArgs.globalRefs;
 
-  auto isSyncInvocation = valueKind != VoidKind && valueKind != PromiseKind;
+  auto isSyncInvocation = isSyncMethod(valueKind);
 
   auto makeGlobalIfNecessary = [&](jobject obj) {
-    if (valueKind == VoidKind || valueKind == PromiseKind) {
+    if (!isSyncInvocation) {
       jobject globalObj = env->NewGlobalRef(obj);
       globalRefs.push_back(globalObj);
       env->DeleteLocalRef(obj);
@@ -449,11 +466,8 @@ JNIArgs convertJSIArgsToJNIArgs(
       }
 
       auto arrayBuffer = arg->getObject(rt).getArrayBuffer(rt);
-      if (arrayBuffer.detached(rt)) {
-        throw jsi::JSError(
-            rt,
-            "JavaTurboModule::convertJSIArgsToJNIArgs: ArrayBuffer is detached.");
-      }
+      AsyncArrayBuffer::throwIfDetached(
+          rt, arrayBuffer, "JavaTurboModule::convertJSIArgsToJNIArgs");
 
       auto size = arrayBuffer.size(rt);
       if (size > static_cast<size_t>(std::numeric_limits<jint>::max())) {
@@ -462,22 +476,40 @@ JNIArgs convertJSIArgsToJNIArgs(
             "JavaTurboModule::convertJSIArgsToJNIArgs: ArrayBuffer exceeds maximum size.");
       }
 
+      // Runtimes without a native buffer for this ArrayBuffer return nullptr,
+      // but the Static Hermes tracing runtime throws instead, and argument
+      // conversion runs outside any std::exception handler. Treat a failed
+      // probe as "no native buffer" so a traced session copies the bytes rather
+      // than aborting the process.
+      std::shared_ptr<jsi::MutableBuffer> mutableBuffer;
+      try {
+        mutableBuffer = arrayBuffer.tryGetMutableBuffer(rt);
+      } catch (const std::exception&) {
+        mutableBuffer = nullptr;
+      }
+
+      bool borrowsJSBytes = false;
       auto jArrayBuffer = [&]() {
         // Backed by a native buffer: alias it and retain its owner, so the
         // bytes stay valid for as long as the module holds the ArrayBuffer.
-        if (auto mutableBuffer = arrayBuffer.tryGetMutableBuffer(rt)) {
+        if (mutableBuffer) {
           return JArrayBuffer::createOwning(std::move(mutableBuffer));
         }
 
         // JS heap bytes on a synchronous call: lend them for the duration of
         // the call.
         if (isSyncInvocation) {
+          borrowsJSBytes = true;
           return JArrayBuffer::createUnowned(arrayBuffer.data(rt), size);
         }
 
         // JS heap bytes that outlive the call: copy.
         return JArrayBuffer::createOwned(arrayBuffer.data(rt), size);
       }();
+
+      if (borrowsJSBytes) {
+        jniArgs.borrowedBuffers.push_back(jni::make_local(jArrayBuffer));
+      }
       jarg->l = makeGlobalIfNecessary(jArrayBuffer.release());
     } else {
       throw JavaTurboModuleInvalidArgumentTypeException(
@@ -567,7 +599,7 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
   const char* methodName = methodNameStr.c_str();
   const char* moduleName = name_.c_str();
 
-  bool isMethodSync = valueKind != VoidKind && valueKind != PromiseKind;
+  bool isMethodSync = isSyncMethod(valueKind);
 
   if (isMethodSync) {
     TMPL::syncMethodCallStart(moduleName, methodName);
@@ -1021,11 +1053,20 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
 
       jsi::Value returnValue = jsi::Value::null();
       if (returnObject != nullptr) {
-        auto jArrayBuffer = jni::adopt_local(
-            static_cast<JArrayBuffer::javaobject>(returnObject));
+        auto returnRef = jni::adopt_local(returnObject);
+        if (!returnRef->isInstanceOf(JArrayBuffer::javaClassStatic())) {
+          throw jsi::JSError(
+              runtime,
+              "JavaTurboModule::invokeJavaMethod: expected " + methodNameStr +
+                  " to return a com.facebook.react.bridge.ArrayBuffer.");
+        }
+
+        auto jArrayBuffer =
+            jni::static_ref_cast<JArrayBuffer::javaobject>(returnRef);
         returnValue = {
             runtime,
-            jsi::ArrayBuffer{runtime, JArrayBuffer::toJSBuffer(jArrayBuffer)}};
+            jsi::ArrayBuffer{
+                runtime, JArrayBuffer::toJSBuffer(runtime, jArrayBuffer)}};
       }
 
       TMPL::syncMethodCallReturnConversionEnd(moduleName, methodName);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -23,7 +23,7 @@
 #include <react/bridging/Bridging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
-#include <react/jni/JByteBufferMutableBuffer.h>
+#include <react/jni/JArrayBuffer.h>
 #include <react/jni/JDynamicNative.h>
 #include <react/jni/NativeMap.h>
 #include <react/jni/ReadableNativeMap.h>
@@ -315,6 +315,8 @@ JNIArgs convertJSIArgsToJNIArgs(
   auto& jargs = jniArgs.args;
   auto& globalRefs = jniArgs.globalRefs;
 
+  auto isSyncInvocation = valueKind != VoidKind && valueKind != PromiseKind;
+
   auto makeGlobalIfNecessary = [&](jobject obj) {
     if (valueKind == VoidKind || valueKind == PromiseKind) {
       jobject globalObj = env->NewGlobalRef(obj);
@@ -440,7 +442,7 @@ JNIArgs convertJSIArgsToJNIArgs(
       auto dynamicFromValue = jsi::dynamicFromValue(rt, *arg);
       auto jParams = JDynamicNative::newObjectCxxArgs(dynamicFromValue);
       jarg->l = makeGlobalIfNecessary(jParams.release());
-    } else if (type == "Ljava/nio/ByteBuffer;") {
+    } else if (type == "Lcom/facebook/react/bridge/ArrayBuffer;") {
       if (!(arg->isObject() && arg->getObject(rt).isArrayBuffer(rt))) {
         throw JavaTurboModuleArgumentConversionException(
             "ArrayBuffer", argIndex, methodName, arg, &rt);
@@ -459,18 +461,24 @@ JNIArgs convertJSIArgsToJNIArgs(
             rt,
             "JavaTurboModule::convertJSIArgsToJNIArgs: ArrayBuffer exceeds maximum size.");
       }
-      auto data = arrayBuffer.data(rt);
-      // ArrayBuffer arguments are always copied into a Java-owned direct
-      // ByteBuffer, so Java fully owns the bytes. Borrowing the JS bytes is
-      // never safe — even on a synchronous call the module may retain the
-      // buffer or hand it to an async method, and JS may garbage-collect the
-      // source ArrayBuffer, leaving Java with a dangling view.
-      auto buffer = jni::JByteBuffer::allocateDirect(static_cast<jint>(size));
-      if (size > 0) {
-        // @lint-ignore CLANGSECURITY facebook-security-vulnerable-memcpy
-        std::memcpy(buffer->getDirectBytes(), data, size);
-      }
-      jarg->l = makeGlobalIfNecessary(buffer.release());
+
+      auto jArrayBuffer = [&]() {
+        // Backed by a native buffer: alias it and retain its owner, so the
+        // bytes stay valid for as long as the module holds the ArrayBuffer.
+        if (auto mutableBuffer = arrayBuffer.tryGetMutableBuffer(rt)) {
+          return JArrayBuffer::createOwning(std::move(mutableBuffer));
+        }
+
+        // JS heap bytes on a synchronous call: lend them for the duration of
+        // the call.
+        if (isSyncInvocation) {
+          return JArrayBuffer::createUnowned(arrayBuffer.data(rt), size);
+        }
+
+        // JS heap bytes that outlive the call: copy.
+        return JArrayBuffer::createOwned(arrayBuffer.data(rt), size);
+      }();
+      jarg->l = makeGlobalIfNecessary(jArrayBuffer.release());
     } else {
       throw JavaTurboModuleInvalidArgumentTypeException(
           type, argIndex, methodName);
@@ -1013,22 +1021,11 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
 
       jsi::Value returnValue = jsi::Value::null();
       if (returnObject != nullptr) {
-        auto jByteBuffer = jni::adopt_local(
-            static_cast<jni::JByteBuffer::javaobject>(returnObject));
-
-        if (!jByteBuffer->isDirect()) {
-          throw jsi::JSError(
-              runtime,
-              "Only direct ByteBuffers (ByteBuffer.allocateDirect) can be returned from a TurboModule.");
-        }
-        // Zero-copy: JByteBufferMutableBuffer takes a global reference that
-        // pins the ByteBuffer's memory for the lifetime of the JS ArrayBuffer,
-        // and its destructor attaches the current thread before releasing that
-        // ref, so JS GC finalization on any thread is safe.
-        auto nativeBuffer =
-            std::make_shared<JByteBufferMutableBuffer>(jByteBuffer);
+        auto jArrayBuffer = jni::adopt_local(
+            static_cast<JArrayBuffer::javaobject>(returnObject));
         returnValue = {
-            runtime, jsi::ArrayBuffer{runtime, std::move(nativeBuffer)}};
+            runtime,
+            jsi::ArrayBuffer{runtime, JArrayBuffer::toJSBuffer(jArrayBuffer)}};
       }
 
       TMPL::syncMethodCallReturnConversionEnd(moduleName, methodName);

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.kt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.kt
@@ -15,6 +15,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ArrayBuffer
 import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
@@ -27,7 +28,6 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder
 import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings
-import java.nio.ByteBuffer
 import java.util.UUID
 
 @DoNotStrip
@@ -155,28 +155,35 @@ public class SampleTurboModule(private val context: ReactApplicationContext) :
     return map
   }
 
+  // Mutating the argument updates the JS ArrayBuffer in place.
   @DoNotStrip
   @Suppress("unused")
-  override fun getArrayBuffer(buffer: ByteBuffer?): ByteBuffer? {
+  override fun getArrayBuffer(buffer: ArrayBuffer?): ArrayBuffer? {
+    if (buffer != null) {
+      val bytes = buffer.bytes
+      for (i in 0 until bytes.capacity()) {
+        bytes.put(i, (bytes.get(i) * 2).toByte())
+      }
+    }
     log("getArrayBuffer", buffer, buffer)
     return buffer
   }
 
   @DoNotStrip
   @Suppress("unused")
-  override fun createNativeBuffer(size: Double): ByteBuffer {
+  override fun createNativeBuffer(size: Double): ArrayBuffer {
     require(size.isFinite() && size >= 0.0 && size <= Int.MAX_VALUE.toDouble()) {
       "createNativeBuffer: size must be a finite value in [0, ${Int.MAX_VALUE}], got $size"
     }
-    val buffer = ByteBuffer.allocateDirect(size.toInt())
+    val buffer = ArrayBuffer(size.toInt())
     log("createNativeBuffer", size, buffer)
     return buffer
   }
 
   @DoNotStrip
   @Suppress("unused")
-  override fun processAsyncBuffer(payload: ByteBuffer?, promise: Promise) {
-    promise.resolve((payload?.capacity() ?: 0).toDouble())
+  override fun processAsyncBuffer(payload: ArrayBuffer?, promise: Promise) {
+    promise.resolve((payload?.size ?: 0).toDouble())
   }
 
   @DoNotStrip

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -114,7 +114,15 @@ class SampleTurboModuleExample extends React.Component<{}, State> {
     getArrayBuffer: () => {
       const input = new Uint8Array([1, 2, 3, 4]);
       const result = NativeSampleTurboModule.getArrayBuffer(input.buffer);
-      return Array.from(new Uint8Array(result));
+      // The native module mutates the bytes in place and returns the same buffer,
+      // but a returned ArrayBuffer is always a new JS object. Whether it aliases
+      // the input bytes depends on whether the platform lent them to native or
+      // copied them.
+      return {
+        bytes: Array.from(new Uint8Array(result)),
+        isSameObject: result === input.buffer,
+        aliasesInput: Array.from(input).toString() === [2, 4, 6, 8].toString(),
+      };
     },
     createNativeBuffer: () =>
       NativeSampleTurboModule.createNativeBuffer(8).byteLength,

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1652,6 +1652,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2794,12 +2795,16 @@ class facebook::react::IntersectionObserverState {
 
 class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
   public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public bool hasBytes() const noexcept;
+  public bool isOwningBytes() const noexcept;
+  public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
   public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
   public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
   public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
-  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
+  public void invalidate() noexcept;
 }
 
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -2792,6 +2792,16 @@ class facebook::react::IntersectionObserverState {
   public static facebook::react::IntersectionObserverState NotIntersecting();
 }
 
+class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
+  public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public static constexpr auto kJavaDescriptor;
+  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static void registerNatives();
+}
+
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {
   public static constexpr auto kJavaDescriptor;
   public ~JBindingsInstaller();

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -1646,6 +1646,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2752,12 +2753,16 @@ class facebook::react::IntersectionObserverState {
 
 class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
   public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public bool hasBytes() const noexcept;
+  public bool isOwningBytes() const noexcept;
+  public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
   public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
   public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
   public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
-  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
+  public void invalidate() noexcept;
 }
 
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -2750,6 +2750,16 @@ class facebook::react::IntersectionObserverState {
   public static facebook::react::IntersectionObserverState NotIntersecting();
 }
 
+class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
+  public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public static constexpr auto kJavaDescriptor;
+  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static void registerNatives();
+}
+
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {
   public static constexpr auto kJavaDescriptor;
   public ~JBindingsInstaller();

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -2789,6 +2789,16 @@ class facebook::react::IntersectionObserverState {
   public static facebook::react::IntersectionObserverState NotIntersecting();
 }
 
+class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
+  public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public static constexpr auto kJavaDescriptor;
+  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static void registerNatives();
+}
+
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {
   public static constexpr auto kJavaDescriptor;
   public ~JBindingsInstaller();

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1650,6 +1650,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2791,12 +2792,16 @@ class facebook::react::IntersectionObserverState {
 
 class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::JArrayBuffer> {
   public JArrayBuffer(std::shared_ptr<facebook::jsi::MutableBuffer> buffer, bool owningBytes) noexcept;
+  public bool hasBytes() const noexcept;
+  public bool isOwningBytes() const noexcept;
+  public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
   public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
   public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
   public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
-  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(jni::alias_ref<javaobject> arrayBuffer);
+  public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
+  public void invalidate() noexcept;
 }
 
 class facebook::react::JBindingsInstaller : public jni::HybridClass<facebook::react::JBindingsInstaller>, public facebook::react::BindingsInstaller {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4244,6 +4244,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -4231,6 +4231,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4242,6 +4242,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -976,6 +976,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -971,6 +971,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -974,6 +974,7 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
+  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;


### PR DESCRIPTION
Summary:

Changelog: [ANDROID][FIXED]  Enforce the ArrayBuffer borrow contract for Java TurboModules

Follow-up hardening for the Android `ArrayBuffer` TurboModule type. Three problems:

**1. Borrowed JS-heap bytes outlived the call that lent them.** For a synchronous
method, `convertJSIArgsToJNIArgs` hands the module a `ByteBuffer` aliasing the JS
`ArrayBuffer`'s bytes without copying. Nothing stopped a module from stashing that
`ArrayBuffer` in a field and reading it later, after the JS heap may have moved,
freed, or reused the memory — a use-after-free that reads as intermittent data
corruption rather than a crash.

The borrow is now explicitly scoped to the call frame. `JNIArgs` records every
borrowed `ArrayBuffer` and revokes it in its destructor — including when the call
throws — via the new `JArrayBuffer::invalidate`, which drops the C++ side's
reference to the bytes. `ArrayBuffer.bytes` and `ArrayBuffer.size` then throw,
with a message pointing at `ArrayBuffer.arrayBufferWithCopiedBytes`, and
`JArrayBuffer::toJSBuffer` throws rather than aliasing revoked memory. Modules
that need the bytes past the call copy them; modules that don't keep the
zero-copy fast path.

Revocation lives entirely on the C++ side: the peer is the single source of
truth, and Kotlin asks it through `isBytesValid`. The destructor runs while the
stack unwinds, possibly with a Java exception pending, so it resolves each peer
pointer at borrow time — the `global_ref` alongside it keeps the Java object, and
therefore the peer, alive — and calls only the `noexcept`
`JArrayBuffer::invalidate`. No JNI calls are made from the destructor, which is
what lets it stay `noexcept` honestly.

**2. Argument conversion aborted under runtimes that refuse `tryGetMutableBuffer`.**
`jsi::Runtime::tryGetMutableBuffer` and `detached` are not universally
implemented: tracing and replay runtimes throw from `tryGetMutableBuffer`, and
`detached` throws a `JSINativeException` if the JS-side property isn't a bool.
`ArrayBuffer` argument conversion is not wrapped in a try/catch, so either throw
propagated out of a JNI frame. Both calls now go through exception-tolerant
helpers in `react/bridging/ArrayBuffer.h`; a runtime that refuses to answer is
treated as "no native buffer available", which selects the copy path. Routing
`AsyncArrayBuffer::acquire` and `::borrow` through the same helper fixes the
identical latent bug on the shared C++/ObjC path.

**3. A wrong return type from a module crashed instead of raising a JS error.**
The `ArrayBufferKind` return path cast the returned `jobject` to `JArrayBuffer`
unconditionally. A module returning any other object type produced undefined
behavior. The cast is now guarded by an `isInstanceOf` check that throws a
`jsi::JSError` naming the offending module and method.

Also in this change:
- `JByteBufferMutableBuffer::data()` reports null for a zero-capacity direct
  buffer instead of calling `getDirectBytes()`, which throws for one. That made
  `createArrayBuffer` throw for an empty `ArrayBuffer`.
- Dropped two dead zero-size branches in `JArrayBuffer`: `JByteBuffer::wrapBytes`
  already routes `size == 0` to an empty buffer.
- `JArrayBuffer.cpp` reuses the shared `detail::OwnedBytesBuffer` from
  `react/bridging/ArrayBuffer.h` instead of a second local copy.
- `ArrayBuffer.kt` KDoc corrected: the returned JS `ArrayBuffer` is a new object
  over the same bytes rather than the identical one, `size` is the capacity and
  not a view's remaining bytes, and `arrayBufferWithOwnedBytes` documents the
  caller's lifetime obligation.
- `ArrayBuffer.kt` moves from the `bridge` target to `native-types`, alongside the
  other JNI-backed bridge types.

Changelog:
[Android][Breaking] - TurboModule methods taking or returning an `ArrayBuffer`
now use `com.facebook.react.bridge.ArrayBuffer` instead of
`java.nio.ByteBuffer`, and an `ArrayBuffer` argument must not be retained past
the method that receives it unless its bytes are copied with
`ArrayBuffer.arrayBufferWithCopiedBytes()`.

Reviewed By: javache

Differential Revision: D115794808
