### PR TITLE
Promote fuseboxWebSocketEventsEnabled to stable

### DIFF
--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -10,13 +10,16 @@
 #import <Foundation/Foundation.h>
 
 /**
- * [Experimental] An interface for reporting network events to the modern
- * debugger server and Web Performance APIs.
+ * An interface for reporting network events to the modern debugger server and
+ * Web Performance APIs.
  *
  * In a production (non dev or profiling) build, CDP reporting is disabled.
  *
- * This is a helper class wrapping
- * `facebook::react::jsinspector_modern::NetworkReporter`.
+ * This is a helper class wrapping `facebook::react::NetworkReporter`, and is
+ * the integration point for third-party networking stacks that replace React
+ * Native's networking modules.
+ *
+ * This is an unstable API. Its exact location and shape may change over time.
  */
 @interface RCTInspectorNetworkReporter : NSObject
 

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -258,6 +258,8 @@ val preparePrefab by
                       Pair("src/main/jni/react/jni", "react/jni/"),
                       // react_cxxreactpackage
                       Pair("src/main/jni/react/runtime/cxxreactpackage", ""),
+                      // react_networking
+                      Pair("../ReactCommon/react/networking/", "react/networking/"),
                       // react_performance_timeline
                       Pair(
                           "../ReactCommon/react/performance/timeline/",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74896623764d3d01d2925fdcf30948f1>>
+ * @generated SignedSource<<feaccd208c512821d2c68caf4af716cb>>
  */
 
 /**
@@ -143,7 +143,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun fuseboxScreenshotCaptureEnabled(): Boolean = true
 
-  override fun fuseboxWebSocketEventsEnabled(): Boolean = false
+  override fun fuseboxWebSocketEventsEnabled(): Boolean = true
 
   override fun optimizedAnimatedPropUpdates(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<22ab94c6b0cc8f7ee39d546d9b93540a>>
+ * @generated SignedSource<<147db1f25292b3319d96e7fd0ff6d066>>
  */
 
 /**
@@ -32,8 +32,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactN
   override fun enableSwiftUIBasedFilters(): Boolean = true
 
   override fun fuseboxFrameRecordingEnabled(): Boolean = true
-
-  override fun fuseboxWebSocketEventsEnabled(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -10,24 +10,26 @@
 package com.facebook.react.modules.network
 
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.soloader.SoLoader
 import okio.ByteString
 
 /**
- * [Experimental] An interface for reporting network events to the modern debugger server and Web
- * Performance APIs.
+ * An interface for reporting network events to the modern debugger server and Web Performance APIs.
  *
  * In a production (non dev or profiling) build, CDP reporting is disabled.
  *
- * This is a helper class wrapping `facebook::react::jsinspector_modern::NetworkReporter`.
+ * This is a helper class wrapping `facebook::react::NetworkReporter`, and is the integration point
+ * for third-party networking stacks that replace React Native's networking modules.
  */
 @DoNotStripAny
-internal object InspectorNetworkReporter {
+@UnstableReactNativeAPI
+public object InspectorNetworkReporter {
   init {
     SoLoader.loadLibrary("react_devsupportjni")
   }
 
-  @JvmStatic external fun isDebuggingEnabled(): Boolean
+  @JvmStatic public external fun isDebuggingEnabled(): Boolean
 
   /**
    * Report a network request that is about to be sent.
@@ -36,7 +38,7 @@ internal object InspectorNetworkReporter {
    *   native request was initiated).
    */
   @JvmStatic
-  external fun reportRequestStart(
+  public external fun reportRequestStart(
       requestId: String,
       requestUrl: String,
       requestMethod: String,
@@ -51,7 +53,8 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
    *   `PerformanceResourceTiming.connectStart`.
    */
-  @JvmStatic external fun reportConnectionTiming(requestId: String, headers: Map<String, String>)
+  @JvmStatic
+  public external fun reportConnectionTiming(requestId: String, headers: Map<String, String>)
 
   /**
    * Report when HTTP response headers have been received, corresponding to when the first byte of
@@ -60,7 +63,7 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.responseStart`.
    */
   @JvmStatic
-  external fun reportResponseStart(
+  public external fun reportResponseStart(
       requestId: String,
       requestUrl: String,
       responseStatus: Int,
@@ -74,35 +77,35 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.dataReceived` in CDP.
    */
   @JvmStatic
-  fun reportDataReceived(requestId: String, data: String) {
+  public fun reportDataReceived(requestId: String, data: String) {
     // Guard call to CDP-only reporting method (avoid encodeToByteArray calculation)
     if (isDebuggingEnabled()) {
       reportDataReceivedImpl(requestId, data.encodeToByteArray().size)
     }
   }
 
-  @JvmStatic external fun reportDataReceivedImpl(requestId: String, dataLength: Int)
+  @JvmStatic public external fun reportDataReceivedImpl(requestId: String, dataLength: Int)
 
   /**
    * Report when a network request is complete and we are no longer receiving response data.
    * - Corresponds to `Network.loadingFinished` in CDP.
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
    */
-  @JvmStatic external fun reportResponseEnd(requestId: String, encodedDataLength: Long)
+  @JvmStatic public external fun reportResponseEnd(requestId: String, encodedDataLength: Long)
 
   /**
    * Report when a network request has failed.
    *
    * Corresponds to `Network.loadingFailed` in CDP.
    */
-  @JvmStatic external fun reportRequestFailed(requestId: String, cancelled: Boolean)
+  @JvmStatic public external fun reportRequestFailed(requestId: String, cancelled: Boolean)
 
   /**
    * Store response body preview. This is an optional reporting method, and is a no-op if CDP
    * debugging is disabled.
    */
   @JvmStatic
-  fun maybeStoreResponseBody(requestId: String, body: String, base64Encoded: Boolean) {
+  public fun maybeStoreResponseBody(requestId: String, body: String, base64Encoded: Boolean) {
     // Guard call to CDP-only reporting method (avoid sending string over JNI)
     if (isDebuggingEnabled()) {
       maybeStoreResponseBodyImpl(requestId, body, base64Encoded)
@@ -110,7 +113,11 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun maybeStoreResponseBodyImpl(requestId: String, body: String, base64Encoded: Boolean)
+  public external fun maybeStoreResponseBodyImpl(
+      requestId: String,
+      body: String,
+      base64Encoded: Boolean,
+  )
 
   /**
    * Incrementally store a response body preview, when a string response is received in chunks.
@@ -120,21 +127,22 @@ internal object InspectorNetworkReporter {
    * is disabled.
    */
   @JvmStatic
-  fun maybeStoreResponseBodyIncremental(requestId: String, data: String) {
+  public fun maybeStoreResponseBodyIncremental(requestId: String, data: String) {
     // Guard call to CDP-only reporting method (avoid sending string over JNI)
     if (isDebuggingEnabled()) {
       maybeStoreResponseBodyIncrementalImpl(requestId, data)
     }
   }
 
-  @JvmStatic external fun maybeStoreResponseBodyIncrementalImpl(requestId: String, data: String)
+  @JvmStatic
+  public external fun maybeStoreResponseBodyIncrementalImpl(requestId: String, data: String)
 
   /**
    * Report that a WebSocket connection is about to be created.
    *
    * Corresponds to `Network.webSocketCreated` in CDP.
    */
-  @JvmStatic external fun reportWebSocketCreated(requestId: String, url: String)
+  @JvmStatic public external fun reportWebSocketCreated(requestId: String, url: String)
 
   /**
    * Report that a WebSocket handshake (HTTP upgrade) request is about to be sent, along with its
@@ -143,7 +151,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketWillSendHandshakeRequest` in CDP.
    */
   @JvmStatic
-  external fun reportWebSocketWillSendHandshakeRequest(
+  public external fun reportWebSocketWillSendHandshakeRequest(
       requestId: String,
       headers: Map<String, String>,
   )
@@ -154,7 +162,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketHandshakeResponseReceived` in CDP.
    */
   @JvmStatic
-  external fun reportWebSocketHandshakeResponseReceived(
+  public external fun reportWebSocketHandshakeResponseReceived(
       requestId: String,
       statusCode: Int,
       headers: Map<String, String>,
@@ -166,7 +174,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameSent` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageSent(requestId: String, message: String) {
+  public fun reportWebSocketMessageSent(requestId: String, message: String) {
     if (isDebuggingEnabled()) {
       reportWebSocketMessageSentImpl(requestId, message, false)
     }
@@ -178,7 +186,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameSent` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageSent(requestId: String, message: ByteString) {
+  public fun reportWebSocketMessageSent(requestId: String, message: ByteString) {
     // Guard call to CDP-only reporting method (avoid base64 encoding)
     if (isDebuggingEnabled()) {
       reportWebSocketMessageSentImpl(requestId, message.base64(), true)
@@ -186,7 +194,7 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun reportWebSocketMessageSentImpl(
+  public external fun reportWebSocketMessageSentImpl(
       requestId: String,
       payloadData: String,
       isBinary: Boolean,
@@ -198,7 +206,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameReceived` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageReceived(requestId: String, message: String) {
+  public fun reportWebSocketMessageReceived(requestId: String, message: String) {
     if (isDebuggingEnabled()) {
       reportWebSocketMessageReceivedImpl(requestId, message, false)
     }
@@ -210,7 +218,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameReceived` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageReceived(requestId: String, message: ByteString) {
+  public fun reportWebSocketMessageReceived(requestId: String, message: ByteString) {
     // Guard call to CDP-only reporting method (avoid base64 encoding)
     if (isDebuggingEnabled()) {
       reportWebSocketMessageReceivedImpl(requestId, message.base64(), true)
@@ -218,7 +226,7 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun reportWebSocketMessageReceivedImpl(
+  public external fun reportWebSocketMessageReceivedImpl(
       requestId: String,
       payloadData: String,
       isBinary: Boolean,
@@ -229,5 +237,5 @@ internal object InspectorNetworkReporter {
    *
    * Corresponds to `Network.webSocketClosed` in CDP.
    */
-  @JvmStatic external fun reportWebSocketClosed(requestId: String)
+  @JvmStatic public external fun reportWebSocketClosed(requestId: String)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -6,6 +6,7 @@
  */
 
 @file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+@file:OptIn(UnstableReactNativeAPI::class)
 
 package com.facebook.react.modules.network
 
@@ -15,6 +16,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableArray
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import java.io.IOException
 import java.net.SocketTimeoutException
 import okhttp3.Headers

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -6,6 +6,7 @@
  */
 
 @file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+@file:OptIn(UnstableReactNativeAPI::class)
 
 package com.facebook.react.modules.websocket
 
@@ -19,6 +20,7 @@ import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.network.CustomClientBuilder

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcc09eb60ab85de9bc72410e93c2a1c>>
+ * @generated SignedSource<<c66ee480ab6c464d1f6b4b2e2cd72084>>
  */
 
 /**
@@ -268,7 +268,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool fuseboxWebSocketEventsEnabled() override {
-    return false;
+    return true;
   }
 
   bool optimizedAnimatedPropUpdates() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<70297dc6230d386e556c82860cbf9985>>
+ * @generated SignedSource<<ed9856a5ef08a8e6c10a615170171332>>
  */
 
 /**
@@ -44,10 +44,6 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
   }
 
   bool fuseboxFrameRecordingEnabled() override {
-    return true;
-  }
-
-  bool fuseboxWebSocketEventsEnabled() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -39,8 +39,13 @@ struct ResourceTimingData {
 };
 
 /**
- * [Experimental] An interface for reporting network events to the modern
- * debugger server and Web Performance APIs.
+ * An interface for reporting network events to the modern debugger server and
+ * Web Performance APIs.
+ *
+ * This is the integration point for networking stacks, including third-party
+ * replacements for React Native's networking modules.
+ *
+ * This is an unstable API. Its exact location and shape may change over time.
  *
  * In a production (non dev or profiling) build, CDP reporting is disabled.
  */

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -691,7 +691,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'stable',
     },
     fuseboxWebSocketEventsEnabled: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-07-11',
         description:
@@ -699,7 +699,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'canary',
+      ossReleaseStage: 'stable',
     },
     optimizedAnimatedPropUpdates: {
       defaultValue: false,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bafad194115f60dcf22f64015fe64856>>
+ * @generated SignedSource<<9067c22a27ea55f2a8211e547f51a96a>>
  * @flow strict
  * @noformat
  */
@@ -449,7 +449,7 @@ export const fuseboxScreenshotCaptureEnabled: Getter<boolean> = createNativeFlag
 /**
  * Enable reporting of WebSocket network events (`Network.webSocket*` CDP events) to the React Native DevTools CDP backend.
  */
-export const fuseboxWebSocketEventsEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxWebSocketEventsEnabled', false);
+export const fuseboxWebSocketEventsEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxWebSocketEventsEnabled', true);
 /**
  * When enabled, uses optimized platform-specific paths to apply animated props synchronously. On Android, this uses a batched int/double buffer protocol with a single JNI call. On iOS, this passes AnimatedProps directly through the delegate chain and applies them via cloneProps, avoiding the folly::dynamic round-trip.
  */


### PR DESCRIPTION
Summary:
NOTE: **🚧 WIP** — Exported as placeholder until the to dos below are resolved.

**To dos**

- [ ] Fix request initiator (currently showing as `WebSocket.js`).

Changelog:
[General][Added] - **React Native DevTools**: Add support for inspecting WebSocket events in the Network panel (core only)

Differential Revision: D116472859
