### PR TITLE
Cover `react/networking:networking` with Stable API guards (#58008)

### DIFF
--- a/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(react_networking
         folly_runtime
         jsinspector_network
         jsinspector_tracing
+        react_cxxstableapi
         react_performance_timeline
         react_timing)
 

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "NetworkTypes.h"
 
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/react/networking/NetworkTypes.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkTypes.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <map>
 #include <optional>
 #include <string>

--- a/packages/react-native/ReactCommon/react/networking/React-networking.podspec
+++ b/packages/react-native/ReactCommon/react/networking/React-networking.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-performancetimeline"
   s.dependency "React-timing"
+  s.dependency "React-cxxstableapi"
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)


### PR DESCRIPTION
Summary:

Classifies `react/networking:networking` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to both of the module's exported headers (`NetworkReporter.h`, `NetworkTypes.h`), and wires the guard dependency into BUCK, CMake, and the podspec.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Differential Revision: D116591313


