### PR TITLE
Use macOS 26 runners for iOS E2E tests

### DIFF
--- a/.github/workflow-scripts/__tests__/maestro-ios-test.js
+++ b/.github/workflow-scripts/__tests__/maestro-ios-test.js
@@ -20,7 +20,7 @@ jest.mock('fs', () => ({
 const childProcess = require('child_process');
 const fs = require('fs');
 
-const {executeFlows} = require('../maestro-ios');
+const {executeFlows, findAvailableSimulator} = require('../maestro-ios');
 
 describe('Maestro iOS runner', () => {
   beforeEach(() => {
@@ -58,5 +58,24 @@ describe('Maestro iOS runner', () => {
     for (const call of childProcess.execSync.mock.calls) {
       expect(call[0]).toContain('test "flow.yml"');
     }
+  });
+
+  it('selects an iPhone Pro simulator from the latest runtime', () => {
+    childProcess.execSync.mockReturnValue(
+      JSON.stringify({
+        devices: {
+          'iOS 18.5': [{name: 'iPhone 16 Pro', udid: 'old-pro'}],
+          'iOS 26.5': [
+            {name: 'iPhone 17 Pro Max', udid: 'new-pro-max'},
+            {name: 'iPhone 17 Pro', udid: 'new-pro'},
+          ],
+        },
+      }),
+    );
+
+    expect(findAvailableSimulator()).toEqual({
+      name: 'iPhone 17 Pro',
+      udid: 'new-pro',
+    });
   });
 });

--- a/.github/workflow-scripts/maestro-ios.js
+++ b/.github/workflow-scripts/maestro-ios.js
@@ -25,10 +25,26 @@ node maestro-android.js <path to app> <app_id> <maestro_flow> <flavor> <working_
 
 const MAX_ATTEMPTS = 5;
 
-function launchSimulator(simulatorName) {
-  console.log(`Launching simulator ${simulatorName}`);
+function findAvailableSimulator() {
+  const output = childProcess.execSync(
+    'xcrun simctl list devices available -j',
+  );
+  const devices = Object.values(JSON.parse(String(output)).devices)
+    .flat()
+    .reverse();
+  const simulator = devices.find(device => /^iPhone .* Pro$/.test(device.name));
+
+  if (simulator == null) {
+    throw new Error('Unable to find an available iPhone Pro simulator');
+  }
+
+  return simulator;
+}
+
+function launchSimulator(simulator) {
+  console.log(`Launching simulator ${simulator.name} (${simulator.udid})`);
   try {
-    childProcess.execSync(`xcrun simctl boot "${simulatorName}"`);
+    childProcess.execSync(`xcrun simctl boot "${simulator.udid}"`);
   } catch (error) {
     if (
       !error.message.includes('Unable to boot device in current state: Booted')
@@ -41,14 +57,6 @@ function launchSimulator(simulatorName) {
 function installAppOnSimulator(appPath) {
   console.log(`Installing app at path ${appPath}`);
   childProcess.execSync(`xcrun simctl install booted "${appPath}"`);
-}
-
-function extractSimulatorUDID() {
-  console.log('Retrieving device UDID');
-  const command = `xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid'`;
-  const udid = String(childProcess.execSync(command)).trim();
-  console.log(`UDID is ${udid}`);
-  return udid;
 }
 
 function bringSimulatorInForeground() {
@@ -166,13 +174,12 @@ async function main(args = process.argv.slice(2)) {
   console.info(`WORKING_DIRECTORY: ${workingDirectory}`);
   console.info('==============================\n');
 
-  const simulatorName = 'iPhone 16 Pro';
-  launchSimulator(simulatorName);
+  const simulator = findAvailableSimulator();
+  launchSimulator(simulator);
   installAppOnSimulator(appPath);
-  const udid = extractSimulatorUDID();
   bringSimulatorInForeground();
-  await launchAppOnSimulator(appId, udid, isDebug);
-  executeFlows(appId, udid, maestroFlow, jsengine);
+  await launchAppOnSimulator(appId, simulator.udid, isDebug);
+  executeFlows(appId, simulator.udid, maestroFlow, jsengine);
   console.log('Test finished');
 }
 
@@ -182,4 +189,5 @@ if (require.main === module) {
 
 module.exports = {
   executeFlows,
+  findAvailableSimulator,
 };

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -35,10 +35,6 @@ jobs:
           path: /tmp/RNTesterBuild/RNTester.app
       - name: Check downloaded folder content
         run: ls -lR /tmp/RNTesterBuild
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '26.0.1'
       - name: Run E2E Tests
         id: run-tests
         continue-on-error: true

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15-large
+    runs-on: macos-26-large
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:
@@ -37,6 +37,8 @@ jobs:
         run: ls -lR /tmp/RNTesterBuild
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '26.0.1'
       - name: Run E2E Tests
         id: run-tests
         continue-on-error: true

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -26,10 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '26.0.1'
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15-large
+    runs-on: macos-26-large
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:
@@ -28,6 +28,8 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '26.0.1'
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn


### PR DESCRIPTION
## Summary:

Moves the RNTester and template app iOS E2E jobs from `macos-15-large` to `macos-26-large`. The new runner image ships with Xcode 26, which is now required by `idb-companion`, and the jobs use the image default Xcode so its hosted simulator platform is available. The Maestro runner discovers an available iPhone Pro simulator and boots it by UDID instead of depending on a device name tied to an older runner image.

### CI follow-ups

- `test_e2e_ios_templateapp / test (Debug)` failed before the E2E tests because the explicitly selected Xcode 26.0.1 installation did not include the iOS Simulator platform. Removed the explicit Xcode selection from both E2E workflows so `macos-26-large` uses its default Xcode 26.6 installation and hosted simulator setup.
- The RNTester E2E attempts then installed `idb-companion` successfully but failed to boot the hardcoded `iPhone 16 Pro`, which is not present on the macOS 26 image. Updated the Maestro iOS runner to discover an available iPhone Pro from the newest installed runtime and boot it by UDID, with a unit test covering selection across runtimes.

## Changelog:

[INTERNAL] [FIXED] - Run iOS E2E tests on macOS 26 runners with Xcode 26.

## Test Plan:

- `git diff --check`
- `yarn prettier --check .github/workflow-scripts/maestro-ios.js .github/workflow-scripts/__tests__/maestro-ios-test.js .github/workflows/e2e-ios-rntester.yml .github/workflows/e2e-ios-templateapp.yml`
- `ruby -ryaml -e "ARGV.each { |path| YAML.parse_file(path) }" .github/workflows/e2e-ios-rntester.yml .github/workflows/e2e-ios-templateapp.yml`
- `node --check .github/workflow-scripts/maestro-ios.js`
- `yarn jest .github/workflow-scripts/__tests__/maestro-ios-test.js --runInBand --config '{"testEnvironment":"node","transform":{}}'`
