### PR TITLE
Add asset utils resource identifier tests

### DIFF
--- a/packages/asset-utils/src/__tests__/AndroidPathUtils-test.js
+++ b/packages/asset-utils/src/__tests__/AndroidPathUtils-test.js
@@ -8,7 +8,10 @@
  * @format
  */
 
-import {getAndroidResourceFolderName} from '../AndroidPathUtils';
+import {
+  getAndroidResourceFolderName,
+  getAndroidResourceIdentifier,
+} from '../AndroidPathUtils';
 
 const DRAWABLE_ASSET = {
   httpServerLocation: '/assets/',
@@ -68,5 +71,37 @@ describe('getAndroidResourceFolderName', () => {
     expect(getAndroidResourceFolderName(NON_DRAWABLE_ASSET, 0.75)).toBe('raw');
     expect(getAndroidResourceFolderName(NON_DRAWABLE_ASSET, 1)).toBe('raw');
     expect(getAndroidResourceFolderName(NON_DRAWABLE_ASSET, 1.25)).toBe('raw');
+  });
+});
+
+describe('getAndroidResourceIdentifier', () => {
+  test('encodes folder structure in the resource name', () => {
+    expect(
+      getAndroidResourceIdentifier({
+        httpServerLocation: '/assets/images/icons',
+        name: 'search',
+        type: 'png',
+      }),
+    ).toBe('images_icons_search');
+  });
+
+  test('normalizes resource names to Android identifier characters', () => {
+    expect(
+      getAndroidResourceIdentifier({
+        httpServerLocation: '/assets/images',
+        name: 'My Icon@2x',
+        type: 'png',
+      }),
+    ).toBe('images_myicon2x');
+  });
+
+  test('removes generated asset path prefixes', () => {
+    expect(
+      getAndroidResourceIdentifier({
+        httpServerLocation: '/assetsunstable_path/packages/app',
+        name: 'logo',
+        type: 'png',
+      }),
+    ).toBe('packages_app_logo');
   });
 });


### PR DESCRIPTION
## Summary:
Adds test coverage for `getAndroidResourceIdentifier` in `@react-native/asset-utils`.

The tests cover folder path encoding, Android resource-name normalization, and generated asset path prefix removal.

## Changelog:
[INTERNAL] - Add test coverage for asset utils Android resource identifier normalization

## Test Plan:
Verified the helper behavior with direct Node assertions.

Could not run Jest locally because dependencies are not installed in this checkout.