### PR TITLE
Fix ResizeObserver SwiftPM iOS builds

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -487,6 +487,7 @@ let reactFabric = RNTarget(
     "components/unimplementedview",
     "components/virtualview",
     "components/root/tests",
+    "observers/resize/tests",
     "scheduler/tests",
   ],
   dependencies: [.reactNativeDependencies, .reactJsiExecutor, .rctTypesafety, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .reactRendererDebug, .reactGraphics, .yoga, .reactJsInspectorTracing],


### PR DESCRIPTION
## Summary:

Commit `b03652af789b5e2d0d31554dc61230cd4ad9964d` added the ResizeObserver implementation to the `React-Fabric` SwiftPM target, but did not exclude its C++ test directory.

SwiftPM therefore recursively treated `ReactCommon/react/renderer/observers/resize/tests/ResizeObserverTest.cpp` as a production framework source. All iOS, iOS Simulator, and Mac Catalyst prebuilt-core slices failed while compiling it because GoogleTest is not a dependency of the production `React-Fabric` target:

```text
fatal error: 'gtest/gtest.h' file not found
```

This adds `observers/resize/tests` to the target's existing test exclusions, matching the treatment of the other React-Fabric test directories and leaving the dedicated C++ test target unchanged.

## Changelog:

[INTERNAL] [FIXED] - Exclude ResizeObserver C++ tests from the React-Fabric SwiftPM production target.

## Test Plan:

- Inspected all six failed `prebuild_react_native_core` jobs from run `32239670611`; each failed compiling `ResizeObserverTest.cpp` due to the missing `gtest/gtest.h` header.
- `git diff --check`
- `swift package --disable-sandbox dump-package` and verified that the `React-Fabric` target excludes `observers/resize/tests`.
- A targeted local `xcodebuild` was attempted, but this environment prevents SwiftPM's `sandbox-exec` from running before dependency resolution; CI will exercise the original failing build path.
