### PR TITLE
Deduplicate the ArrayBuffer helpers and align the ObjC, C++ and JNI implementations (#58004)

### DIFF
--- a/packages/react-native/React/Base/RCTArrayBuffer.h
+++ b/packages/react-native/React/Base/RCTArrayBuffer.h
@@ -17,7 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  - `YES` — safe to retain and use from any thread (synchronize if aliasing JS
  *     memory).
  *  - `NO` — valid only during the synchronous call on the calling thread; copy with
- *    `arrayBufferWithCopiedBytes:length:` to keep the bytes.
+ *    `arrayBufferWithCopiedBytes:length:` to keep the bytes. Such a buffer must not be captured in
+ *    a block or handed to a callback or promise resolve block, which deliver after the call
+ *    returns. The TurboModule framework copies rather than aliases whenever the method signature
+ *    exposes a block parameter, and buffers nested inside `NSArray` or `NSDictionary` arguments
+ *    always own their bytes.
  */
 @interface RCTArrayBuffer : NSObject
 

--- a/packages/react-native/React/Base/RCTArrayBuffer.h
+++ b/packages/react-native/React/Base/RCTArrayBuffer.h
@@ -26,7 +26,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTArrayBuffer : NSObject
 
 /**
- * NULL when `length` is 0, non-NULL otherwise, matching `NSData.bytes`.
+ * NULL when `length` is 0, non-NULL otherwise, matching `NSData.bytes`. Holds for every factory: a
+ * zero-length buffer normalizes its pointer to NULL.
  */
 @property (nonatomic, readonly, nullable) void *mutableBytes NS_RETURNS_INNER_POINTER;
 

--- a/packages/react-native/React/Base/RCTArrayBuffer.mm
+++ b/packages/react-native/React/Base/RCTArrayBuffer.mm
@@ -23,12 +23,13 @@
 @end
 
 @implementation RCTArrayBuffer {
-  void *_bytes;
-  NSUInteger _length;
-  BOOL _owningBytes;
   void (^_cleanup)(void);
   std::vector<uint8_t> _copiedBytes;
 }
+
+@synthesize mutableBytes = _bytes;
+@synthesize length = _length;
+@synthesize owningBytes = _owningBytes;
 
 #pragma mark - Initializers
 
@@ -38,12 +39,17 @@
                             cleanup:(void (^)(void))cleanup
 {
   if (bytes == NULL && length != 0) {
+    // Nothing else will ever release whatever `bytes` was meant to be once this fails.
+    if (cleanup != nil) {
+      cleanup();
+    }
     [NSException raise:NSInvalidArgumentException
                 format:@"RCTArrayBuffer: NULL bytes with length %lu", (unsigned long)length];
   }
 
-  if (self = [super init]) {
-    _bytes = bytes;
+  if ((self = [super init]) != nil) {
+    // `mutableBytes` is documented as NULL exactly when empty.
+    _bytes = length == 0 ? NULL : bytes;
     _length = length;
     _owningBytes = owningBytes;
     _cleanup = [cleanup copy];
@@ -63,7 +69,7 @@
   }
 
   // Moving a vector hands over its heap buffer, so `data()` stays valid in `_copiedBytes`.
-  if (self = [self initWithBytesNoCopy:copy.data() length:length owningBytes:YES cleanup:nil]) {
+  if ((self = [self initWithBytesNoCopy:copy.data() length:length owningBytes:YES cleanup:nil]) != nil) {
     _copiedBytes = std::move(copy);
   }
   return self;
@@ -93,21 +99,6 @@
 
 #pragma mark - Accessors
 
-- (void *)mutableBytes
-{
-  return _bytes;
-}
-
-- (NSUInteger)length
-{
-  return _length;
-}
-
-- (BOOL)isOwningBytes
-{
-  return _owningBytes;
-}
-
 - (NSString *)description
 {
   return [NSString stringWithFormat:@"<%@: %p; length = %lu; owningBytes = %@>",
@@ -119,6 +110,7 @@
 
 - (void)dealloc
 {
+  // Runs on whichever thread drops the last reference, so cleanup blocks must be thread-agnostic.
   if (_cleanup != nil) {
     _cleanup();
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.cpp
@@ -8,10 +8,8 @@
 #include "JArrayBuffer.h"
 
 #include <cstring>
-#include <span>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 #include <react/bridging/ArrayBuffer.h>
 
@@ -49,19 +47,6 @@ jboolean JArrayBuffer::isBytesValid() {
   return hasBytes() ? JNI_TRUE : JNI_FALSE;
 }
 
-void JArrayBuffer::invalidate() noexcept {
-  if (!owningBytes_) {
-    buffer_.reset();
-  }
-}
-
-const std::shared_ptr<jsi::MutableBuffer>& JArrayBuffer::mutableBuffer() const {
-  if (!hasBytes()) {
-    throw std::runtime_error(kRevokedBorrowMessage);
-  }
-  return buffer_;
-}
-
 jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::create(
     jni::local_ref<jni::JByteBuffer> byteBuffer,
     std::shared_ptr<jsi::MutableBuffer> buffer,
@@ -72,22 +57,13 @@ jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::create(
   return javaPart;
 }
 
-jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwning(
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createWithOwnedBytes(
     std::shared_ptr<jsi::MutableBuffer> buffer) {
   auto byteBuffer = jni::JByteBuffer::wrapBytes(buffer->data(), buffer->size());
   return create(std::move(byteBuffer), std::move(buffer), true);
 }
 
-jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createUnowned(
-    void* bytes,
-    size_t size) {
-  auto byteBuffer =
-      jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(bytes), size);
-  auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
-  return create(std::move(byteBuffer), std::move(buffer), false);
-}
-
-jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwned(
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createWithCopiedBytes(
     const void* bytes,
     size_t size) {
   auto byteBuffer = jni::JByteBuffer::allocateDirect(static_cast<jint>(size));
@@ -98,6 +74,15 @@ jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createOwned(
 
   auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
   return create(std::move(byteBuffer), std::move(buffer), true);
+}
+
+jni::local_ref<JArrayBuffer::javaobject> JArrayBuffer::createWithUnownedBytes(
+    void* bytes,
+    size_t size) {
+  auto byteBuffer =
+      jni::JByteBuffer::wrapBytes(static_cast<uint8_t*>(bytes), size);
+  auto buffer = std::make_shared<JByteBufferMutableBuffer>(byteBuffer);
+  return create(std::move(byteBuffer), std::move(buffer), false);
 }
 
 std::shared_ptr<jsi::MutableBuffer> JArrayBuffer::toJSBuffer(
@@ -115,15 +100,26 @@ std::shared_ptr<jsi::MutableBuffer> JArrayBuffer::toJSBuffer(
   }
 
   const auto& buffer = self->mutableBuffer();
-  if (self->owningBytes_) {
+  if (self->isOwningBytes()) {
     return buffer;
   }
 
   // Borrowed bytes still belong to the inbound JS ArrayBuffer; copy them before
   // handing a new buffer back to JS.
-  auto bytes = std::span<uint8_t>(buffer->data(), buffer->size());
-  return std::make_shared<detail::OwnedBytesBuffer>(
-      std::vector<uint8_t>(bytes.begin(), bytes.end()));
+  return detail::copyToOwnedBuffer(buffer->data(), buffer->size());
+}
+
+const std::shared_ptr<jsi::MutableBuffer>& JArrayBuffer::mutableBuffer() const {
+  if (!hasBytes()) {
+    throw std::runtime_error(kRevokedBorrowMessage);
+  }
+  return buffer_;
+}
+
+void JArrayBuffer::invalidate() noexcept {
+  if (!owningBytes_) {
+    buffer_.reset();
+  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JArrayBuffer.h
@@ -28,27 +28,22 @@ class JArrayBuffer : public jni::HybridClass<JArrayBuffer> {
 
   // JS ArrayBuffer with a native MutableBuffer (tryGetMutableBuffer). Retain
   // the owner so the bytes stay valid after the call.
-  static jni::local_ref<javaobject> createOwning(std::shared_ptr<jsi::MutableBuffer> buffer);
-
-  // JS-heap bytes passed to a synchronous call. Zero-copy for the call only;
-  // do not retain the result.
-  static jni::local_ref<javaobject> createUnowned(void *bytes, size_t size);
+  static jni::local_ref<javaobject> createWithOwnedBytes(std::shared_ptr<jsi::MutableBuffer> buffer);
 
   // Copy JS-heap bytes into a new owned buffer. Used for async/promise calls
   // and anywhere the module needs its own copy of the data.
-  static jni::local_ref<javaobject> createOwned(const void *bytes, size_t size);
+  static jni::local_ref<javaobject> createWithCopiedBytes(const void *bytes, size_t size);
+
+  // JS-heap bytes passed to a synchronous call. Zero-copy for the call only;
+  // do not retain the result. No Kotlin equivalent by design: only the
+  // TurboModule bridge may lend out JS-heap bytes.
+  static jni::local_ref<javaobject> createWithUnownedBytes(void *bytes, size_t size);
 
   // Convert a module return value for rt.createArrayBuffer. Owning buffers pass
   // through; borrowed ones are copied because createArrayBuffer needs its own
   // backing store. Raises a jsi::JSError if the buffer has no native peer or
   // its borrow has been revoked.
   static std::shared_ptr<jsi::MutableBuffer> toJSBuffer(jsi::Runtime &runtime, jni::alias_ref<javaobject> arrayBuffer);
-
-  // Revokes access to borrowed bytes. Called when the call frame that lent the
-  // bytes unwinds, so a module that retained a non-owning ArrayBuffer gets an
-  // exception instead of reading memory the JS heap has moved or freed. Owning
-  // buffers are unaffected.
-  void invalidate() noexcept;
 
   // The bytes this buffer was created over. Throws if a borrow has since been
   // revoked by invalidate().
@@ -65,6 +60,12 @@ class JArrayBuffer : public jni::HybridClass<JArrayBuffer> {
   {
     return owningBytes_;
   }
+
+  // Revokes access to borrowed bytes. Called when the call frame that lent the
+  // bytes unwinds, so a module that retained a non-owning ArrayBuffer gets an
+  // exception instead of reading memory the JS heap has moved or freed. Owning
+  // buffers are unaffected.
+  void invalidate() noexcept;
 
   JArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer, bool owningBytes) noexcept
       : buffer_(std::move(buffer)), owningBytes_(owningBytes)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/test/JArrayBufferTest.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/test/JArrayBufferTest.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/bridging/ArrayBuffer.h>
 #include <react/jni/JArrayBuffer.h>
 #include <react/jni/JByteBufferMutableBuffer.h>
 
@@ -19,22 +20,9 @@ namespace facebook::react {
 
 namespace {
 
-class TestBuffer final : public jsi::MutableBuffer {
- public:
-  explicit TestBuffer(std::vector<uint8_t> bytes) noexcept
-      : bytes_(std::move(bytes)) {}
-
-  size_t size() const override {
-    return bytes_.size();
-  }
-
-  uint8_t* data() override {
-    return bytes_.data();
-  }
-
- private:
-  std::vector<uint8_t> bytes_;
-};
+std::shared_ptr<jsi::MutableBuffer> makeBuffer(std::vector<uint8_t> bytes) {
+  return std::make_shared<detail::OwnedBytesBuffer>(std::move(bytes));
+}
 
 } // namespace
 
@@ -47,7 +35,7 @@ class TestBuffer final : public jsi::MutableBuffer {
  */
 
 TEST(JArrayBufferTest, owningBufferExposesItsBytes) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   JArrayBuffer arrayBuffer{buffer, true};
 
   EXPECT_TRUE(arrayBuffer.isOwningBytes());
@@ -55,7 +43,7 @@ TEST(JArrayBufferTest, owningBufferExposesItsBytes) {
 }
 
 TEST(JArrayBufferTest, borrowedBufferExposesItsBytesBeforeInvalidation) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   JArrayBuffer arrayBuffer{buffer, false};
 
   EXPECT_FALSE(arrayBuffer.isOwningBytes());
@@ -69,7 +57,7 @@ TEST(JArrayBufferTest, borrowedBufferExposesItsBytesBeforeInvalidation) {
  * occupies that memory.
  */
 TEST(JArrayBufferTest, invalidateRevokesABorrow) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   JArrayBuffer arrayBuffer{buffer, false};
 
   arrayBuffer.invalidate();
@@ -78,7 +66,7 @@ TEST(JArrayBufferTest, invalidateRevokesABorrow) {
 }
 
 TEST(JArrayBufferTest, invalidateLeavesAnOwningBufferUsable) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   JArrayBuffer arrayBuffer{buffer, true};
 
   arrayBuffer.invalidate();
@@ -87,7 +75,7 @@ TEST(JArrayBufferTest, invalidateLeavesAnOwningBufferUsable) {
 }
 
 TEST(JArrayBufferTest, invalidateIsIdempotent) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   JArrayBuffer arrayBuffer{buffer, false};
 
   arrayBuffer.invalidate();
@@ -100,7 +88,7 @@ TEST(JArrayBufferTest, invalidateIsIdempotent) {
 // aliasing adapter (and the JNI global ref inside it) is torn down with the
 // call frame rather than at the whim of the Java GC.
 TEST(JArrayBufferTest, invalidateReleasesTheBorrowedBuffer) {
-  auto buffer = std::make_shared<TestBuffer>(std::vector<uint8_t>{1, 2, 3});
+  auto buffer = makeBuffer({1, 2, 3});
   std::weak_ptr<jsi::MutableBuffer> weakBuffer = buffer;
   JArrayBuffer arrayBuffer{std::move(buffer), false};
 

--- a/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/bridging/ArrayBuffer.h>
+
+#include <atomic>
+#include <span>
+#include <string>
+
+namespace facebook::react::detail {
+
+void throwIfDetached(
+    jsi::Runtime& rt,
+    const jsi::ArrayBuffer& buffer,
+    const char* callerName) {
+  // Latched the first time a runtime rejects the check, so the property get and
+  // the thrown-and-caught exception are paid once rather than per conversion.
+  // Process-wide because every runtime in a process shares one engine build.
+  static std::atomic<bool> unsupported{false};
+  if (unsupported.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  bool detached = false;
+  try {
+    detached = buffer.detached(rt);
+  } catch (const jsi::JSINativeException&) {
+    unsupported.store(true, std::memory_order_relaxed);
+    return;
+  }
+  if (detached) {
+    throw jsi::JSError(
+        rt, std::string(callerName) + ": ArrayBuffer is detached");
+  }
+}
+
+std::shared_ptr<jsi::MutableBuffer> copyToOwnedBuffer(
+    const uint8_t* bytes,
+    size_t size) {
+  if (size == 0) {
+    return std::make_shared<OwnedBytesBuffer>(std::vector<uint8_t>{});
+  }
+  auto span = std::span<const uint8_t>(bytes, size);
+  return std::make_shared<OwnedBytesBuffer>(
+      std::vector<uint8_t>(span.begin(), span.end()));
+}
+
+} // namespace facebook::react::detail

--- a/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.h
+++ b/packages/react-native/ReactCommon/react/bridging/ArrayBuffer.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <span>
-#include <string>
+#include <memory>
+#include <vector>
 
 #include <react/bridging/Base.h>
 
@@ -39,6 +39,20 @@ class OwnedBytesBuffer final : public jsi::MutableBuffer {
  private:
   std::vector<uint8_t> bytes_;
 };
+
+/**
+ * Best-effort detached check. jsi::ArrayBuffer::detached relies on the JS-level
+ * `detached` property, which some runtimes (e.g. Hermes) don't implement and
+ * signal by throwing. In that case we silently skip the check rather than
+ * surfacing a confusing error from an unrelated method, and remember that the
+ * runtime rejected it so later calls skip it for free.
+ */
+void throwIfDetached(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer, const char *callerName);
+
+/**
+ * Copies bytes into a new owning buffer. `bytes` may be null when `size` is 0.
+ */
+std::shared_ptr<jsi::MutableBuffer> copyToOwnedBuffer(const uint8_t *bytes, size_t size);
 
 } // namespace detail
 
@@ -77,7 +91,7 @@ class AsyncArrayBuffer {
   // Zero-copy if the input has a native MutableBuffer; copies otherwise.
   static AsyncArrayBuffer acquire(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
   {
-    throwIfDetached(rt, buffer, "AsyncArrayBuffer::acquire");
+    detail::throwIfDetached(rt, buffer, "AsyncArrayBuffer::acquire");
     if (auto mutableBuf = buffer.tryGetMutableBuffer(rt)) {
       return AsyncArrayBuffer{std::move(mutableBuf)};
     }
@@ -87,7 +101,7 @@ class AsyncArrayBuffer {
   // Zero-copy. Throws if the input has no native MutableBuffer.
   static AsyncArrayBuffer borrow(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
   {
-    throwIfDetached(rt, buffer, "AsyncArrayBuffer::borrow");
+    detail::throwIfDetached(rt, buffer, "AsyncArrayBuffer::borrow");
     auto mutableBuf = buffer.tryGetMutableBuffer(rt);
     if (!mutableBuf) {
       throw jsi::JSError(
@@ -101,7 +115,7 @@ class AsyncArrayBuffer {
   // Always copies.
   static AsyncArrayBuffer copy(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
   {
-    throwIfDetached(rt, buffer, "AsyncArrayBuffer::copy");
+    detail::throwIfDetached(rt, buffer, "AsyncArrayBuffer::copy");
     return copyBytes(rt, buffer);
   }
 
@@ -140,30 +154,12 @@ class AsyncArrayBuffer {
     return buffer_;
   }
 
-  // Best-effort detached check. jsi::ArrayBuffer::detached relies on the JS-level
-  // `detached` property, which some runtimes (e.g. Hermes) don't implement and
-  // signal by throwing. In that case we silently skip the check rather than
-  // surfacing a confusing error from an unrelated method.
-  static void throwIfDetached(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer, const char *callerName)
-  {
-    bool detached = false;
-    try {
-      detached = buffer.detached(rt);
-    } catch (const jsi::JSINativeException &) {
-      return;
-    }
-    if (detached) {
-      throw jsi::JSError(rt, std::string(callerName) + ": ArrayBuffer is detached");
-    }
-  }
-
  private:
   explicit AsyncArrayBuffer(std::shared_ptr<jsi::MutableBuffer> buffer) noexcept : buffer_{std::move(buffer)} {}
 
   static AsyncArrayBuffer copyBytes(jsi::Runtime &rt, const jsi::ArrayBuffer &buffer)
   {
-    auto bytes = std::span(buffer.data(rt), buffer.size(rt));
-    return wrap(std::vector<uint8_t>(bytes.begin(), bytes.end()));
+    return AsyncArrayBuffer{detail::copyToOwnedBuffer(buffer.data(rt), buffer.size(rt))};
   }
 
   std::shared_ptr<jsi::MutableBuffer> buffer_;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/iostests/RCTTurboModuleTests.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/iostests/RCTTurboModuleTests.mm
@@ -11,6 +11,7 @@
 #import <ReactCommon/RCTTurboModule.h>
 #import <hermes/hermes.h>
 #import <jsi/decorator.h>
+#import <react/bridging/ArrayBuffer.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 
@@ -47,52 +48,6 @@ RCT_EXPORT_METHOD(testMethodWhichTakesObject : (id)object) {}
 }
 
 @end
-
-@interface RCTThrowingTurboModule : NSObject <RCTBridgeModule>
-
-@end
-
-@implementation RCTThrowingTurboModule
-
-RCT_EXPORT_MODULE()
-
-// A plain `NSArray *` parameter has no element converter to sanitise it (unlike, say,
-// `NSArray<NSString *> *`, which RCTConvert routes through `NSStringArray:` and which drops nulls),
-// so `convertJSIArrayToNSArray` substituting `[NSNull null]` for a null element to preserve the
-// indices is what this loop actually receives from a JS caller passing `['a', null]`.
-RCT_EXPORT_METHOD(testMethodWhichReadsStringsFromArray : (NSArray *)items)
-{
-  for (NSUInteger i = 0; i < items.count; i++) {
-    (void)[(NSString *)items[i] length];
-  }
-}
-
-@end
-
-class ReactNativeFeatureFlagsNSNullConversionEnabled : public ReactNativeFeatureFlagsDefaults {
- public:
-  bool enableModuleArgumentNSNullConversionIOS() override
-  {
-    return true;
-  }
-};
-
-// Minimal concrete MutableBuffer that owns its bytes, used to observe lifetime.
-class TestMutableBuffer : public facebook::jsi::MutableBuffer {
- public:
-  explicit TestMutableBuffer(size_t size) : bytes_(size, 0) {}
-  size_t size() const override
-  {
-    return bytes_.size();
-  }
-  uint8_t *data() override
-  {
-    return bytes_.data();
-  }
-
- private:
-  std::vector<uint8_t> bytes_;
-};
 
 // `jsi::Runtime::tryGetMutableBuffer` is optional — the Hermes branch linked into apps returns
 // nullptr for every ArrayBuffer — so decorate the runtime to answer it for the buffers created
@@ -363,7 +318,7 @@ class ExceptionCapturingNativeMethodCallInvoker : public NativeMethodCallInvoker
   auto hermesRuntime = facebook::hermes::makeHermesRuntime();
   MutableBufferAwareRuntime runtime(*hermesRuntime);
 
-  auto buffer = std::make_shared<TestMutableBuffer>(kBufferSize);
+  auto buffer = std::make_shared<detail::OwnedBytesBuffer>(std::vector<uint8_t>(kBufferSize, 0));
   *buffer->data() = 0xAB;
   const uint8_t *sourceBytes = buffer->data();
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -8,6 +8,8 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <mutex>
+#include <stdexcept>
 #include <string>
 
 #include <cxxreact/TraceSection.h>
@@ -466,7 +468,7 @@ JNIArgs convertJSIArgsToJNIArgs(
       }
 
       auto arrayBuffer = arg->getObject(rt).getArrayBuffer(rt);
-      AsyncArrayBuffer::throwIfDetached(
+      detail::throwIfDetached(
           rt, arrayBuffer, "JavaTurboModule::convertJSIArgsToJNIArgs");
 
       auto size = arrayBuffer.size(rt);
@@ -476,16 +478,21 @@ JNIArgs convertJSIArgsToJNIArgs(
             "JavaTurboModule::convertJSIArgsToJNIArgs: ArrayBuffer exceeds maximum size.");
       }
 
-      // Runtimes without a native buffer for this ArrayBuffer return nullptr,
-      // but the Static Hermes tracing runtime throws instead, and argument
-      // conversion runs outside any std::exception handler. Treat a failed
-      // probe as "no native buffer" so a traced session copies the bytes rather
-      // than aborting the process.
+      // Runtimes without a native buffer return nullptr, but the Static Hermes
+      // tracing runtime signals that by throwing std::logic_error. Treat a
+      // failed probe as "no native buffer" so a traced session copies rather
+      // than aborting; anything else is a real failure and propagates.
       std::shared_ptr<jsi::MutableBuffer> mutableBuffer;
       try {
         mutableBuffer = arrayBuffer.tryGetMutableBuffer(rt);
-      } catch (const std::exception&) {
-        mutableBuffer = nullptr;
+      } catch (const std::logic_error& e) {
+        static std::once_flag warnOnce;
+        std::call_once(warnOnce, [&] {
+          LOG(WARNING)
+              << "JavaTurboModule::convertJSIArgsToJNIArgs: tryGetMutableBuffer is unsupported by this runtime ("
+              << e.what()
+              << "); ArrayBuffer arguments will be copied instead of aliased";
+        });
       }
 
       bool borrowsJSBytes = false;
@@ -493,18 +500,21 @@ JNIArgs convertJSIArgsToJNIArgs(
         // Backed by a native buffer: alias it and retain its owner, so the
         // bytes stay valid for as long as the module holds the ArrayBuffer.
         if (mutableBuffer) {
-          return JArrayBuffer::createOwning(std::move(mutableBuffer));
+          return JArrayBuffer::createWithOwnedBytes(std::move(mutableBuffer));
         }
 
         // JS heap bytes on a synchronous call: lend them for the duration of
-        // the call.
+        // the call. Unlike iOS, which copies whenever the method signature
+        // exposes a block, a module that retains the buffer here gets an
+        // IllegalStateException from the revocation below.
         if (isSyncInvocation) {
           borrowsJSBytes = true;
-          return JArrayBuffer::createUnowned(arrayBuffer.data(rt), size);
+          return JArrayBuffer::createWithUnownedBytes(
+              arrayBuffer.data(rt), size);
         }
 
         // JS heap bytes that outlive the call: copy.
-        return JArrayBuffer::createOwned(arrayBuffer.data(rt), size);
+        return JArrayBuffer::createWithCopiedBytes(arrayBuffer.data(rt), size);
       }();
 
       if (borrowsJSBytes) {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -210,11 +210,29 @@ convertJSIFunctionToCallback(jsi::Runtime &rt, jsi::Function &&function, const s
   };
 }
 
+// A block parameter means the module can hand an argument to a callback it invokes after the call
+// returns, so nothing passed to such a method may alias the JS heap.
+static BOOL methodSignatureTakesBlock(NSMethodSignature *methodSignature)
+{
+  const char *BLOCK_TYPE = @encode(
+      __typeof__(^{
+      }));
+
+  for (NSUInteger i = 2; i < methodSignature.numberOfArguments; i++) {
+    const std::string objCArgType = [methodSignature getArgumentTypeAtIndex:i];
+    if (objCArgType == BLOCK_TYPE) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 // Native-backed buffers are aliased and keep their backing store alive, so they stay valid for
 // as long as the module holds them. JS-heap buffers have nothing to retain — their bytes are
 // freed when the ArrayBuffer is collected or detached — so `mustCopyBytes` is set whenever the
-// invocation may outlive the JS call, and they are aliased only when it cannot. Engines that
-// don't hand out the backing MutableBuffer fall back to those JS-heap rules for every buffer.
+// invocation may outlive the JS call (an async return kind, or a block parameter the module can
+// call later), and they are aliased only when it cannot. Engines that don't hand out the backing
+// MutableBuffer fall back to those JS-heap rules for every buffer.
 static RCTArrayBuffer *
 convertJSIArrayBufferToRCTArrayBuffer(jsi::Runtime &rt, const jsi::ArrayBuffer &arrayBuffer, BOOL mustCopyBytes)
 {
@@ -849,10 +867,15 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
   NSInvocation *inv = [NSInvocation invocationWithMethodSignature:methodSignature];
   [inv setSelector:selector];
 
+  // A block argument can outlive the call, and JS drains it asynchronously, so an ArrayBuffer the
+  // module hands to it must own its bytes even when the method itself returns synchronously.
+  BOOL mustCopyArrayBufferBytes = mustCopyBytes || methodSignatureTakesBlock(methodSignature);
+
   for (size_t i = 0; i < count; i++) {
     const jsi::Value &arg = args[i];
     const std::string objCArgType = [methodSignature getArgumentTypeAtIndex:i + 2];
-    setInvocationArg(runtime, methodName, objCArgType, arg, i, inv, retainedObjectsForInvocation, mustCopyBytes);
+    setInvocationArg(
+        runtime, methodName, objCArgType, arg, i, inv, retainedObjectsForInvocation, mustCopyArrayBufferBytes);
   }
 
   if (isSync) {

--- a/packages/rn-tester/RNTesterUnitTests/RCTTurboModuleArrayBufferTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTTurboModuleArrayBufferTests.mm
@@ -14,6 +14,7 @@
 #import <hermes/hermes.h>
 #import <react/bridging/ArrayBuffer.h>
 
+#import <array>
 #import <list>
 #import <vector>
 
@@ -140,6 +141,15 @@ RCT_EXPORT_MODULE()
 - (void)testMethodWhichStoresArrayBuffer:(RCTArrayBuffer *)payload
 {
   self.lastReceivedPayload = [NSData dataWithBytes:payload.mutableBytes length:payload.length];
+}
+
+- (NSNumber *)testMethodWhichPassesArrayBufferToCallback:(RCTArrayBuffer *)buffer
+                                                callback:(RCTResponseSenderBlock)callback
+{
+  // The buffer escapes into a callback JS drains after this method returns, so the framework must
+  // have handed us a copy rather than an alias of the JS heap.
+  callback(@[ buffer ]);
+  return @(buffer.isOwningBytes);
 }
 
 - (void)testMethodWhichCallsBackWithArrayBuffer:(double)size callback:(RCTResponseSenderBlock)callback
@@ -442,6 +452,69 @@ RCT_EXPORT_MODULE()
   XCTAssertEqual(callbackBytes[0], 0);
   XCTAssertEqual(callbackBytes[1], 1);
   XCTAssertEqual(callbackBytes[2], 2);
+}
+
+// A sync method that hands its argument to a callback lets the buffer escape the call, so the
+// argument must be copied even though the return kind would otherwise allow aliasing.
+- (void)testArrayBufferIsCopiedWhenAMethodTakesACallback
+{
+  auto hermesRuntime = createHermesRuntime();
+  facebook::jsi::Runtime *rt = hermesRuntime.get();
+  auto jsInvoker = std::make_shared<TestCallInvoker>(*rt);
+  auto *instance = [RCTTestArrayBufferTurboModule new];
+
+  ObjCTurboModule::InitParams params = {
+      .moduleName = "TestModule",
+      .instance = instance,
+      .jsInvoker = jsInvoker,
+      .nativeMethodCallInvoker = std::make_shared<ImmediateNativeMethodCallInvoker>(),
+      .isSyncModule = false,
+  };
+  ObjCTurboModule module(params);
+
+  auto sourceBuffer = rt->global()
+                          .getPropertyAsFunction(*rt, "eval")
+                          .call(*rt, "new Uint8Array([1, 2, 3]).buffer")
+                          .asObject(*rt)
+                          .getArrayBuffer(*rt);
+
+  std::vector<uint8_t> callbackBytes;
+  auto onCallback = facebook::jsi::Function::createFromHostFunction(
+      *rt,
+      facebook::jsi::PropNameID::forAscii(*rt, "onCallback"),
+      1,
+      [&callbackBytes](
+          facebook::jsi::Runtime &runtime,
+          const facebook::jsi::Value &,
+          const facebook::jsi::Value *callbackArgs,
+          size_t count) -> facebook::jsi::Value {
+        if (count == 1) {
+          const auto &callbackArg = *callbackArgs;
+          if (callbackArg.isObject() && callbackArg.asObject(runtime).isArrayBuffer(runtime)) {
+            callbackBytes = bytesFromArrayBuffer(runtime, callbackArg.asObject(runtime).getArrayBuffer(runtime));
+          }
+        }
+        return facebook::jsi::Value::undefined();
+      });
+  std::array<facebook::jsi::Value, 2> args = {
+      facebook::jsi::Value(*rt, sourceBuffer), facebook::jsi::Value(*rt, onCallback)};
+
+  auto result = module.invokeObjCMethod(
+      *rt,
+      BooleanKind,
+      "testMethodWhichPassesArrayBufferToCallback",
+      @selector(testMethodWhichPassesArrayBufferToCallback:callback:),
+      args.data(),
+      2);
+
+  XCTAssertTrue(result.getBool(), @"A buffer that can escape into a callback must own its bytes");
+
+  jsInvoker->flushQueue();
+
+  XCTAssertEqual(callbackBytes.size(), 3u);
+  XCTAssertEqual(callbackBytes[0], 1);
+  XCTAssertEqual(callbackBytes[1], 2);
+  XCTAssertEqual(callbackBytes[2], 3);
 }
 
 - (void)testPromiseResolvesArrayBuffer

--- a/packages/rn-tester/RNTesterUnitTests/RCTTurboModuleArrayBufferTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTTurboModuleArrayBufferTests.mm
@@ -571,4 +571,23 @@ RCT_EXPORT_MODULE()
   XCTAssertEqual(resolvedBytes[3], 3);
 }
 
+// +arrayBufferWithOwnedBytes:length:cleanup: takes ownership of `bytes` via `cleanup`, so raising
+// without running the block leaks the caller's allocation.
+- (void)testOwnedBytesCleanupRunsBeforeRaisingOnNullBytes
+{
+  __block BOOL cleanupRan = NO;
+
+  XCTAssertThrowsSpecificNamed(
+      [RCTArrayBuffer arrayBufferWithOwnedBytes:NULL
+                                         length:4
+                                        cleanup:^{
+                                          cleanupRan = YES;
+                                        }],
+      // NOLINTNEXTLINE(misc-throw-by-value-catch-by-reference) - XCTest catches this class as a pointer
+      NSException,
+      NSInvalidArgumentException,
+      @"NULL bytes with a non-zero length must raise");
+  XCTAssertTrue(cleanupRan, @"The cleanup block must run before the initializer raises, or its bytes leak");
+}
+
 @end

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1659,7 +1659,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2811,9 +2810,9 @@ class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::J
   public bool isOwningBytes() const noexcept;
   public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
-  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
-  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
-  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithCopiedBytes(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithOwnedBytes(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createWithUnownedBytes(void* bytes, size_t size);
   public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
   public void invalidate() noexcept;
@@ -10106,6 +10105,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -10128,6 +10128,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -1653,7 +1653,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2769,9 +2768,9 @@ class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::J
   public bool isOwningBytes() const noexcept;
   public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
-  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
-  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
-  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithCopiedBytes(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithOwnedBytes(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createWithUnownedBytes(void* bytes, size_t size);
   public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
   public void invalidate() noexcept;
@@ -9719,6 +9718,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -9741,6 +9741,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1657,7 +1657,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -2808,9 +2807,9 @@ class facebook::react::JArrayBuffer : public jni::HybridClass<facebook::react::J
   public bool isOwningBytes() const noexcept;
   public const std::shared_ptr<facebook::jsi::MutableBuffer>& mutableBuffer() const;
   public static constexpr auto kJavaDescriptor;
-  public static jni::local_ref<javaobject> createOwned(const void* bytes, size_t size);
-  public static jni::local_ref<javaobject> createOwning(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
-  public static jni::local_ref<javaobject> createUnowned(void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithCopiedBytes(const void* bytes, size_t size);
+  public static jni::local_ref<javaobject> createWithOwnedBytes(std::shared_ptr<facebook::jsi::MutableBuffer> buffer);
+  public static jni::local_ref<javaobject> createWithUnownedBytes(void* bytes, size_t size);
   public static std::shared_ptr<facebook::jsi::MutableBuffer> toJSBuffer(facebook::jsi::Runtime& runtime, jni::alias_ref<javaobject> arrayBuffer);
   public static void registerNatives();
   public void invalidate() noexcept;
@@ -9950,6 +9949,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -9972,6 +9972,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4261,7 +4261,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -11996,6 +11995,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -12018,6 +12018,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -4248,7 +4248,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -11675,6 +11674,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -11697,6 +11697,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4259,7 +4259,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -11850,6 +11849,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -11872,6 +11872,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -983,7 +983,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -7107,6 +7106,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -7129,6 +7129,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -978,7 +978,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -6931,6 +6930,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -6953,6 +6953,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -981,7 +981,6 @@ class facebook::react::AsyncArrayBuffer {
   public static facebook::react::AsyncArrayBuffer copy(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer);
   public static facebook::react::AsyncArrayBuffer wrap(std::shared_ptr<facebook::jsi::MutableBuffer> buffer) noexcept;
   public static facebook::react::AsyncArrayBuffer wrap(std::vector<uint8_t> bytes);
-  public static void throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
   public std::shared_ptr<facebook::jsi::MutableBuffer> getMutableBuffer() const noexcept;
   public uint8_t* data() noexcept;
   public ~AsyncArrayBuffer() = default;
@@ -7098,6 +7097,7 @@ constexpr uint8_t facebook::react::detail::clampAlpha(std::optional<float> alpha
 constexpr uint8_t facebook::react::detail::hexToNumeric(std::string_view hex, facebook::react::detail::HexColorType hexType);
 float facebook::react::detail::normalizeHue(float hue);
 std::optional<float> facebook::react::detail::normalizeHueComponent(const std::variant<std::monostate, facebook::react::CSSNumber, facebook::react::CSSAngle>& component);
+std::shared_ptr<facebook::jsi::MutableBuffer> facebook::react::detail::copyToOwnedBuffer(const uint8_t* bytes, size_t size);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hslToRgb(float h, float s, float l);
 std::tuple<uint8_t, uint8_t, uint8_t> facebook::react::detail::hwbToRgb(float h, float w, float b);
 template <CSSDataType... FirstComponentAllowedTypesT>
@@ -7120,6 +7120,7 @@ template <typename T, typename C>
 C facebook::react::detail::memberFunctionClass(T C::*);
 template <typename... ComponentT>
 constexpr std::optional<float> facebook::react::detail::normalizeComponent(const std::variant<std::monostate, ComponentT...>& component, float baseValue);
+void facebook::react::detail::throwIfDetached(facebook::jsi::Runtime& rt, const facebook::jsi::ArrayBuffer& buffer, const char* callerName);
 
 class facebook::react::detail::OwnedBytesBuffer : public facebook::jsi::MutableBuffer {
   public OwnedBytesBuffer(std::vector<uint8_t> bytes) noexcept;


### PR DESCRIPTION
Summary:

Follow-up cleanup on the `ArrayBuffer` TurboModule plumbing. No behaviour change except
the leak fix below.

- Move `detail::throwIfDetached` out of the header into a new
  `react/bridging/ArrayBuffer.cpp`, and drop the `AsyncArrayBuffer::throwIfDetached`
  wrapper that only forwarded to it. The JNI path now calls `detail::throwIfDetached`
  directly instead of going through `AsyncArrayBuffer`.
- Add `detail::copyToOwnedBuffer`, so the C++ bridging path and the tests build an
  owning buffer the same way instead of each hand-rolling a `std::vector` copy. The
  header no longer needs `<span>`/`<string>`.
- Rename the `JArrayBuffer` factories to say what they do about ownership:
  `createOwning`/`createOwned`/`createUnowned` become
  `createWithOwnedBytes`/`createWithCopiedBytes`/`createWithUnownedBytes`, matching the
  `RCTArrayBuffer` naming. Move `invalidate()` next to the other private members.
- `RCTArrayBuffer` uses `synthesize` rather than three hand-written accessors, and
  normalizes `mutableBytes` to NULL for a zero-length buffer so the documented
  "NULL exactly when empty" invariant holds for every factory.
- Run the caller's `cleanup` block before the designated initializer raises on a
  NULL/non-zero-length mismatch. Nothing else would ever release those bytes, so
  raising first leaked them.
- Treat only `std::logic_error` from `tryGetMutableBuffer` as "this runtime has no
  native buffer" on the JNI path, and log it once, instead of swallowing every
  `std::exception`.
- Keep the macOS mirror of `RCTArrayBuffer` byte-identical to the iOS one.

Changelog:
[General][Changed] - Rename the internal JArrayBuffer factories and deduplicate the ArrayBuffer helpers

Differential Revision: D116358593


