### PR TITLE
Add strict API support for `react/renderer/components/*` private targets (#58009)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -167,6 +167,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/image/",
                           "react/renderer/components/image/",
                       ),
+                      Pair(
+                          "../ReactCommon/react/renderer/components/image/React/",
+                          "React/",
+                      ),
                       // rrc_view
                       Pair(
                           "../ReactCommon/react/renderer/components/view/",

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -186,6 +186,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/root/",
                           "react/renderer/components/root/",
                       ),
+                      Pair(
+                          "../ReactCommon/react/renderer/components/root/React/",
+                          "React/",
+                      ),
                       // runtimeexecutor
                       Pair("../ReactCommon/runtimeexecutor/", ""),
                       // react_renderer_textlayoutmanager

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -128,8 +128,14 @@ Pod::Spec.new do |s|
   s.subspec "components" do |ss|
     ss.subspec "root" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/root/**/*.{m,mm,cpp,h}", "react/renderer/components/root/**/*.{h}")
-      sss.exclude_files        = "react/renderer/components/root/tests"
+      sss.exclude_files        = ["react/renderer/components/root/tests", "react/renderer/components/root/React"]
       sss.header_dir           = "react/renderer/components/root"
+    end
+
+    ss.subspec "rootUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/root/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/root/React"
     end
 
     ss.subspec "view" do |sss|
@@ -148,7 +154,13 @@ Pod::Spec.new do |s|
     ss.subspec "scrollview" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/scrollview/**/*.{m,mm,cpp,h}", "react/renderer/components/scrollview/**/*.{h}")
       sss.header_dir           = "react/renderer/components/scrollview"
-      sss.exclude_files        = "react/renderer/components/scrollview/tests", "react/renderer/components/scrollview/platform/android"
+      sss.exclude_files        = "react/renderer/components/scrollview/tests", "react/renderer/components/scrollview/platform/android", "react/renderer/components/scrollview/React"
+    end
+
+    ss.subspec "scrollviewUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/scrollview/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/scrollview/React"
     end
 
     ss.subspec "legacyviewmanagerinterop" do |sss|

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -95,6 +95,12 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/modal"
     end
 
+    ss.subspec "modalUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/modal/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/modal/React"
+    end
+
     ss.subspec "safeareaview" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}", "react/renderer/components/safeareaview/**/*.h")
       # Exclude tests to avoid conflicts with the react-native-safe-area-context package

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -43,12 +43,18 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files         = podspec_sources("react/renderer/components/image/**/*.{m,mm,cpp,h}", "react/renderer/components/image/**/*.h")
-  s.exclude_files        = "react/renderer/components/image/tests"
+  s.exclude_files        = ["react/renderer/components/image/tests", "react/renderer/components/image/React"]
   s.header_dir           = "react/renderer/components/image"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
                           }
+
+  s.subspec "ImageUmbrella" do |ss|
+    ss.source_files        = "react/renderer/components/image/React/*.h"
+    ss.header_dir          = "React"
+    ss.header_mappings_dir = "react/renderer/components/image/React"
+  end
 
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_FabricImage")
 
@@ -60,6 +66,7 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   s.dependency "React-utils"
   s.dependency "Yoga"
+  s.dependency "React-cxxstableapi"
 
   add_dependency(s, "React-ImageManager", :additional_framework_paths => [
     "react/renderer/components/view/platform/cxx",

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(rrc_image
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_utils
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/image/ImageShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/imagemanager/primitives.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/image/ImageEventEmitter.h>
 #include <react/renderer/components/image/ImageProps.h>
 #include <react/renderer/components/image/ImageState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
 #include <react/renderer/imagemanager/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/image` module - public entry point.
+//
+//   #include <React/Image.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/image/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/image/ImageComponentDescriptor.h>
+#include <react/renderer/components/image/ImageEventEmitter.h>
+#include <react/renderer/components/image/ImageProps.h>
+#include <react/renderer/components/image/ImageShadowNode.h>
+#include <react/renderer/components/image/ImageState.h>
+#include <react/renderer/components/image/conversions.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <unordered_map>
 
 #include <glog/logging.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/components/inputaccessory/InputAccessoryShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/inputaccessory/InputAccessoryState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(rrc_legacyviewmanagerinterop
         glog_init
         folly_runtime
         jsi
+        react_cxxstableapi
         react_renderer_core
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #import <memory>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(rrc_modal
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_renderer_componentregistry
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/modal/ModalHostViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 #include "ModalHostViewUtils.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Size.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/modal` module - public
+// entry point.
+//
+//   #include <React/Modal.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/modal/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
+#include <react/renderer/components/modal/ModalHostViewShadowNode.h>
+#include <react/renderer/components/modal/ModalHostViewState.h>
+#include <react/renderer/components/modal/ModalHostViewUtils.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(rrc_progressbar
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include "AndroidProgressBarMeasurementsManager.h"
 #include "AndroidProgressBarShadowNode.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(rrc_root
         folly_runtime
         glog
         glog_init
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/root` module - public
+// entry point.
+//
+//   #include <React/Root.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/root/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/root/RootComponentDescriptor.h>
+#include <react/renderer/components/root/RootProps.h>
+#include <react/renderer/components/root/RootShadowNode.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/root/RootProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/safeareaview/SafeAreaViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/safeareaview/SafeAreaViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/graphics/RectangleEdges.h>
 
 #ifdef ANDROID

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(rrc_scrollview
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/scrollview` module -
+// public entry point.
+//
+//   #include <React/ScrollView.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained
+// `<react/renderer/components/scrollview/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/scrollview/BaseScrollViewProps.h>
+#include <react/renderer/components/scrollview/HostPlatformScrollViewProps.h>
+#include <react/renderer/components/scrollview/ScrollEvent.h>
+#include <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
+#include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
+#include <react/renderer/components/scrollview/ScrollViewProps.h>
+#include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
+#include <react/renderer/components/scrollview/ScrollViewState.h>
+#include <react/renderer/components/scrollview/conversions.h>
+#include <react/renderer/components/scrollview/primitives.h>
+
+#ifdef ANDROID
+#include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h>
+#include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventPayload.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/scrollview/ScrollEvent.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/HostPlatformScrollViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
 #include <react/renderer/components/scrollview/ScrollViewProps.h>
 #include <react/renderer/components/scrollview/ScrollViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/Rect.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
 #include <react/renderer/components/scrollview/ScrollViewState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/BaseScrollViewProps.h>
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/cxx/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/cxx/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/BaseScrollViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <tuple>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "AndroidSwitchMeasurementsManager.h"
 #include "AndroidSwitchShadowNode.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "AndroidSwitchMeasurementsManager.h"
 
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(rrc_unimplementedview
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/unimplementedview/UnimplementedViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/virtualview/VirtualViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -444,6 +444,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-FabricImage.podspec': {
+    name: 'React-FabricImage',
+    headerPatterns: ['react/renderer/components/image/**/*.h'],
+    excludePatterns: [
+      'react/renderer/components/image/tests',
+      'react/renderer/components/image/React',
+    ],
+    headerDir: 'react/renderer/components/image',
+    subSpecs: [
+      {
+        name: 'ImageUmbrella',
+        headerPatterns: ['react/renderer/components/image/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'React-Core.podspec': {
     name: 'React-Core',
     headerPatterns: [],

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -101,8 +101,17 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
           {
             name: 'root',
             headerPatterns: ['react/renderer/components/root/**/*.h'],
-            excludePatterns: ['react/renderer/components/root/tests'],
+            excludePatterns: [
+              'react/renderer/components/root/tests',
+              'react/renderer/components/root/React',
+            ],
             headerDir: 'react/renderer/components/root',
+          },
+
+          {
+            name: 'rootUmbrella',
+            headerPatterns: ['react/renderer/components/root/React/*.h'],
+            headerDir: 'React',
           },
           {
             name: 'view',
@@ -126,7 +135,14 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
             excludePatterns: [
               'react/renderer/components/scrollview/tests',
               'react/renderer/components/scrollview/platform/android',
+              'react/renderer/components/scrollview/React',
             ],
+          },
+
+          {
+            name: 'scrollviewUmbrella',
+            headerPatterns: ['react/renderer/components/scrollview/React/*.h'],
+            headerDir: 'React',
           },
 
           {
@@ -330,6 +346,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
             headerPatterns: ['react/renderer/components/modal/*.h'],
             excludePatterns: ['react/renderer/components/modal/tests'],
             headerDir: 'react/renderer/components/modal',
+          },
+
+          {
+            name: 'modalUmbrella',
+            headerPatterns: ['react/renderer/components/modal/React/*.h'],
+            headerDir: 'React',
           },
 
           {


### PR DESCRIPTION
Summary:

This change adds the umbrella-header and include-guard mechanism across `react/renderer/components/*` private modules. The change includes:

- react/renderer/components/inputaccessory:inputaccessory - `private`,
- react/renderer/components/legacyviewmanagerinterop:legacyviewmanagerinterop - `private`,
- react/renderer/components/progressbar:androidprogressbar - `private`,
- react/renderer/components/safeareaview:safeareaview - `private`,
- react/renderer/components/switch:androidswitch - `private`,
- react/renderer/components/unimplementedview:unimplementedview - `private`,
- react/renderer/components/virtualview:virtualview - `private`,

Changelog: [Internal]

Differential Revision: D116298251
