### PR TITLE
Re-attach key window observer in RCTDeviceInfo

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -154,8 +154,10 @@ RCT_EXPORT_MODULE()
   // The key window is looked up again instead of trusting the one captured in -init: when the host
   // app creates its window after this module is built, that capture is nil, the KVO below is never
   // installed, and app activation is left as the only trigger for a dimensions update.
+  // A nil key window means there is nothing to observe yet (backgrounded app, scene transition);
+  // keeping the current observer is better than dropping it until the next trigger comes along.
   UIWindow *keyWindow = RCTKeyWindow();
-  if (keyWindow == _applicationWindow) {
+  if (keyWindow == nil || keyWindow == _applicationWindow) {
     return;
   }
 

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -277,16 +277,23 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)didReceiveNewContentSizeMultiplier
 {
-  [self invalidateCachedConstants];
-  NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
-
-  RCTModuleRegistry *moduleRegistry = _moduleRegistry;
+  // This notification can arrive off the main thread (RCTAccessibilityManager has no methodQueue,
+  // so a JS setAccessibilityContentSizeMultipliers call posts it synchronously on the module
+  // queue), while the possible key-window KVO registration must happen on main.
+  __weak __typeof(self) weakSelf = self;
   RCTExecuteOnMainQueue(^{
-  // Report the event across the bridge.
+    __typeof(self) strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
+    [strongSelf invalidateCachedConstants];
+    NSDictionary *nextInterfaceDimensions = strongSelf->_constants[@"Dimensions"];
+
+    // Report the event across the bridge.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [[moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"didUpdateDimensions"
-                                                                         body:nextInterfaceDimensions];
+    [[strongSelf->_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"didUpdateDimensions"
+                                                                                      body:nextInterfaceDimensions];
 #pragma clang diagnostic pop
   });
 }
@@ -338,8 +345,6 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)_interfaceFrameDidChange
 {
-  [self _observeKeyWindowIfNeeded];
-
   [self invalidateCachedConstants];
   NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
 

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -140,6 +140,28 @@ RCT_EXPORT_MODULE()
     // Use <SafeAreaView> instead.
     @"isIPhoneX_deprecated" : @(RCTIsIPhoneNotched()),
   };
+
+  [self _observeKeyWindowIfNeeded];
+}
+
+- (void)_observeKeyWindowIfNeeded
+{
+  RCTAssertMainQueue();
+  if (_invalidated) {
+    return;
+  }
+
+  // The key window is looked up again instead of trusting the one captured in -init: when the host
+  // app creates its window after this module is built, that capture is nil, the KVO below is never
+  // installed, and app activation is left as the only trigger for a dimensions update.
+  UIWindow *keyWindow = RCTKeyWindow();
+  if (keyWindow == _applicationWindow) {
+    return;
+  }
+
+  [_applicationWindow removeObserver:self forKeyPath:kFrameKeyPath];
+  _applicationWindow = keyWindow;
+  [_applicationWindow addObserver:self forKeyPath:kFrameKeyPath options:NSKeyValueObservingOptionNew context:nil];
 }
 
 - (void)invalidate
@@ -314,6 +336,8 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)_interfaceFrameDidChange
 {
+  [self _observeKeyWindowIfNeeded];
+
   [self invalidateCachedConstants];
   NSDictionary *nextInterfaceDimensions = _constants[@"Dimensions"];
 


### PR DESCRIPTION
## Summary:

`RCTDeviceInfo` publishes dimension updates to JS from four triggers: a KVO on the key window's `frame`, `UIDeviceOrientationDidChangeNotification`, `UIApplicationDidBecomeActiveNotification` and `RCTUserInterfaceStyleDidChangeNotification`.

The window it observes is captured once, in `-init`:

```objc
- (instancetype)init
{
  if (self = [super init]) {
    _applicationWindow = RCTKeyWindow();
    [_applicationWindow addObserver:self forKeyPath:kFrameKeyPath options:NSKeyValueObservingOptionNew context:nil];
  }
  return self;
}
```

When the host app creates its `UIWindow` after this module is built — which is what the current template's `UIApplicationDelegate` does, assigning `self.window` inside `application:didFinishLaunchingWithOptions:` — `RCTKeyWindow()` returns `nil`, `[nil addObserver:…]` silently does nothing, and nothing re-attaches the observer later. The frame KVO then never fires for the lifetime of the app.

On a device this is masked by `UIDeviceOrientationDidChangeNotification`. It is not masked when there is no orientation sensor: running an iPad app on an Apple Silicon Mac ("Designed for iPad"), rotating through *View → Landscape* leaves `Dimensions`/`useWindowDimensions` reporting the previous size, and the window server displays that stale canvas rotated. Focusing another app and coming back fixes it, because that fires `UIApplicationDidBecomeActiveNotification`.

This is the symptom of #36118, which was fixed by #37649 (61861d21) with an observer on `RCTRootViewFrameDidChangeNotification`, posted by `RCTRootView`. That symbol no longer exists in the repository — there is no observer, no constant, and nothing posting it — so apps on the New Architecture have no equivalent trigger and the original behaviour is back. #47262 and #54105 report the same class of problem for iPad Split View and Stage Manager and may share this root cause.

This change looks the key window up again in `-initialize` and at the top of `-_interfaceFrameDidChange`, instead of trusting the `-init` capture. It is a no-op when the window is unchanged, and the previous observer is removed before a new one is attached, so `-_cleanupObservers` stays correct. No other change is needed: `RCTExportedDimensions` already reads `RCTKeyWindow().bounds` live.

An alternative would be to reintroduce a root-view-level notification for the new renderer; happy to go that way instead if maintainers prefer it.

## Changelog:

[iOS] [Fixed] - Re-attach the key window observer in RCTDeviceInfo so Dimensions update without requiring app activation

## Test Plan:

Verified against an app built for iPad and run on an Apple Silicon Mac, whose `AppDelegate` creates its own `UIWindow` in `application(_:didFinishLaunchingWithOptions:)`, New Architecture enabled:

1. Launch the app on the Mac.
2. Rotate with *View → Landscape* in the menu bar.

Before: `useWindowDimensions()` keeps the previous size and the UI is drawn rotated; it only corrects after switching to another app and back.
After: the dimensions update on rotation and the UI re-lays-out immediately.

Also verified as an equivalent patch on 0.86.2 in a production app (`xcodebuild` Debug/iphonesimulator succeeds, app launches and renders normally, iPhone rotation still behaves as before).
