### PR TITLE
Fold optional TextAttributes fields into a presence mask when hashing (#57984)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -133,7 +133,11 @@ struct hash<facebook::react::TextAttributes> {
     for (const auto &effect : textAttributes.textEffects) {
       facebook::react::hash_combine(textEffectsHash, effect);
     }
-    return facebook::react::hash_combine(
+    // The optionals are folded into one presence mask rather than being chained individually, so
+    // that the properties a given text run does not set stay off the hash's dependency chain.
+    size_t seed = 0;
+    facebook::react::hash_combine(
+        seed,
         textAttributes.foregroundColor,
         textAttributes.backgroundColor,
         textAttributes.opacity,
@@ -141,30 +145,33 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.fontSize,
         textAttributes.maxFontSizeMultiplier,
         textAttributes.fontSizeMultiplier,
+        textAttributes.letterSpacing,
+        textAttributes.lineHeight,
+        textAttributes.textShadowRadius,
+        textAttributes.textDecorationColor,
+        textAttributes.textShadowColor,
+        textEffectsHash);
+    facebook::react::hash_combine_optionals(
+        seed,
         textAttributes.fontWeight,
         textAttributes.fontStyle,
         textAttributes.fontVariant,
         textAttributes.fontVariationSettings,
         textAttributes.allowFontScaling,
-        textAttributes.letterSpacing,
         textAttributes.textTransform,
-        textAttributes.lineHeight,
         textAttributes.alignment,
         textAttributes.baseWritingDirection,
         textAttributes.lineBreakStrategy,
         textAttributes.lineBreakMode,
-        textAttributes.textDecorationColor,
         textAttributes.textDecorationLineType,
         textAttributes.textDecorationStyle,
         textAttributes.textShadowOffset,
-        textAttributes.textShadowRadius,
-        textAttributes.textShadowColor,
         textAttributes.isHighlighted,
         textAttributes.isPressable,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
-        textAttributes.role,
-        textEffectsHash);
+        textAttributes.role);
+    return seed;
   }
 };
 } // namespace std

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/TextAttributesHashTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/TextAttributesHashTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+#include <react/renderer/attributedstring/TextAttributes.h>
+
+namespace facebook::react {
+namespace {
+
+template <typename T>
+void expectOptionalFieldAffectsHash(
+    const char* fieldName,
+    std::optional<T> TextAttributes::* field) {
+  SCOPED_TRACE(fieldName);
+  TextAttributes baseline;
+  TextAttributes changed;
+  changed.*field = T{};
+
+  EXPECT_NE(
+      std::hash<TextAttributes>{}(baseline),
+      std::hash<TextAttributes>{}(changed));
+}
+
+} // namespace
+
+TEST(TextAttributesHashTest, equalAttributesHaveEqualHashes) {
+  TextAttributes lhs;
+  lhs.fontWeight = FontWeight::Weight400;
+  lhs.fontStyle = FontStyle::Italic;
+  lhs.fontVariationSettings = "'wght' 400";
+  lhs.allowFontScaling = true;
+  lhs.alignment = TextAlignment::Center;
+  lhs.textShadowOffset = Size{.width = 1, .height = 2};
+  lhs.isPressable = true;
+
+  TextAttributes rhs = lhs;
+
+  EXPECT_EQ(lhs, rhs);
+  EXPECT_EQ(std::hash<TextAttributes>{}(lhs), std::hash<TextAttributes>{}(rhs));
+}
+
+TEST(TextAttributesHashTest, everyOptionalHashedFieldAffectsHash) {
+  expectOptionalFieldAffectsHash("fontWeight", &TextAttributes::fontWeight);
+  expectOptionalFieldAffectsHash("fontStyle", &TextAttributes::fontStyle);
+  expectOptionalFieldAffectsHash("fontVariant", &TextAttributes::fontVariant);
+  expectOptionalFieldAffectsHash(
+      "fontVariationSettings", &TextAttributes::fontVariationSettings);
+  expectOptionalFieldAffectsHash(
+      "allowFontScaling", &TextAttributes::allowFontScaling);
+  expectOptionalFieldAffectsHash(
+      "textTransform", &TextAttributes::textTransform);
+  expectOptionalFieldAffectsHash("alignment", &TextAttributes::alignment);
+  expectOptionalFieldAffectsHash(
+      "baseWritingDirection", &TextAttributes::baseWritingDirection);
+  expectOptionalFieldAffectsHash(
+      "lineBreakStrategy", &TextAttributes::lineBreakStrategy);
+  expectOptionalFieldAffectsHash(
+      "lineBreakMode", &TextAttributes::lineBreakMode);
+  expectOptionalFieldAffectsHash(
+      "textDecorationLineType", &TextAttributes::textDecorationLineType);
+  expectOptionalFieldAffectsHash(
+      "textDecorationStyle", &TextAttributes::textDecorationStyle);
+  expectOptionalFieldAffectsHash(
+      "textShadowOffset", &TextAttributes::textShadowOffset);
+  expectOptionalFieldAffectsHash(
+      "isHighlighted", &TextAttributes::isHighlighted);
+  expectOptionalFieldAffectsHash("isPressable", &TextAttributes::isPressable);
+  expectOptionalFieldAffectsHash(
+      "layoutDirection", &TextAttributes::layoutDirection);
+  expectOptionalFieldAffectsHash(
+      "accessibilityRole", &TextAttributes::accessibilityRole);
+  expectOptionalFieldAffectsHash("role", &TextAttributes::role);
+}
+
+TEST(TextAttributesHashTest, identicalValuesInDifferentSlotsHashDifferently) {
+  TextAttributes highlighted;
+  highlighted.isHighlighted = true;
+
+  TextAttributes pressable;
+  pressable.isPressable = true;
+
+  EXPECT_NE(
+      std::hash<TextAttributes>{}(highlighted),
+      std::hash<TextAttributes>{}(pressable));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -147,20 +147,28 @@ inline size_t textAttributesHashLayoutWise(const TextAttributes &textAttributes)
 {
   // Taking into account the same props as
   // `areTextAttributesEquivalentLayoutWise` mentions.
-  return facebook::react::hash_combine(
+  // The optionals are folded into one presence mask rather than being chained individually, so
+  // that the properties a given text run does not set stay off the hash's dependency chain. This
+  // is the hot path: it runs on every measurement-cache probe.
+  size_t seed = 0;
+  facebook::react::hash_combine(
+      seed,
       textAttributes.fontFamily,
       textAttributes.fontSize,
       textAttributes.fontSizeMultiplier,
+      textAttributes.maxFontSizeMultiplier,
+      textAttributes.letterSpacing,
+      textAttributes.lineHeight);
+  facebook::react::hash_combine_optionals(
+      seed,
       textAttributes.fontWeight,
       textAttributes.fontStyle,
       textAttributes.fontVariant,
       textAttributes.fontVariationSettings,
       textAttributes.allowFontScaling,
-      textAttributes.maxFontSizeMultiplier,
       textAttributes.dynamicTypeRamp,
-      textAttributes.letterSpacing,
-      textAttributes.lineHeight,
       textAttributes.alignment);
+  return seed;
 }
 
 inline bool areAttributedStringFragmentsEquivalentLayoutWise(

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cmath>
 
 #include <react/renderer/textlayoutmanager/TextMeasureCache.h>
@@ -79,6 +80,122 @@ TEST(TextLayoutManagerTest, emptyFontVariationSettingsClearInheritedSettings) {
 
   EXPECT_TRUE(parent.fontVariationSettings.has_value());
   EXPECT_TRUE(parent.fontVariationSettings->empty());
+}
+
+TEST(TextLayoutManagerTest, everyLayoutAttributeAffectsEqualityAndHash) {
+  TextAttributes baseline;
+  baseline.fontFamily = "Inter";
+  baseline.fontSize = 16;
+  baseline.fontSizeMultiplier = 1;
+  baseline.maxFontSizeMultiplier = 2;
+  baseline.letterSpacing = 0.5;
+  baseline.lineHeight = 20;
+  baseline.fontWeight = FontWeight::Weight400;
+  baseline.fontStyle = FontStyle::Normal;
+  baseline.fontVariant = FontVariant::Default;
+  baseline.fontVariationSettings = "'wght' 400";
+  baseline.allowFontScaling = true;
+  baseline.dynamicTypeRamp = DynamicTypeRamp::Body;
+  baseline.alignment = TextAlignment::Natural;
+
+  struct TestCase {
+    const char* name;
+    void (*mutate)(TextAttributes&);
+  };
+  const std::array<TestCase, 13> testCases{{
+      {.name = "fontFamily",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontFamily = "Roboto";
+           }},
+      {.name = "fontSize",
+       .mutate = [](TextAttributes& attributes) { attributes.fontSize = 17; }},
+      {.name = "fontSizeMultiplier",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontSizeMultiplier = 1.5;
+           }},
+      {.name = "maxFontSizeMultiplier",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.maxFontSizeMultiplier = 3;
+           }},
+      {.name = "letterSpacing",
+       .mutate =
+           [](TextAttributes& attributes) { attributes.letterSpacing = 1; }},
+      {.name = "lineHeight",
+       .mutate =
+           [](TextAttributes& attributes) { attributes.lineHeight = 24; }},
+      {.name = "fontWeight",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontWeight = FontWeight::Weight700;
+           }},
+      {.name = "fontStyle",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontStyle = FontStyle::Italic;
+           }},
+      {.name = "fontVariant",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontVariant = FontVariant::SmallCaps;
+           }},
+      {.name = "fontVariationSettings",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.fontVariationSettings = "'wght' 700";
+           }},
+      {.name = "allowFontScaling",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.allowFontScaling = false;
+           }},
+      {.name = "dynamicTypeRamp",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.dynamicTypeRamp = DynamicTypeRamp::Headline;
+           }},
+      {.name = "alignment",
+       .mutate =
+           [](TextAttributes& attributes) {
+             attributes.alignment = TextAlignment::Center;
+           }},
+  }};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    auto changed = baseline;
+    testCase.mutate(changed);
+
+    EXPECT_FALSE(areTextAttributesEquivalentLayoutWise(baseline, changed));
+    EXPECT_NE(
+        textAttributesHashLayoutWise(baseline),
+        textAttributesHashLayoutWise(changed));
+  }
+}
+
+TEST(TextLayoutManagerTest, equivalentPopulatedLayoutAttributesHashEqually) {
+  TextAttributes lhs;
+  lhs.fontFamily = "Inter";
+  lhs.fontSize = 16;
+  lhs.fontSizeMultiplier = 1;
+  lhs.maxFontSizeMultiplier = 2;
+  lhs.letterSpacing = 0.5;
+  lhs.lineHeight = 20;
+  lhs.fontWeight = FontWeight::Weight400;
+  lhs.fontStyle = FontStyle::Italic;
+  lhs.fontVariant = FontVariant::SmallCaps;
+  lhs.fontVariationSettings = "'wght' 400";
+  lhs.allowFontScaling = true;
+  lhs.dynamicTypeRamp = DynamicTypeRamp::Body;
+  lhs.alignment = TextAlignment::Center;
+
+  auto rhs = lhs;
+
+  EXPECT_TRUE(areTextAttributesEquivalentLayoutWise(lhs, rhs));
+  EXPECT_EQ(
+      textAttributesHashLayoutWise(lhs), textAttributesHashLayoutWise(rhs));
 }
 
 // Measurements are rounded to the pixel grid, so a measurement cached at one

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/benchmarks/TextAttributesHashBenchmark.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/tests/benchmarks/TextAttributesHashBenchmark.cpp
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+#include <react/utils/hash_combine.h>
+
+namespace facebook::react {
+namespace {
+
+size_t legacyTextAttributesHash(const TextAttributes& textAttributes) {
+  size_t textEffectsHash = 0;
+  for (const auto& effect : textAttributes.textEffects) {
+    hash_combine(textEffectsHash, effect);
+  }
+  return hash_combine(
+      textAttributes.foregroundColor,
+      textAttributes.backgroundColor,
+      textAttributes.opacity,
+      textAttributes.fontFamily,
+      textAttributes.fontSize,
+      textAttributes.maxFontSizeMultiplier,
+      textAttributes.fontSizeMultiplier,
+      textAttributes.fontWeight,
+      textAttributes.fontStyle,
+      textAttributes.fontVariant,
+      textAttributes.fontVariationSettings,
+      textAttributes.allowFontScaling,
+      textAttributes.letterSpacing,
+      textAttributes.textTransform,
+      textAttributes.lineHeight,
+      textAttributes.alignment,
+      textAttributes.baseWritingDirection,
+      textAttributes.lineBreakStrategy,
+      textAttributes.lineBreakMode,
+      textAttributes.textDecorationColor,
+      textAttributes.textDecorationLineType,
+      textAttributes.textDecorationStyle,
+      textAttributes.textShadowOffset,
+      textAttributes.textShadowRadius,
+      textAttributes.textShadowColor,
+      textAttributes.isHighlighted,
+      textAttributes.isPressable,
+      textAttributes.layoutDirection,
+      textAttributes.accessibilityRole,
+      textAttributes.role,
+      textEffectsHash);
+}
+
+size_t legacyLayoutHash(const TextAttributes& textAttributes) {
+  return hash_combine(
+      textAttributes.fontFamily,
+      textAttributes.fontSize,
+      textAttributes.fontSizeMultiplier,
+      textAttributes.fontWeight,
+      textAttributes.fontStyle,
+      textAttributes.fontVariant,
+      textAttributes.fontVariationSettings,
+      textAttributes.allowFontScaling,
+      textAttributes.maxFontSizeMultiplier,
+      textAttributes.dynamicTypeRamp,
+      textAttributes.letterSpacing,
+      textAttributes.lineHeight,
+      textAttributes.alignment);
+}
+
+TextAttributes sparseAttributes() {
+  TextAttributes attributes;
+  attributes.fontWeight = FontWeight::Weight400;
+  return attributes;
+}
+
+TextAttributes partialAttributes() {
+  TextAttributes attributes;
+  attributes.fontFamily = "Inter";
+  attributes.fontSize = 16;
+  attributes.fontSizeMultiplier = 1;
+  attributes.maxFontSizeMultiplier = 2;
+  attributes.letterSpacing = 0.5;
+  attributes.lineHeight = 20;
+  attributes.fontWeight = FontWeight::Weight400;
+  attributes.fontStyle = FontStyle::Normal;
+  attributes.allowFontScaling = true;
+  attributes.alignment = TextAlignment::Natural;
+  return attributes;
+}
+
+TextAttributes fullAttributes() {
+  auto attributes = partialAttributes();
+  attributes.fontVariant = FontVariant::SmallCaps;
+  attributes.fontVariationSettings = "'wght' 400";
+  attributes.dynamicTypeRamp = DynamicTypeRamp::Body;
+  attributes.textTransform = TextTransform::None;
+  attributes.baseWritingDirection = WritingDirection::LeftToRight;
+  attributes.lineBreakStrategy = LineBreakStrategy::Standard;
+  attributes.lineBreakMode = LineBreakMode::Word;
+  attributes.textDecorationLineType = TextDecorationLineType::Underline;
+  attributes.textDecorationStyle = TextDecorationStyle::Solid;
+  attributes.textShadowOffset = Size{.width = 1, .height = 1};
+  attributes.isHighlighted = false;
+  attributes.isPressable = true;
+  attributes.layoutDirection = LayoutDirection{};
+  attributes.accessibilityRole = AccessibilityRole{};
+  attributes.role = Role{};
+  return attributes;
+}
+
+struct DefaultAttributes {
+  static TextAttributes make() {
+    return {};
+  }
+};
+
+struct SparseAttributes {
+  static TextAttributes make() {
+    return sparseAttributes();
+  }
+};
+
+struct PartialAttributes {
+  static TextAttributes make() {
+    return partialAttributes();
+  }
+};
+
+struct FullAttributes {
+  static TextAttributes make() {
+    return fullAttributes();
+  }
+};
+
+struct LegacyFullHash {
+  static size_t hash(const TextAttributes& attributes) {
+    return legacyTextAttributesHash(attributes);
+  }
+};
+
+struct OptimizedFullHash {
+  static size_t hash(const TextAttributes& attributes) {
+    return std::hash<TextAttributes>{}(attributes);
+  }
+};
+
+struct LegacyLayoutHash {
+  static size_t hash(const TextAttributes& attributes) {
+    return legacyLayoutHash(attributes);
+  }
+};
+
+struct OptimizedLayoutHash {
+  static size_t hash(const TextAttributes& attributes) {
+    return textAttributesHashLayoutWise(attributes);
+  }
+};
+
+template <typename Attributes, typename Hash>
+void textAttributesHashBenchmark(benchmark::State& state) {
+  const auto attributes = Attributes::make();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(attributes);
+    benchmark::DoNotOptimize(Hash::hash(attributes));
+  }
+}
+
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    DefaultAttributes,
+    LegacyFullHash)
+    ->Name("LegacyFull_Default");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    DefaultAttributes,
+    OptimizedFullHash)
+    ->Name("OptimizedFull_Default");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    SparseAttributes,
+    LegacyFullHash)
+    ->Name("LegacyFull_Sparse");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    SparseAttributes,
+    OptimizedFullHash)
+    ->Name("OptimizedFull_Sparse");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    PartialAttributes,
+    LegacyFullHash)
+    ->Name("LegacyFull_Partial");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    PartialAttributes,
+    OptimizedFullHash)
+    ->Name("OptimizedFull_Partial");
+BENCHMARK_TEMPLATE(textAttributesHashBenchmark, FullAttributes, LegacyFullHash)
+    ->Name("LegacyFull_Full");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    FullAttributes,
+    OptimizedFullHash)
+    ->Name("OptimizedFull_Full");
+
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    DefaultAttributes,
+    LegacyLayoutHash)
+    ->Name("LegacyLayout_Default");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    DefaultAttributes,
+    OptimizedLayoutHash)
+    ->Name("OptimizedLayout_Default");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    SparseAttributes,
+    LegacyLayoutHash)
+    ->Name("LegacyLayout_Sparse");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    SparseAttributes,
+    OptimizedLayoutHash)
+    ->Name("OptimizedLayout_Sparse");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    PartialAttributes,
+    LegacyLayoutHash)
+    ->Name("LegacyLayout_Partial");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    PartialAttributes,
+    OptimizedLayoutHash)
+    ->Name("OptimizedLayout_Partial");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    FullAttributes,
+    LegacyLayoutHash)
+    ->Name("LegacyLayout_Full");
+BENCHMARK_TEMPLATE(
+    textAttributesHashBenchmark,
+    FullAttributes,
+    OptimizedLayoutHash)
+    ->Name("OptimizedLayout_Full");
+
+} // namespace
+} // namespace facebook::react
+
+BENCHMARK_MAIN();

--- a/packages/react-native/ReactCommon/react/utils/hash_combine.h
+++ b/packages/react-native/ReactCommon/react/utils/hash_combine.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
+#include <optional>
 #include <type_traits>
 
 namespace facebook::react {
@@ -30,6 +32,40 @@ std::size_t hash_combine(const T &v, const Args &...args)
   std::size_t seed = 0;
   hash_combine<T, Args...>(seed, v, args...);
   return seed;
+}
+
+/*
+ * Combines a run of optional fields into `seed` as a single presence bitmask followed by the
+ * engaged values only.
+ *
+ * Each `hash_combine` step mixes into the previous seed, so it forms a dependency chain the CPU
+ * cannot overlap and an unset field still costs a full link. The optionals are hashed into an
+ * independent seed and merged into the preceding seed once, allowing both chains to overlap.
+ * Folding presence into one word keeps unused fields off the optional chain: a further optional
+ * costs a bit in the mask rather than a link.
+ *
+ * The mask is what keeps this collision-free. Skipping disengaged fields on its own would make the
+ * same value in two different slots hash identically.
+ *
+ * Both packs are expanded from the same parameter pack, so the mask's bit order cannot drift out
+ * of sync with the order the values are combined.
+ */
+template <Hashable... Ts>
+  requires(sizeof...(Ts) <= 32)
+void hash_combine_optionals(std::size_t &seed, const std::optional<Ts> &...optionals)
+{
+  std::uint32_t presence = 0;
+  std::uint32_t bit = 1;
+  ((presence |= optionals.has_value() ? bit : 0u, bit <<= 1), ...);
+  std::size_t optionalsSeed = presence;
+
+  auto combineIfEngaged = [&optionalsSeed](const auto &optional) {
+    if (optional.has_value()) {
+      hash_combine(optionalsSeed, *optional);
+    }
+  };
+  (combineIfEngaged(optionals), ...);
+  hash_combine(seed, optionalsSeed);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
+++ b/packages/react-native/ReactCommon/react/utils/tests/hash_combineTests.cpp
@@ -8,6 +8,12 @@
 #include <gtest/gtest.h>
 #include <react/utils/hash_combine.h>
 
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
 struct Person {
   std::string firstName;
   std::string lastName;
@@ -77,6 +83,124 @@ TEST(hash_combineTests, testCustomTypes) {
   EXPECT_EQ(hashedValue, seed);
 
   EXPECT_NE(hash_combine(person1), hash_combine(person2));
+}
+
+TEST(hash_combineTests, optionalsCombinePresenceBeforeEngagedValues) {
+  std::optional<int> first{17};
+  std::optional<std::string> second;
+  std::optional<bool> third{true};
+
+  std::size_t actual = 41;
+  hash_combine_optionals(actual, first, second, third);
+
+  std::size_t optionalsHash = std::uint32_t{0b101};
+  hash_combine(optionalsHash, *first, *third);
+  std::size_t expected = 41;
+  hash_combine(expected, optionalsHash);
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(hash_combineTests, disengagedOptionalsOnlyCombinePresence) {
+  std::optional<int> first;
+  std::optional<std::string> second;
+
+  std::size_t actual = 41;
+  hash_combine_optionals(actual, first, second);
+
+  std::size_t expected = 41;
+  hash_combine(expected, std::uint32_t{0});
+  EXPECT_EQ(actual, expected);
+}
+
+TEST(hash_combineTests, optionalStringContentsAffectProvidedSeed) {
+  std::optional<std::string> react{"react"};
+  std::optional<std::string> reactNative{"react native"};
+
+  std::size_t reactHash = 41;
+  hash_combine_optionals(reactHash, react);
+
+  std::size_t optionalsHash = std::uint32_t{1};
+  hash_combine(optionalsHash, *react);
+  std::size_t expected = 41;
+  hash_combine(expected, optionalsHash);
+  EXPECT_EQ(reactHash, expected);
+
+  std::size_t reactNativeHash = 41;
+  hash_combine_optionals(reactNativeHash, reactNative);
+  EXPECT_NE(reactHash, reactNativeHash);
+}
+
+TEST(hash_combineTests, emptyOptionalStringDiffersFromDisengaged) {
+  std::optional<std::string> emptyString{""};
+  std::optional<std::string> disengaged;
+
+  std::size_t emptyStringHash = 41;
+  hash_combine_optionals(emptyStringHash, emptyString);
+
+  std::size_t disengagedHash = 41;
+  hash_combine_optionals(disengagedHash, disengaged);
+
+  EXPECT_NE(emptyStringHash, disengagedHash);
+}
+
+TEST(hash_combineTests, optionalPositionAffectsHash) {
+  std::optional<int> engaged{17};
+  std::optional<int> disengaged;
+
+  std::size_t firstPosition = 0;
+  hash_combine_optionals(firstPosition, engaged, disengaged);
+
+  std::size_t secondPosition = 0;
+  hash_combine_optionals(secondPosition, disengaged, engaged);
+
+  EXPECT_NE(firstPosition, secondPosition);
+}
+
+namespace {
+
+struct Unhashable {};
+
+template <typename... Ts>
+concept CanHashCombineOptionals =
+    requires(std::size_t& seed, const std::optional<Ts>&... optionals) {
+      hash_combine_optionals(seed, optionals...);
+    };
+
+template <std::size_t... Indices>
+constexpr bool canHashOptionalCount(
+    std::index_sequence<Indices...> /*unused*/) {
+  return requires(std::size_t& seed, const std::optional<int>& optional) {
+    hash_combine_optionals(seed, ((void)Indices, optional)...);
+  };
+}
+
+static_assert(CanHashCombineOptionals<int, std::string, bool>);
+static_assert(!CanHashCombineOptionals<Unhashable>);
+static_assert(canHashOptionalCount(std::make_index_sequence<32>{}));
+static_assert(!canHashOptionalCount(std::make_index_sequence<33>{}));
+
+template <std::size_t... Indices>
+void combineArrayOptionals(
+    std::size_t& seed,
+    const std::array<std::optional<int>, 32>& optionals,
+    std::index_sequence<Indices...> /*unused*/) {
+  hash_combine_optionals(seed, optionals[Indices]...);
+}
+
+} // namespace
+
+TEST(hash_combineTests, supportsHighestPresenceBit) {
+  std::array<std::optional<int>, 32> optionals;
+  optionals.back() = 17;
+
+  std::size_t actual = 41;
+  combineArrayOptionals(actual, optionals, std::make_index_sequence<32>{});
+
+  std::size_t optionalsHash = std::uint32_t{1} << 31;
+  hash_combine(optionalsHash, 17);
+  std::size_t expected = 41;
+  hash_combine(expected, optionalsHash);
+  EXPECT_EQ(actual, expected);
 }
 
 } // namespace facebook::react

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1019,6 +1019,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -1015,6 +1015,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1019,6 +1019,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -3863,6 +3863,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3852,6 +3852,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -3863,6 +3863,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -588,6 +588,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -585,6 +585,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -588,6 +588,8 @@ template <Hashable T, Hashable... Args>
 std::size_t facebook::react::hash_combine(const T& v, const Args &... args);
 template <Hashable T, Hashable... Rest>
 void facebook::react::hash_combine(std::size_t& seed, const T& v, const Rest &... rest);
+template <Hashable... Ts>
+void facebook::react::hash_combine_optionals(std::size_t& seed, const std::optional<Ts> &... optionals);
 template <class T, class T0 = typename std::remove_reference<T>::type>
 facebook::react::MoveWrapper<T0> facebook::react::makeMoveWrapper(T&& t);
 template <typename CSSColor>


### PR DESCRIPTION
Summary:

`hash_combine` mixes each field into the previous seed, so it forms a dependency chain the CPU
cannot overlap and an unset optional still costs a full link. `hash_combine_optionals` folds a run
of optionals into one presence-mask link plus the engaged values, so a further optional costs a bit
in the mask rather than a link. The mask is what keeps it collision-free: skipping disengaged
fields alone would make the same value in two different slots hash identically.

Equality moves from `std::tie` to a short-circuit chain ordered cheapest first, with the string and
vector fields last, because the dominant caller is a successful cache lookup where the keys are
equal and every field has to be examined.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D115621401


