### PR TITLE
Add stable public MapBuffer C++ entry point (#58013)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -252,6 +252,7 @@ val preparePrefab by
                           "react/renderer/leakchecker/",
                       ),
                       Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/"),
+                      Pair("../ReactCommon/react/renderer/mapbuffer/React/", "React/"),
                       Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
                       Pair(
                           "../ReactCommon/react/renderer/runtimescheduler/",

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -26,14 +26,21 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = podspec_sources("react/renderer/mapbuffer/*.{cpp,h}", "react/renderer/mapbuffer/*.h")
-  s.exclude_files          = "react/renderer/mapbuffer/tests"
+  s.exclude_files          = ["react/renderer/mapbuffer/tests", "react/renderer/mapbuffer/React"]
   s.public_header_files    = 'react/renderer/mapbuffer/*.h'
   s.header_dir             = "react/renderer/mapbuffer"
   s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
+  s.subspec "MapBufferUmbrella" do |ss|
+    ss.source_files        = "react/renderer/mapbuffer/React/*.h"
+    ss.header_dir          = "React"
+    ss.header_mappings_dir = "react/renderer/mapbuffer/React"
+  end
+
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_Mapbuffer")
 
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -11,6 +11,6 @@ file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
 target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_renderer_mapbuffer glog glog_init react_debug)
+target_link_libraries(react_renderer_mapbuffer glog glog_init react_cxxstableapi react_debug)
 target_compile_reactnative_options(react_renderer_mapbuffer PRIVATE)
 target_compile_options(react_renderer_mapbuffer PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 
 #include <glog/logging.h>

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 #include <vector>
 #include "MapBuffer.h"

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/mapbuffer` module - public entry point.
+//
+//   #include <React/MapBuffer.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/mapbuffer/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -466,6 +466,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-Mapbuffer.podspec': {
+    name: 'React-Mapbuffer',
+    headerPatterns: ['react/renderer/mapbuffer/**/*.h'],
+    excludePatterns: [
+      'react/renderer/mapbuffer/tests',
+      'react/renderer/mapbuffer/React',
+    ],
+    headerDir: 'react/renderer/mapbuffer',
+    subSpecs: [
+      {
+        name: 'MapBufferUmbrella',
+        headerPatterns: ['react/renderer/mapbuffer/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'ReactCommon/React-FabricImage.podspec': {
     name: 'React-FabricImage',
     headerPatterns: ['react/renderer/components/image/**/*.h'],


### PR DESCRIPTION
Summary:

Add `<React/MapBuffer.h>` as the public C++ entry point for MapBuffer and MapBufferBuilder. Guard direct leaf-header inclusion for strict API consumers while preserving existing React Native builds and legacy include paths.

Export and stage the umbrella consistently through Buck, CMake, Android Prefab, CocoaPods, and the Apple prebuilt-header inventory.

Changelog:
[Internal]

Reviewed By: cipolleschi

Differential Revision: D116632721


