### PR TITLE
Fix NativeSyntheticEvent compatibility with BaseSyntheticEvent

### DIFF
--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -11,24 +11,24 @@
 import type {HostInstance} from '../../src/private/types/HostInstance';
 
 export type NativeSyntheticEvent<out T> = Readonly<{
-  bubbles: ?boolean,
-  cancelable: ?boolean,
+  bubbles: boolean,
+  cancelable: boolean,
   currentTarget: number | HostInstance,
-  defaultPrevented: ?boolean,
+  defaultPrevented: boolean,
   dispatchConfig: Readonly<{
     registrationName: string,
   }>,
-  eventPhase: ?number,
+  eventPhase: number,
   preventDefault: () => void,
   isDefaultPrevented: () => boolean,
   stopPropagation: () => void,
   isPropagationStopped: () => boolean,
-  isTrusted: ?boolean,
+  isTrusted: boolean,
   nativeEvent: T,
   persist: () => void,
   target: ?number | HostInstance,
   timeStamp: number,
-  type: ?string,
+  type: string,
 }>;
 
 export type ResponderSyntheticEvent<T> = Readonly<{

--- a/packages/react-native/ReactNativeApi.d.ts
+++ b/packages/react-native/ReactNativeApi.d.ts
@@ -3180,19 +3180,19 @@ declare type NativeScrollVelocity = {
   readonly y: number
 }
 declare type NativeSyntheticEvent<T> = {
-  readonly bubbles: boolean | undefined
-  readonly cancelable: boolean | undefined
+  readonly bubbles: boolean
+  readonly cancelable: boolean
   readonly currentTarget: HostInstance | number
-  readonly defaultPrevented: boolean | undefined
+  readonly defaultPrevented: boolean
   readonly dispatchConfig: {
     readonly registrationName: string
   }
-  readonly eventPhase: number | undefined
-  readonly isTrusted: boolean | undefined
+  readonly eventPhase: number
+  readonly isTrusted: boolean
   readonly nativeEvent: T
   readonly target: (number | undefined) | HostInstance
   readonly timeStamp: number
-  readonly type: string | undefined
+  readonly type: string
   readonly isDefaultPrevented: () => boolean
   readonly isPropagationStopped: () => boolean
   readonly persist: () => void

--- a/packages/react-native/__typetests__/index.tsx
+++ b/packages/react-native/__typetests__/index.tsx
@@ -391,6 +391,9 @@ processColor(Symbol('test'));
 const testNativeSyntheticEvent = <T extends {}>(
   e: NativeSyntheticEvent<T>,
 ): void => {
+  const baseEvent: React.BaseSyntheticEvent = e;
+  baseEvent.preventDefault();
+
   e.isDefaultPrevented();
   e.preventDefault();
   e.isPropagationStopped();


### PR DESCRIPTION
## Summary:

Fixes #57910.

The generated strict TypeScript definition of `NativeSyntheticEvent` allowed `undefined` for standard `BaseSyntheticEvent` fields such as `bubbles`, `cancelable`, and `defaultPrevented`. This made React Native event handlers incompatible with shared handlers accepting `React.BaseSyntheticEvent`, despite the legacy React Native definition extending that React type directly.

This change aligns the standard event fields with the React synthetic event contract and adds a type test that assigns a React Native event to `React.BaseSyntheticEvent`. The committed generated API snapshot is updated to match the Flow source.

## Changelog:

[GENERAL] [FIXED] - Restore `NativeSyntheticEvent` compatibility with React `BaseSyntheticEvent` in the strict TypeScript API

## Test Plan:

- Reproduced the original TS2322 failure with TypeScript 6.0.3 and `@types/react` 19.2.3.
- Confirmed the focused strict TypeScript compatibility test passes after the change.
- Added coverage to `packages/react-native/__typetests__/index.tsx`.
- CI: `yarn test-generated-typescript`