### PR TITLE
Fix initial underlineColorAndroid application in Fabric

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -13,8 +13,10 @@ import android.content.res.Configuration
 import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
+import android.graphics.PorterDuff
 import android.graphics.Rect
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.text.Editable
@@ -66,6 +68,7 @@ import com.facebook.react.uimanager.PixelUtil.toDIPFromPixel
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.drawable.CompositeBackgroundDrawable
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderStyle
@@ -138,6 +141,8 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   private var fontFamily: String? = null
   private var fontWeight = ReactConstants.UNSET
   private var fontStyle = ReactConstants.UNSET
+  private var hasUnderlineColor = false
+  private var underlineColor: Int? = null
   internal var parsedFontVariationSettings: String? = null
     private set
 
@@ -1056,6 +1061,39 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
 
   override fun setBackgroundColor(color: Int) {
     setBackgroundColor(this, color)
+  }
+
+  internal fun setUnderlineColor(color: Int?) {
+    hasUnderlineColor = true
+    underlineColor = color
+    applyUnderlineColor()
+  }
+
+  override fun setBackgroundDrawable(background: Drawable?) {
+    super.setBackgroundDrawable(background)
+    if (hasUnderlineColor) {
+      applyUnderlineColor()
+    }
+  }
+
+  private fun applyUnderlineColor() {
+    var drawableToMutate =
+        (background as? CompositeBackgroundDrawable)?.originalBackground ?: background ?: return
+
+    if (drawableToMutate.constantState != null) {
+      try {
+        drawableToMutate = checkNotNull(drawableToMutate.mutate())
+      } catch (e: NullPointerException) {
+        FLog.e(TAG, "NullPointerException when setting underlineColorAndroid for TextInput", e)
+      }
+    }
+
+    if (underlineColor == null) {
+      drawableToMutate.clearColorFilter()
+    } else {
+      @Suppress("DEPRECATION")
+      drawableToMutate.setColorFilter(checkNotNull(underlineColor), PorterDuff.Mode.SRC_IN)
+    }
   }
 
   public fun setBorderWidth(position: Int, width: Float) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -524,29 +524,7 @@ public open class ReactTextInputManager public constructor() :
 
   @ReactProp(name = "underlineColorAndroid", customType = "Color")
   public fun setUnderlineColor(view: ReactEditText, underlineColor: Int?) {
-    // Drawable.mutate() can sometimes crash due to an AOSP bug:
-    // See https://code.google.com/p/android/issues/detail?id=191754 for more info
-    val background = view.background
-    var drawableToMutate = background
-
-    if (background == null) {
-      return
-    }
-
-    if (background.constantState != null) {
-      try {
-        drawableToMutate = checkNotNull(background.mutate())
-      } catch (e: NullPointerException) {
-        FLog.e(TAG, "NullPointerException when setting underlineColorAndroid for TextInput", e)
-      }
-    }
-
-    if (underlineColor == null) {
-      drawableToMutate.clearColorFilter()
-    } else {
-      @Suppress("DEPRECATION")
-      drawableToMutate.setColorFilter(underlineColor, PorterDuff.Mode.SRC_IN)
-    }
+    view.setUnderlineColor(underlineColor)
   }
 
   @SuppressLint("WrongConstant")

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -12,6 +12,7 @@
 package com.facebook.react.views.textinput
 
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.text.InputFilter
 import android.text.InputFilter.AllCaps
@@ -94,6 +95,20 @@ class ReactTextInputPropertyTest {
     manager.updateProperties(view, buildStyles("autoCorrect", null))
     assertThat(view.inputType and InputType.TYPE_TEXT_FLAG_AUTO_CORRECT).isZero
     assertThat(view.inputType and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS).isZero
+  }
+
+  @Test
+  fun testUnderlineColorAppliedWhenBackgroundBecomesAvailable() {
+    view.background = null
+
+    manager.setUnderlineColor(view, Color.RED)
+
+    val background = ColorDrawable(Color.WHITE)
+    view.background = background
+    assertThat(background.colorFilter).isNotNull()
+
+    manager.setUnderlineColor(view, null)
+    assertThat(background.colorFilter).isNull()
   }
 
   @Test


### PR DESCRIPTION
## Summary:

Fixes #57921.

On Android Fabric, `underlineColorAndroid` can be applied before a `TextInput` has a background drawable. `ReactTextInputManager.setUnderlineColor` currently returns in that case, so the initial prop value is lost and is only applied after a later render.

This change moves underline color handling into `ReactEditText`, where the requested color is retained and reapplied when a background drawable becomes available. When React Native has wrapped the native background in a `CompositeBackgroundDrawable`, the color filter is applied to its original Android background instead of the wrapper.

A Robolectric regression test covers applying the prop while the background is null and then installing the background drawable.

## Changelog:

[ANDROID] [FIXED] - Apply `underlineColorAndroid` on the initial Fabric render when the TextInput background becomes available later

## Test Plan:

- Added `testUnderlineColorAppliedWhenBackgroundBecomesAvailable` to `ReactTextInputPropertyTest`.
- `git diff --check` passes.
- CI: `./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.views.textinput.ReactTextInputPropertyTest.testUnderlineColorAppliedWhenBackgroundBecomesAvailable`
- Not run locally: the Gradle distribution download was unavailable in the execution environment.

