### PR TITLE
Cover `react/renderer/viewtransition:viewtransition` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_renderer_viewtransition PUBLIC ${REACT_COMMON_D
 
 target_link_libraries(react_renderer_viewtransition
         glog
+        react_cxxstableapi
         react_renderer_core
         react_renderer_mounting
         react_renderer_uimanager

--- a/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/viewtransition/ViewTransitionModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <queue>
 #include <unordered_set>
 


### PR DESCRIPTION
Summary:
Classifies `react/renderer/viewtransition:viewtransition` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to all three headers in the module and declares the guard dependency in the build config (parent podspec is already configured).

Changelog: [Internal]

Differential Revision: D116452310


