### PR TITLE
fix(codegen): infinite loop on type aliases that shadow CodegenTypes member names

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -946,6 +946,34 @@ export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 
 `;
 
+const NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
+import type {CodegenTypes} from 'react-native';
+
+type Double = CodegenTypes.Double;
+type MyFloat = CodegenTypes.Float;
+
+export interface Spec extends TurboModule {
+  +getDouble: (arg: Double) => Double;
+  +getFloat: (arg: MyFloat) => MyFloat;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 const NAMESPACED_NATIVE_MODULE_WITH_EVENT_EMITTERS = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -1046,4 +1074,5 @@ module.exports = {
   NAMESPACED_NATIVE_MODULE_WITH_FLOAT_AND_INT32,
   NAMESPACED_NATIVE_MODULE_WITH_UNSAFE_OBJECT,
   NAMESPACED_NATIVE_MODULE_WITH_EVENT_EMITTERS,
+  NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -845,6 +845,62 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_NATIVE_MODULE_WI
 }"
 `;
 
+exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliasMap': {},
+      'enumMap': {},
+      'spec': {
+        'eventEmitters': [],
+        'methods': [
+          {
+            'name': 'getDouble',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'DoubleTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'DoubleTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getFloat',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'FloatTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'FloatTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleName': 'SampleTurboModule'
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_NATIVE_MODULE_WITH_UNSAFE_OBJECT 1`] = `
 "{
   'modules': {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -418,6 +418,7 @@ class FlowParser implements Parser {
     let typeResolutionStatus: TypeResolutionStatus = {
       successful: false,
     };
+    const resolvedTypeAliases = new Set<string>();
 
     for (;;) {
       if (node.type === 'NullableTypeAnnotation') {
@@ -430,11 +431,21 @@ class FlowParser implements Parser {
         break;
       }
 
-      const typeAnnotationName = this.getTypeAnnotationName(node);
-      const resolvedTypeAnnotation = types[typeAnnotationName];
-      if (resolvedTypeAnnotation == null) {
+      // A qualified name (e.g. CodegenTypes.Double) refers to a namespace
+      // member, not to the local type alias of the same unqualified name.
+      if (node.id.type === 'QualifiedTypeIdentifier') {
         break;
       }
+
+      const typeAnnotationName = this.getTypeAnnotationName(node);
+      const resolvedTypeAnnotation = types[typeAnnotationName];
+      if (
+        resolvedTypeAnnotation == null ||
+        resolvedTypeAliases.has(typeAnnotationName)
+      ) {
+        break;
+      }
+      resolvedTypeAliases.add(typeAnnotationName);
       const {typeAnnotation: typeAnnotationNode, typeResolutionStatus: status} =
         handleGenericTypeAnnotation(node, resolvedTypeAnnotation, this);
       typeResolutionStatus = status;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -959,6 +959,31 @@ export interface Spec extends TurboModule {
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 `;
 
+const NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {CodegenTypes} from 'react-native';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type Double = CodegenTypes.Double;
+type MyFloat = CodegenTypes.Float;
+
+export interface Spec extends TurboModule {
+  readonly getDouble: (arg: Double) => Double;
+  readonly getFloat: (arg: MyFloat) => MyFloat;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+`;
+
 const NAMESPACED_NATIVE_MODULE_WITH_EVENT_EMITTERS = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -1057,4 +1082,5 @@ module.exports = {
   NAMESPACED_NATIVE_MODULE_WITH_FLOAT_AND_INT32,
   NAMESPACED_NATIVE_MODULE_WITH_UNSAFE_OBJECT,
   NAMESPACED_NATIVE_MODULE_WITH_EVENT_EMITTERS,
+  NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -843,6 +843,62 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_NATIVE_MOD
 }"
 `;
 
+exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliasMap': {},
+      'enumMap': {},
+      'spec': {
+        'eventEmitters': [],
+        'methods': [
+          {
+            'name': 'getDouble',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'DoubleTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'DoubleTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'getFloat',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'FloatTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'FloatTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleName': 'SampleTurboModule'
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_NATIVE_MODULE_WITH_UNSAFE_OBJECT 1`] = `
 "{
   'modules': {

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -455,6 +455,7 @@ class TypeScriptParser implements Parser {
     let typeResolutionStatus: TypeResolutionStatus = {
       successful: false,
     };
+    const resolvedTypeAliases = new Set<string>();
 
     for (;;) {
       const topLevelType = parseTopLevelType(node, parser);
@@ -465,11 +466,21 @@ class TypeScriptParser implements Parser {
         break;
       }
 
-      const typeAnnotationName = this.getTypeAnnotationName(node);
-      const resolvedTypeAnnotation = types[typeAnnotationName];
-      if (resolvedTypeAnnotation == null) {
+      // A qualified name (e.g. CodegenTypes.Double) refers to a namespace
+      // member, not to the local type alias of the same unqualified name.
+      if (node.typeName.type === 'TSQualifiedName') {
         break;
       }
+
+      const typeAnnotationName = this.getTypeAnnotationName(node);
+      const resolvedTypeAnnotation = types[typeAnnotationName];
+      if (
+        resolvedTypeAnnotation == null ||
+        resolvedTypeAliases.has(typeAnnotationName)
+      ) {
+        break;
+      }
+      resolvedTypeAliases.add(typeAnnotationName);
 
       const {typeAnnotation: typeAnnotationNode, typeResolutionStatus: status} =
         handleGenericTypeAnnotation(node, resolvedTypeAnnotation, this);


### PR DESCRIPTION
## Summary

Fixes #57956.

A spec containing a type alias whose name matches the aliased `CodegenTypes` member hangs codegen forever:

```js
import type {CodegenTypes} from 'react-native';

type Double = CodegenTypes.Double;
```

`getResolvedTypeAnnotation` resolves `Double` to the alias's RHS (`CodegenTypes.Double`), but `getTypeAnnotationName` strips the namespace qualifier before the local-alias lookup — so the RHS resolves straight back to the same alias, forever. This hangs the Node process of anything driving the parser, most visibly ESLint via `@react-native/eslint-plugin-specs`. Contrary to the issue's initial isolation, **both** the Flow and the TypeScript parsers hang (verified with a subprocess-timeout harness against both).

Two guards in each parser's resolution loop:

1. A qualified name (`CodegenTypes.Double` / `TSQualifiedName`) names a namespace member, never a local alias — stop local resolution there. Downstream translation already handles qualified names, so the alias now resolves to the correct primitive (`DoubleTypeAnnotation`).
2. Track resolved alias names, so genuinely cyclic aliases (`type A = B; type B = A;`) stop resolving and fail through the existing `UnsupportedGenericParserError` (`Unrecognized generic type 'A'`) instead of hanging.

## Changelog:

[GENERAL] [FIXED] - Codegen no longer hangs on type aliases that shadow CodegenTypes member names

## Test Plan

- New `NAMESPACED_NATIVE_MODULE_WITH_LOCAL_TYPE_ALIASES` fixture in both the Flow and TypeScript module snapshot suites — before the fix these hang the test runner; after it they produce the correct schema (aliased `Double`/`Float` resolve to `DoubleTypeAnnotation`/`FloatTypeAnnotation`, snapshots included, cross-parser consistency suite passes).
- `jest packages/react-native-codegen/src/parsers`: 13 suites, 1965 tests, 186 snapshots — all passing.
- `jest packages/eslint-plugin-specs`: passing.
- Verified `type A = B; type B = A;` now throws `UnsupportedGenericParserError` instead of hanging.