### PR TITLE
Add NetworkThrottling example to RNTester

### DIFF
--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -12,11 +12,19 @@
 #import <React/RCTNetworking.h>
 #import <ReactCommon/RCTTurboModule.h>
 
+#import "RCTInspectorNetworkEmulationGate.h"
 #import "RCTNetworkPlugins.h"
 
 @interface RCTHTTPRequestHandler () <NSURLSessionDataDelegate, RCTTurboModule>
 
 @end
+
+static NSError *RCTNetworkThrottleOfflineError(void)
+{
+  return [NSError errorWithDomain:NSURLErrorDomain
+                             code:NSURLErrorNotConnectedToInternet
+                         userInfo:@{NSLocalizedDescriptionKey : @"The Internet connection appears to be offline."}];
+}
 
 static NSURLSessionConfigurationProvider urlSessionConfigurationProvider;
 
@@ -34,7 +42,9 @@ void RCTSetCustomHTTPRequestInterceptor(RCTHTTPRequestInterceptor interceptor)
 
 @implementation RCTHTTPRequestHandler {
   NSMapTable *_delegates;
+  NSMapTable *_throttleGates;
   NSURLSession *_session;
+  dispatch_queue_t _callbackQueue;
   std::mutex _mutex;
 }
 
@@ -85,7 +95,17 @@ RCT_EXPORT_MODULE()
 
     NSOperationQueue *callbackQueue = [NSOperationQueue new];
     callbackQueue.maxConcurrentOperationCount = 1;
-    callbackQueue.underlyingQueue = [[_moduleRegistry moduleForName:"Networking"] methodQueue];
+    // The Networking module's method queue is not always available (e.g. when
+    // no module is registered under the name "Networking"). Fall back to a
+    // dedicated serial queue so that delegate callbacks — and the simulated
+    // throttling delivery paths that re-dispatch onto this same queue — always
+    // have a valid serial queue.
+    dispatch_queue_t callbackUnderlyingQueue = [[_moduleRegistry moduleForName:"Networking"] methodQueue];
+    if (callbackUnderlyingQueue == nil) {
+      callbackUnderlyingQueue =
+          dispatch_queue_create("com.facebook.react.RCTHTTPRequestHandler", DISPATCH_QUEUE_SERIAL);
+    }
+    callbackQueue.underlyingQueue = callbackUnderlyingQueue;
     NSURLSessionConfiguration *configuration;
     if (urlSessionConfigurationProvider != nullptr) {
       configuration = urlSessionConfigurationProvider();
@@ -101,10 +121,14 @@ RCT_EXPORT_MODULE()
     }
     assert(configuration != nil);
     _session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:callbackQueue];
+    _callbackQueue = callbackUnderlyingQueue;
 
     _delegates = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory
                                            valueOptions:NSPointerFunctionsStrongMemory
                                                capacity:0];
+    _throttleGates = [[NSMapTable alloc] initWithKeyOptions:NSPointerFunctionsStrongMemory
+                                               valueOptions:NSPointerFunctionsStrongMemory
+                                                   capacity:0];
   }
   NSURLRequest *finalRequest = request;
   if (httpRequestInterceptor != nullptr) {
@@ -115,6 +139,40 @@ RCT_EXPORT_MODULE()
   }
   NSURLSessionDataTask *task = [_session dataTaskWithRequest:finalRequest];
   [_delegates setObject:delegate forKey:task];
+
+  if ([RCTInspectorNetworkEmulationGate isActive]) {
+    if ([RCTInspectorNetworkEmulationGate isOffline]) {
+      // Offline emulation: fail the request without touching the network.
+      [_delegates removeObjectForKey:task];
+      dispatch_async(_callbackQueue, ^{
+        [delegate URLRequest:task didCompleteWithError:RCTNetworkThrottleOfflineError()];
+      });
+      return task;
+    }
+
+    __weak RCTHTTPRequestHandler *weakSelf = self;
+    RCTInspectorNetworkEmulationGate *gate = [[RCTInspectorNetworkEmulationGate alloc]
+        initWithDeliveryQueue:_callbackQueue
+               onDisconnected:^{
+                 // The request was failed by going offline mid-flight. The
+                 // failure is latched: the real task is cancelled silently.
+                 RCTHTTPRequestHandler *strongSelf = weakSelf;
+                 if (strongSelf != nil) {
+                   std::lock_guard<std::mutex> innerLock(strongSelf->_mutex);
+                   [strongSelf->_delegates removeObjectForKey:task];
+                   [strongSelf->_throttleGates removeObjectForKey:task];
+                 }
+                 [task cancel];
+                 [delegate URLRequest:task didCompleteWithError:RCTNetworkThrottleOfflineError()];
+               }];
+    [_throttleGates setObject:gate forKey:task];
+    [task resume];
+    // Approximates the real send-end time, from which the emulated latency
+    // floor is measured.
+    [gate noteRequestSent];
+    return task;
+  }
+
   [task resume];
   return task;
 }
@@ -124,8 +182,16 @@ RCT_EXPORT_MODULE()
   {
     std::lock_guard<std::mutex> lock(_mutex);
     [_delegates removeObjectForKey:task];
+    [[_throttleGates objectForKey:task] cancel];
+    [_throttleGates removeObjectForKey:task];
   }
   [task cancel];
+}
+
+- (RCTInspectorNetworkEmulationGate *)throttleGateForTask:(NSURLSessionTask *)task
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  return [_throttleGates objectForKey:task];
 }
 
 #pragma mark - NSURLSession delegate
@@ -169,7 +235,14 @@ RCT_EXPORT_MODULE()
     std::lock_guard<std::mutex> lock(_mutex);
     delegate = [_delegates objectForKey:task];
   }
-  [delegate URLRequest:task didReceiveResponse:response];
+  RCTInspectorNetworkEmulationGate *gate = [self throttleGateForTask:task];
+  if (gate != nil) {
+    [gate throttleResponseDelivery:^{
+      [delegate URLRequest:task didReceiveResponse:response];
+    }];
+  } else {
+    [delegate URLRequest:task didReceiveResponse:response];
+  }
   completionHandler(NSURLSessionResponseAllow);
 }
 
@@ -180,18 +253,44 @@ RCT_EXPORT_MODULE()
     std::lock_guard<std::mutex> lock(_mutex);
     delegate = [_delegates objectForKey:task];
   }
-  [delegate URLRequest:task didReceiveData:data];
+  RCTInspectorNetworkEmulationGate *gate = [self throttleGateForTask:task];
+  if (gate != nil) {
+    [gate throttleDataDelivery:data
+                       deliver:^(NSData *chunk) {
+                         [delegate URLRequest:task didReceiveData:chunk];
+                       }];
+  } else {
+    [delegate URLRequest:task didReceiveData:data];
+  }
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
   id<RCTURLRequestDelegate> delegate;
+  RCTInspectorNetworkEmulationGate *gate;
   {
     std::lock_guard<std::mutex> lock(_mutex);
     delegate = [_delegates objectForKey:task];
     [_delegates removeObjectForKey:task];
+    gate = [_throttleGates objectForKey:task];
+    [_throttleGates removeObjectForKey:task];
   }
-  [delegate URLRequest:task didCompleteWithError:error];
+  if (gate != nil) {
+    if (error != nil) {
+      // Real errors (including cancellation) complete unthrottled. Dispatch
+      // async to stay ordered behind any already-released deliveries.
+      [gate cancel];
+      dispatch_async(_callbackQueue, ^{
+        [delegate URLRequest:task didCompleteWithError:error];
+      });
+    } else {
+      [gate throttleCompletionDelivery:^{
+        [delegate URLRequest:task didCompleteWithError:nil];
+      }];
+    }
+  } else {
+    [delegate URLRequest:task didCompleteWithError:error];
+  }
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkEmulationGate.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkEmulationGate.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * [Experimental] A per-request delivery gate applying simulated network
+ * throttling for CDP debugging (`Network.emulateNetworkConditions`).
+ *
+ * Events (response headers, body chunks, completion) are enqueued in order
+ * and delivered on the given serial queue once the shared throttling engine
+ * releases them. Response bodies are re-chunked into packet-sized (1500 byte)
+ * increments while download throttling is active.
+ *
+ * This is a helper class wrapping
+ * `facebook::react::jsinspector_modern::NetworkThrottler`. In a production
+ * (non dev or profiling) build, throttling is never active.
+ */
+@interface RCTInspectorNetworkEmulationGate : NSObject
+
+/**
+ * Whether new requests should be routed through a throttle gate: requires
+ * the `fuseboxNetworkThrottlingEnabled` feature flag and active emulated
+ * network conditions.
+ */
++ (BOOL)isActive;
+
+/**
+ * Whether offline network emulation is currently active. Callers should fail
+ * new requests with `NSURLErrorNotConnectedToInternet` without touching the
+ * network.
+ */
++ (BOOL)isOffline;
+
+/**
+ * \param deliveryQueue The serial queue on which delivery and failure blocks
+ * are invoked.
+ * \param onDisconnected Invoked at most once if the request is failed by
+ * offline emulation mid-flight. Enqueued and undelivered events are dropped.
+ */
+- (instancetype)initWithDeliveryQueue:(dispatch_queue_t)deliveryQueue onDisconnected:(dispatch_block_t)onDisconnected;
+
+/**
+ * Record that the request has finished sending. The emulated latency floor
+ * for the response stage is measured from this point.
+ */
+- (void)noteRequestSent;
+
+/** Enqueue the response-headers event, subject to the emulated latency floor. */
+- (void)throttleResponseDelivery:(dispatch_block_t)deliver;
+
+/**
+ * Enqueue a body data event, subject to download throughput emulation.
+ * `deliver` may be invoked multiple times with successive subranges of
+ * `data`.
+ */
+- (void)throttleDataDelivery:(NSData *)data deliver:(void (^)(NSData *chunk))deliver;
+
+/** Enqueue the completion event, delivered after all preceding events. */
+- (void)throttleCompletionDelivery:(dispatch_block_t)deliver;
+
+/**
+ * Cancel the gate: drop all queued events and detach from the throttling
+ * engine. No further blocks are invoked.
+ */
+- (void)cancel;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkEmulationGate.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkEmulationGate.mm
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorNetworkEmulationGate.h"
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+#import <react/featureflags/ReactNativeFeatureFlags.h>
+
+#import <jsinspector-modern/network/NetworkThrottler.h>
+
+#import <deque>
+#import <mutex>
+
+using facebook::react::jsinspector_modern::NetworkThrottler;
+
+namespace {
+
+/**
+ * One queued delivery event. Events are processed strictly in order, with at
+ * most one outstanding throttler record per gate at a time.
+ */
+struct PendingEvent {
+  dispatch_block_t deliver;
+  int64_t bytes;
+  BOOL isStart;
+  BOOL isThrottled;
+};
+
+} // namespace
+#endif
+
+@implementation RCTInspectorNetworkEmulationGate {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  dispatch_queue_t _deliveryQueue;
+  dispatch_block_t _onDisconnected;
+
+  std::mutex _mutex;
+  std::deque<PendingEvent> _pendingEvents;
+  bool _awaitingRelease;
+  bool _failed;
+  bool _cancelled;
+  int64_t _byteDebt;
+  uint64_t _token;
+  NetworkThrottler::TimePoint _sendEnd;
+#endif
+}
+
++ (BOOL)isActive
+{
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  if (!facebook::react::ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled()) {
+    return NO;
+  }
+  auto &throttler = NetworkThrottler::getInstance();
+  return throttler.isThrottling() || throttler.isOffline();
+#else
+  return NO;
+#endif
+}
+
++ (BOOL)isOffline
+{
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  return facebook::react::ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled() &&
+      NetworkThrottler::getInstance().isOffline();
+#else
+  return NO;
+#endif
+}
+
+- (instancetype)initWithDeliveryQueue:(dispatch_queue_t)deliveryQueue onDisconnected:(dispatch_block_t)onDisconnected
+{
+  if (self = [super init]) {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+    _deliveryQueue = deliveryQueue;
+    _onDisconnected = onDisconnected;
+    _token = NetworkThrottler::getInstance().createRecordToken();
+    _sendEnd = NetworkThrottler::Clock::now();
+#endif
+  }
+  return self;
+}
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+
+- (void)noteRequestSent
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _sendEnd = NetworkThrottler::Clock::now();
+}
+
+- (void)throttleResponseDelivery:(dispatch_block_t)deliver
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _pendingEvents.push_back(PendingEvent{deliver, 0, YES, YES});
+  [self pumpLocked];
+}
+
+- (void)throttleDataDelivery:(NSData *)data deliver:(void (^)(NSData *chunk))deliver
+{
+  // Re-chunk into packet-sized increments while download throttling is
+  // active, so progress feels like a slow network rather than one long stall.
+  auto &throttler = NetworkThrottler::getInstance();
+  std::lock_guard<std::mutex> lock(_mutex);
+  NSUInteger offset = 0;
+  while (offset < data.length) {
+    auto chunkLength = (NSUInteger)throttler.getReadBufLen((int64_t)(data.length - offset));
+    NSData *chunk = [data subdataWithRange:NSMakeRange(offset, chunkLength)];
+    _pendingEvents.push_back(PendingEvent{
+        ^{
+          deliver(chunk);
+  }
+  , (int64_t)chunk.length, NO, YES
+});
+offset += chunkLength;
+}
+[self pumpLocked];
+}
+
+- (void)throttleCompletionDelivery:(dispatch_block_t)deliver
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _pendingEvents.push_back(PendingEvent{deliver, 0, NO, NO});
+  [self pumpLocked];
+}
+
+- (void)cancel
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _cancelled = true;
+  _pendingEvents.clear();
+  NetworkThrottler::getInstance().stopThrottle(_token);
+}
+
+/**
+ * Process queued events until one is left pending in the throttling engine.
+ * Must be called with `_mutex` held. Deliveries are dispatched asynchronously
+ * onto the delivery queue, preserving order.
+ */
+- (void)pumpLocked
+{
+  while (!_awaitingRelease && !_failed && !_cancelled && !_pendingEvents.empty()) {
+    PendingEvent event = _pendingEvents.front();
+    _pendingEvents.pop_front();
+
+    if (!event.isThrottled) {
+      dispatch_async(_deliveryQueue, event.deliver);
+      continue;
+    }
+
+    _byteDebt += event.bytes;
+
+    dispatch_block_t deliver = event.deliver;
+    auto result = NetworkThrottler::getInstance().startThrottle(
+        _token,
+        _byteDebt,
+        _sendEnd,
+        event.isStart == YES,
+        /* isUpload */ false,
+        [self, deliver](bool disconnected, int64_t newDebt) {
+          // NOTE: `self` is captured strongly: the throttling engine owns the
+          // gate until the record fires or is removed via `stopThrottle`. The
+          // real request may complete (and the request handler release its
+          // reference) before the gated events are delivered.
+          //
+          // Invoked from an arbitrary thread. Bounce to the delivery queue
+          // before taking the gate lock, so the throttling engine never
+          // blocks on gate mutexes.
+          dispatch_async(self->_deliveryQueue, ^{
+            [self handleRelease:deliver disconnected:disconnected newDebt:newDebt];
+          });
+        });
+
+    switch (result) {
+      case NetworkThrottler::StartResult::PassThrough:
+        dispatch_async(_deliveryQueue, deliver);
+        break;
+      case NetworkThrottler::StartResult::Disconnected:
+        [self failLocked];
+        return;
+      case NetworkThrottler::StartResult::Pending:
+        _awaitingRelease = true;
+        return;
+    }
+  }
+}
+
+- (void)handleRelease:(dispatch_block_t)deliver disconnected:(bool)disconnected newDebt:(int64_t)newDebt
+{
+  BOOL shouldDeliver = NO;
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _awaitingRelease = false;
+    if (_cancelled || _failed) {
+      return;
+    }
+    _byteDebt = newDebt;
+    if (disconnected) {
+      [self failLocked];
+    } else {
+      shouldDeliver = YES;
+    }
+  }
+  if (shouldDeliver) {
+    // Already on the delivery queue; deliver in-line to stay ordered ahead
+    // of any events enqueued by this delivery.
+    deliver();
+    std::lock_guard<std::mutex> lock(_mutex);
+    [self pumpLocked];
+  }
+}
+
+/** Must be called with `_mutex` held. */
+- (void)failLocked
+{
+  if (_failed) {
+    return;
+  }
+  _failed = true;
+  _pendingEvents.clear();
+  if (_onDisconnected != nil) {
+    dispatch_async(_deliveryQueue, _onDisconnected);
+    _onDisconnected = nil;
+  }
+}
+
+#else
+
+- (void)noteRequestSent
+{
+}
+
+- (void)throttleResponseDelivery:(dispatch_block_t)deliver
+{
+  deliver();
+}
+
+- (void)throttleDataDelivery:(NSData *)data deliver:(void (^)(NSData *chunk))deliver
+{
+  deliver(data);
+}
+
+- (void)throttleCompletionDelivery:(dispatch_block_t)deliver
+{
+  deliver();
+}
+
+- (void)cancel
+{
+}
+
+#endif
+
+@end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -10,13 +10,16 @@
 #import <Foundation/Foundation.h>
 
 /**
- * [Experimental] An interface for reporting network events to the modern
- * debugger server and Web Performance APIs.
+ * An interface for reporting network events to the modern debugger server and
+ * Web Performance APIs.
  *
  * In a production (non dev or profiling) build, CDP reporting is disabled.
  *
- * This is a helper class wrapping
- * `facebook::react::jsinspector_modern::NetworkReporter`.
+ * This is a helper class wrapping `facebook::react::NetworkReporter`, and is
+ * the integration point for third-party networking stacks that replace React
+ * Native's networking modules.
+ *
+ * This is an unstable API. Its exact location and shape may change over time.
  */
 @interface RCTInspectorNetworkReporter : NSObject
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d5bab65a116d6f6d3415c5c8a2f08db9>>
+ * @generated SignedSource<<80263dac03f7cac44cbdec968e8b75e4>>
  */
 
 /**
@@ -383,6 +383,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun fuseboxFrameRecordingEnabled(): Boolean = accessor.fuseboxFrameRecordingEnabled()
+
+  /**
+   * Enable simulated network throttling (Network.emulateNetworkConditions) in the React Native DevTools CDP backend.
+   */
+  @JvmStatic
+  public fun fuseboxNetworkThrottlingEnabled(): Boolean = accessor.fuseboxNetworkThrottlingEnabled()
 
   /**
    * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<331c699ee09143bbb98a81857cb2659c>>
+ * @generated SignedSource<<1cac5c34715e5a4fa1076ad1293fd7a1>>
  */
 
 /**
@@ -79,6 +79,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var fuseboxAssertSingleHostStateCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxFrameRecordingEnabledCache: Boolean? = null
+  private var fuseboxNetworkThrottlingEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var fuseboxWebSocketEventsEnabledCache: Boolean? = null
   private var optimizedAnimatedPropUpdatesCache: Boolean? = null
@@ -635,6 +636,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.fuseboxFrameRecordingEnabled()
       fuseboxFrameRecordingEnabledCache = cached
+    }
+    return cached
+  }
+
+  override fun fuseboxNetworkThrottlingEnabled(): Boolean {
+    var cached = fuseboxNetworkThrottlingEnabledCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.fuseboxNetworkThrottlingEnabled()
+      fuseboxNetworkThrottlingEnabledCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9cf60776cac41ff2ebb6a5e267343ca>>
+ * @generated SignedSource<<ca22cf5ac64a00302885f94bc3ae727f>>
  */
 
 /**
@@ -145,6 +145,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip @JvmStatic public external fun fuseboxFrameRecordingEnabled(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun fuseboxNetworkThrottlingEnabled(): Boolean
 
   @DoNotStrip @JvmStatic public external fun fuseboxScreenshotCaptureEnabled(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74896623764d3d01d2925fdcf30948f1>>
+ * @generated SignedSource<<53b04426d5186d635b14d89d5337ffbf>>
  */
 
 /**
@@ -140,6 +140,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun fuseboxEnabledRelease(): Boolean = false
 
   override fun fuseboxFrameRecordingEnabled(): Boolean = false
+
+  override fun fuseboxNetworkThrottlingEnabled(): Boolean = false
 
   override fun fuseboxScreenshotCaptureEnabled(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e05552bb01ea7e80fde1c19b5199caa>>
+ * @generated SignedSource<<54907e7552375b4008e8fb233cc1761f>>
  */
 
 /**
@@ -83,6 +83,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var fuseboxAssertSingleHostStateCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxFrameRecordingEnabledCache: Boolean? = null
+  private var fuseboxNetworkThrottlingEnabledCache: Boolean? = null
   private var fuseboxScreenshotCaptureEnabledCache: Boolean? = null
   private var fuseboxWebSocketEventsEnabledCache: Boolean? = null
   private var optimizedAnimatedPropUpdatesCache: Boolean? = null
@@ -698,6 +699,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.fuseboxFrameRecordingEnabled()
       accessedFeatureFlags.add("fuseboxFrameRecordingEnabled")
       fuseboxFrameRecordingEnabledCache = cached
+    }
+    return cached
+  }
+
+  override fun fuseboxNetworkThrottlingEnabled(): Boolean {
+    var cached = fuseboxNetworkThrottlingEnabledCache
+    if (cached == null) {
+      cached = currentProvider.fuseboxNetworkThrottlingEnabled()
+      accessedFeatureFlags.add("fuseboxNetworkThrottlingEnabled")
+      fuseboxNetworkThrottlingEnabledCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<998a99e804cf713c8ce8adafa1b1b83b>>
+ * @generated SignedSource<<61e3f1e7a355ac90bf87875a2144bf02>>
  */
 
 /**
@@ -140,6 +140,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip public fun fuseboxFrameRecordingEnabled(): Boolean
+
+  @DoNotStrip public fun fuseboxNetworkThrottlingEnabled(): Boolean
 
   @DoNotStrip public fun fuseboxScreenshotCaptureEnabled(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkEmulationInterceptor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkEmulationInterceptor.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
+package com.facebook.react.modules.network
+
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import java.io.IOException
+import java.net.UnknownHostException
+import kotlin.math.min
+import okhttp3.Interceptor
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.ForwardingSource
+import okio.Okio
+
+/**
+ * [Experimental] An OkHttp application interceptor applying simulated network throttling for CDP
+ * debugging (`Network.emulateNetworkConditions`).
+ *
+ * The real request runs at full speed; the response headers wait out the emulated latency floor,
+ * and the response body is delivered in packet-sized (1500 byte) reads gated on the shared
+ * throttling engine. When offline emulation is active, requests fail with an [UnknownHostException]
+ * without touching the network.
+ */
+internal class InspectorNetworkEmulationInterceptor : Interceptor {
+  @Throws(IOException::class)
+  override fun intercept(chain: Interceptor.Chain): Response {
+    if (!ReactNativeFeatureFlags.fuseboxNetworkThrottlingEnabled()) {
+      return chain.proceed(chain.request())
+    }
+    if (InspectorNetworkEmulationSession.isOffline()) {
+      throw UnknownHostException(
+          "Unable to resolve host: offline mode is emulated by React Native DevTools",
+      )
+    }
+    if (!InspectorNetworkEmulationSession.isThrottling()) {
+      return chain.proceed(chain.request())
+    }
+
+    val token = InspectorNetworkEmulationSession.createRecordToken()
+    // Approximates the real send-end time with the start of the call; the
+    // emulated latency floor is measured from this point.
+    val sendStartNanos = System.nanoTime()
+    val response = chain.proceed(chain.request())
+
+    val sendEndAgeMs = (System.nanoTime() - sendStartNanos) / 1e6
+    var byteDebt = InspectorNetworkEmulationSession.awaitThrottle(token, 0, sendEndAgeMs, true)
+
+    val body = response.body() ?: return response
+    val throttledSource =
+        object : ForwardingSource(body.source()) {
+          @Throws(IOException::class)
+          override fun read(sink: Buffer, byteCount: Long): Long {
+            // Deliver the body in packet-sized increments, so progress feels
+            // like a slow network rather than one long stall.
+            val bytesRead = super.read(sink, min(byteCount, PACKET_SIZE))
+            if (bytesRead > 0) {
+              byteDebt =
+                  InspectorNetworkEmulationSession.awaitThrottle(
+                      token,
+                      byteDebt + bytesRead,
+                      0.0,
+                      false,
+                  )
+            }
+            return bytesRead
+          }
+        }
+    return response
+        .newBuilder()
+        .body(
+            ResponseBody.create(
+                body.contentType(),
+                body.contentLength(),
+                Okio.buffer(throttledSource),
+            ),
+        )
+        .build()
+  }
+
+  private companion object {
+    private const val PACKET_SIZE = 1500L
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkEmulationSession.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkEmulationSession.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.network
+
+import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.soloader.SoLoader
+import java.io.IOException
+
+/**
+ * [Experimental] An interface to the simulated network throttling engine for CDP debugging
+ * (`Network.emulateNetworkConditions`).
+ *
+ * This is a helper class wrapping `facebook::react::jsinspector_modern::NetworkThrottler`.
+ */
+@DoNotStripAny
+internal object InspectorNetworkEmulationSession {
+  init {
+    SoLoader.loadLibrary("react_devsupportjni")
+  }
+
+  /**
+   * Whether offline network emulation is active. Callers should fail new requests with a network
+   * error without touching the network.
+   */
+  @JvmStatic external fun isOffline(): Boolean
+
+  /** Whether any throttling behavior (latency or throughput) is active. */
+  @JvmStatic external fun isThrottling(): Boolean
+
+  /** Create an opaque token identifying one request's throttled operations. */
+  @JvmStatic external fun createRecordToken(): Long
+
+  /**
+   * Block the calling thread until the throttling engine releases the operation.
+   *
+   * @param token Identifies the request (see [createRecordToken]).
+   * @param bytes The request's cumulative outstanding byte debt: bytes newly received plus the
+   *   (normally negative) remainder returned by the previous call.
+   * @param sendEndAgeMs How long ago the request finished being sent, in milliseconds. Only
+   *   meaningful when `isStart` is true; the emulated latency floor is measured from that point.
+   * @param isStart Whether this is the response-headers stage (subject to the latency floor).
+   * @return The new byte debt to carry into the next call.
+   * @throws IOException if the request was failed by offline emulation.
+   */
+  @JvmStatic
+  @Throws(IOException::class)
+  external fun awaitThrottle(token: Long, bytes: Long, sendEndAgeMs: Double, isStart: Boolean): Long
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -10,24 +10,26 @@
 package com.facebook.react.modules.network
 
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.soloader.SoLoader
 import okio.ByteString
 
 /**
- * [Experimental] An interface for reporting network events to the modern debugger server and Web
- * Performance APIs.
+ * An interface for reporting network events to the modern debugger server and Web Performance APIs.
  *
  * In a production (non dev or profiling) build, CDP reporting is disabled.
  *
- * This is a helper class wrapping `facebook::react::jsinspector_modern::NetworkReporter`.
+ * This is a helper class wrapping `facebook::react::NetworkReporter`, and is the integration point
+ * for third-party networking stacks that replace React Native's networking modules.
  */
 @DoNotStripAny
-internal object InspectorNetworkReporter {
+@UnstableReactNativeAPI
+public object InspectorNetworkReporter {
   init {
     SoLoader.loadLibrary("react_devsupportjni")
   }
 
-  @JvmStatic external fun isDebuggingEnabled(): Boolean
+  @JvmStatic public external fun isDebuggingEnabled(): Boolean
 
   /**
    * Report a network request that is about to be sent.
@@ -36,7 +38,7 @@ internal object InspectorNetworkReporter {
    *   native request was initiated).
    */
   @JvmStatic
-  external fun reportRequestStart(
+  public external fun reportRequestStart(
       requestId: String,
       requestUrl: String,
       requestMethod: String,
@@ -51,7 +53,8 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
    *   `PerformanceResourceTiming.connectStart`.
    */
-  @JvmStatic external fun reportConnectionTiming(requestId: String, headers: Map<String, String>)
+  @JvmStatic
+  public external fun reportConnectionTiming(requestId: String, headers: Map<String, String>)
 
   /**
    * Report when HTTP response headers have been received, corresponding to when the first byte of
@@ -60,7 +63,7 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.responseStart`.
    */
   @JvmStatic
-  external fun reportResponseStart(
+  public external fun reportResponseStart(
       requestId: String,
       requestUrl: String,
       responseStatus: Int,
@@ -74,35 +77,35 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.dataReceived` in CDP.
    */
   @JvmStatic
-  fun reportDataReceived(requestId: String, data: String) {
+  public fun reportDataReceived(requestId: String, data: String) {
     // Guard call to CDP-only reporting method (avoid encodeToByteArray calculation)
     if (isDebuggingEnabled()) {
       reportDataReceivedImpl(requestId, data.encodeToByteArray().size)
     }
   }
 
-  @JvmStatic external fun reportDataReceivedImpl(requestId: String, dataLength: Int)
+  @JvmStatic public external fun reportDataReceivedImpl(requestId: String, dataLength: Int)
 
   /**
    * Report when a network request is complete and we are no longer receiving response data.
    * - Corresponds to `Network.loadingFinished` in CDP.
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
    */
-  @JvmStatic external fun reportResponseEnd(requestId: String, encodedDataLength: Long)
+  @JvmStatic public external fun reportResponseEnd(requestId: String, encodedDataLength: Long)
 
   /**
    * Report when a network request has failed.
    *
    * Corresponds to `Network.loadingFailed` in CDP.
    */
-  @JvmStatic external fun reportRequestFailed(requestId: String, cancelled: Boolean)
+  @JvmStatic public external fun reportRequestFailed(requestId: String, cancelled: Boolean)
 
   /**
    * Store response body preview. This is an optional reporting method, and is a no-op if CDP
    * debugging is disabled.
    */
   @JvmStatic
-  fun maybeStoreResponseBody(requestId: String, body: String, base64Encoded: Boolean) {
+  public fun maybeStoreResponseBody(requestId: String, body: String, base64Encoded: Boolean) {
     // Guard call to CDP-only reporting method (avoid sending string over JNI)
     if (isDebuggingEnabled()) {
       maybeStoreResponseBodyImpl(requestId, body, base64Encoded)
@@ -110,7 +113,11 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun maybeStoreResponseBodyImpl(requestId: String, body: String, base64Encoded: Boolean)
+  public external fun maybeStoreResponseBodyImpl(
+      requestId: String,
+      body: String,
+      base64Encoded: Boolean,
+  )
 
   /**
    * Incrementally store a response body preview, when a string response is received in chunks.
@@ -120,21 +127,22 @@ internal object InspectorNetworkReporter {
    * is disabled.
    */
   @JvmStatic
-  fun maybeStoreResponseBodyIncremental(requestId: String, data: String) {
+  public fun maybeStoreResponseBodyIncremental(requestId: String, data: String) {
     // Guard call to CDP-only reporting method (avoid sending string over JNI)
     if (isDebuggingEnabled()) {
       maybeStoreResponseBodyIncrementalImpl(requestId, data)
     }
   }
 
-  @JvmStatic external fun maybeStoreResponseBodyIncrementalImpl(requestId: String, data: String)
+  @JvmStatic
+  public external fun maybeStoreResponseBodyIncrementalImpl(requestId: String, data: String)
 
   /**
    * Report that a WebSocket connection is about to be created.
    *
    * Corresponds to `Network.webSocketCreated` in CDP.
    */
-  @JvmStatic external fun reportWebSocketCreated(requestId: String, url: String)
+  @JvmStatic public external fun reportWebSocketCreated(requestId: String, url: String)
 
   /**
    * Report that a WebSocket handshake (HTTP upgrade) request is about to be sent, along with its
@@ -143,7 +151,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketWillSendHandshakeRequest` in CDP.
    */
   @JvmStatic
-  external fun reportWebSocketWillSendHandshakeRequest(
+  public external fun reportWebSocketWillSendHandshakeRequest(
       requestId: String,
       headers: Map<String, String>,
   )
@@ -154,7 +162,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketHandshakeResponseReceived` in CDP.
    */
   @JvmStatic
-  external fun reportWebSocketHandshakeResponseReceived(
+  public external fun reportWebSocketHandshakeResponseReceived(
       requestId: String,
       statusCode: Int,
       headers: Map<String, String>,
@@ -166,7 +174,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameSent` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageSent(requestId: String, message: String) {
+  public fun reportWebSocketMessageSent(requestId: String, message: String) {
     if (isDebuggingEnabled()) {
       reportWebSocketMessageSentImpl(requestId, message, false)
     }
@@ -178,7 +186,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameSent` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageSent(requestId: String, message: ByteString) {
+  public fun reportWebSocketMessageSent(requestId: String, message: ByteString) {
     // Guard call to CDP-only reporting method (avoid base64 encoding)
     if (isDebuggingEnabled()) {
       reportWebSocketMessageSentImpl(requestId, message.base64(), true)
@@ -186,7 +194,7 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun reportWebSocketMessageSentImpl(
+  public external fun reportWebSocketMessageSentImpl(
       requestId: String,
       payloadData: String,
       isBinary: Boolean,
@@ -198,7 +206,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameReceived` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageReceived(requestId: String, message: String) {
+  public fun reportWebSocketMessageReceived(requestId: String, message: String) {
     if (isDebuggingEnabled()) {
       reportWebSocketMessageReceivedImpl(requestId, message, false)
     }
@@ -210,7 +218,7 @@ internal object InspectorNetworkReporter {
    * Corresponds to `Network.webSocketFrameReceived` in CDP.
    */
   @JvmStatic
-  fun reportWebSocketMessageReceived(requestId: String, message: ByteString) {
+  public fun reportWebSocketMessageReceived(requestId: String, message: ByteString) {
     // Guard call to CDP-only reporting method (avoid base64 encoding)
     if (isDebuggingEnabled()) {
       reportWebSocketMessageReceivedImpl(requestId, message.base64(), true)
@@ -218,7 +226,7 @@ internal object InspectorNetworkReporter {
   }
 
   @JvmStatic
-  external fun reportWebSocketMessageReceivedImpl(
+  public external fun reportWebSocketMessageReceivedImpl(
       requestId: String,
       payloadData: String,
       isBinary: Boolean,
@@ -229,5 +237,5 @@ internal object InspectorNetworkReporter {
    *
    * Corresponds to `Network.webSocketClosed` in CDP.
    */
-  @JvmStatic external fun reportWebSocketClosed(requestId: String)
+  @JvmStatic public external fun reportWebSocketClosed(requestId: String)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -6,6 +6,7 @@
  */
 
 @file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+@file:OptIn(UnstableReactNativeAPI::class)
 
 package com.facebook.react.modules.network
 
@@ -15,6 +16,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableArray
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import java.io.IOException
 import java.net.SocketTimeoutException
 import okhttp3.Headers

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -98,10 +98,17 @@ public class NetworkingModule(
 
   init {
     var resolvedClient: OkHttpClient = client
-    if (networkInterceptorCreators != null) {
+    if (networkInterceptorCreators != null || ReactBuildConfig.DEBUG) {
       val clientBuilder = client.newBuilder()
-      for (networkInterceptorCreator in networkInterceptorCreators) {
-        clientBuilder.addNetworkInterceptor(networkInterceptorCreator.create())
+      if (networkInterceptorCreators != null) {
+        for (networkInterceptorCreator in networkInterceptorCreators) {
+          clientBuilder.addNetworkInterceptor(networkInterceptorCreator.create())
+        }
+      }
+      if (ReactBuildConfig.DEBUG) {
+        // Simulated network throttling for CDP debugging. NOTE: Debugger and
+        // Metro traffic uses separate OkHttp clients and is never throttled.
+        clientBuilder.addInterceptor(InspectorNetworkEmulationInterceptor())
       }
       resolvedClient = clientBuilder.build()
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -6,6 +6,7 @@
  */
 
 @file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+@file:OptIn(UnstableReactNativeAPI::class)
 
 package com.facebook.react.modules.websocket
 
@@ -19,6 +20,7 @@ import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.modules.network.CustomClientBuilder

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorNetworkEmulationSession.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorNetworkEmulationSession.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JInspectorNetworkEmulationSession.h"
+
+#include <jsinspector-modern/network/NetworkThrottler.h>
+
+#include <algorithm>
+#include <chrono>
+#include <future>
+#include <memory>
+
+using namespace facebook::jni;
+
+namespace facebook::react::jsinspector_modern {
+
+/* static */ jboolean JInspectorNetworkEmulationSession::isOffline(
+    jni::alias_ref<jclass> /*unused*/) {
+  return static_cast<jboolean>(NetworkThrottler::getInstance().isOffline());
+}
+
+/* static */ jboolean JInspectorNetworkEmulationSession::isThrottling(
+    jni::alias_ref<jclass> /*unused*/) {
+  return static_cast<jboolean>(NetworkThrottler::getInstance().isThrottling());
+}
+
+/* static */ jlong JInspectorNetworkEmulationSession::createRecordToken(
+    jni::alias_ref<jclass> /*unused*/) {
+  return static_cast<jlong>(
+      NetworkThrottler::getInstance().createRecordToken());
+}
+
+/* static */ jlong JInspectorNetworkEmulationSession::awaitThrottle(
+    jni::alias_ref<jclass> /*unused*/,
+    jlong token,
+    jlong bytes,
+    jdouble sendEndAgeMs,
+    jboolean isStart) {
+  auto& throttler = NetworkThrottler::getInstance();
+
+  auto sendEnd = NetworkThrottler::Clock::now() -
+      std::chrono::duration_cast<NetworkThrottler::Clock::duration>(
+                     std::chrono::duration<double, std::milli>(
+                         std::max(0.0, static_cast<double>(sendEndAgeMs))));
+
+  // Block the calling (OkHttp dispatcher) thread until the operation is
+  // released. Records always complete eventually: rate-limited by the timer,
+  // or flushed when conditions change.
+  auto promise = std::make_shared<std::promise<std::pair<bool, int64_t>>>();
+  auto result = throttler.startThrottle(
+      static_cast<uint64_t>(token),
+      static_cast<int64_t>(bytes),
+      sendEnd,
+      isStart != 0u,
+      /* isUpload */ false,
+      [promise](bool disconnected, int64_t newDebt) {
+        promise->set_value({disconnected, newDebt});
+      });
+
+  switch (result) {
+    case NetworkThrottler::StartResult::PassThrough:
+      return bytes;
+    case NetworkThrottler::StartResult::Disconnected:
+      jni::throwNewJavaException(
+          "java/net/UnknownHostException",
+          "Unable to resolve host: offline mode is emulated by React Native DevTools");
+    case NetworkThrottler::StartResult::Pending: {
+      auto [disconnected, newDebt] = promise->get_future().get();
+      if (disconnected) {
+        jni::throwNewJavaException(
+            "java/net/UnknownHostException",
+            "Unable to resolve host: offline mode is emulated by React Native DevTools");
+      }
+      return static_cast<jlong>(newDebt);
+    }
+  }
+  return bytes;
+}
+
+/* static */ void JInspectorNetworkEmulationSession::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "isOffline", JInspectorNetworkEmulationSession::isOffline),
+      makeNativeMethod(
+          "isThrottling", JInspectorNetworkEmulationSession::isThrottling),
+      makeNativeMethod(
+          "createRecordToken",
+          JInspectorNetworkEmulationSession::createRecordToken),
+      makeNativeMethod(
+          "awaitThrottle", JInspectorNetworkEmulationSession::awaitThrottle),
+  });
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorNetworkEmulationSession.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorNetworkEmulationSession.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace facebook::react::jsinspector_modern {
+
+class JInspectorNetworkEmulationSession : public jni::HybridClass<JInspectorNetworkEmulationSession> {
+ public:
+  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/modules/network/InspectorNetworkEmulationSession;";
+
+  static jboolean isOffline(jni::alias_ref<jclass> /*unused*/);
+
+  static jboolean isThrottling(jni::alias_ref<jclass> /*unused*/);
+
+  static jlong createRecordToken(jni::alias_ref<jclass> /*unused*/);
+
+  static jlong
+  awaitThrottle(jni::alias_ref<jclass> /*unused*/, jlong token, jlong bytes, jdouble sendEndAgeMs, jboolean isStart);
+
+  static void registerNatives();
+
+ private:
+  JInspectorNetworkEmulationSession() = delete;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/OnLoad.cpp
@@ -8,6 +8,7 @@
 #include "JCxxInspectorPackagerConnection.h"
 #include "JCxxInspectorPackagerConnectionWebSocketDelegate.h"
 #include "JInspectorFlags.h"
+#include "JInspectorNetworkEmulationSession.h"
 #include "JInspectorNetworkReporter.h"
 
 #include <fbjni/fbjni.h>
@@ -20,6 +21,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* /*unused*/) {
         JCxxInspectorPackagerConnectionWebSocketDelegate::registerNatives();
     facebook::react::jsinspector_modern::JInspectorFlags::registerNatives();
     facebook::react::jsinspector_modern::JInspectorNetworkReporter::
+        registerNatives();
+    facebook::react::jsinspector_modern::JInspectorNetworkEmulationSession::
         registerNatives();
   });
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7513432f85b9832654814f381b13fe97>>
+ * @generated SignedSource<<1ffa383ec45a8a72e6f7580c88dc779e>>
  */
 
 /**
@@ -390,6 +390,12 @@ class ReactNativeFeatureFlagsJavaProvider
   bool fuseboxFrameRecordingEnabled() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("fuseboxFrameRecordingEnabled");
+    return method(javaProvider_);
+  }
+
+  bool fuseboxNetworkThrottlingEnabled() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("fuseboxNetworkThrottlingEnabled");
     return method(javaProvider_);
   }
 
@@ -860,6 +866,11 @@ bool JReactNativeFeatureFlagsCxxInterop::fuseboxFrameRecordingEnabled(
   return ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkThrottlingEnabled(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::fuseboxScreenshotCaptureEnabled(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled();
@@ -1208,6 +1219,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "fuseboxFrameRecordingEnabled",
         JReactNativeFeatureFlagsCxxInterop::fuseboxFrameRecordingEnabled),
+      makeNativeMethod(
+        "fuseboxNetworkThrottlingEnabled",
+        JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkThrottlingEnabled),
       makeNativeMethod(
         "fuseboxScreenshotCaptureEnabled",
         JReactNativeFeatureFlagsCxxInterop::fuseboxScreenshotCaptureEnabled),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9689c541fa98ffbaf9f5d83077ab1208>>
+ * @generated SignedSource<<7bca41bc389c1008b40a08c6293220b1>>
  */
 
 /**
@@ -205,6 +205,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool fuseboxFrameRecordingEnabled(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool fuseboxNetworkThrottlingEnabled(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool fuseboxScreenshotCaptureEnabled(

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -328,6 +328,7 @@ namespace {
 struct StaticHostTargetMetadata {
   std::optional<bool> isProfilingBuild;
   std::optional<bool> networkInspectionEnabled;
+  std::optional<bool> networkThrottlingEnabled;
   std::optional<bool> frameRecordingEnabled;
 };
 
@@ -337,6 +338,7 @@ StaticHostTargetMetadata getStaticHostMetadata() {
   return {
       .isProfilingBuild = inspectorFlags.getIsProfilingBuild(),
       .networkInspectionEnabled = true,
+      .networkThrottlingEnabled = inspectorFlags.getNetworkThrottlingEnabled(),
       .frameRecordingEnabled = inspectorFlags.getFrameRecordingEnabled()};
 }
 
@@ -371,6 +373,10 @@ folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata) {
   if (staticMetadata.networkInspectionEnabled) {
     result["unstable_networkInspectionEnabled"] =
         staticMetadata.networkInspectionEnabled.value();
+  }
+  if (staticMetadata.networkThrottlingEnabled) {
+    result["unstable_networkThrottlingEnabled"] =
+        staticMetadata.networkThrottlingEnabled.value();
   }
   if (staticMetadata.frameRecordingEnabled) {
     result["unstable_frameRecordingEnabled"] =

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -41,6 +41,10 @@ bool InspectorFlags::getIsProfilingBuild() const {
   return loadFlagsAndAssertUnchanged().isProfilingBuild;
 }
 
+bool InspectorFlags::getNetworkThrottlingEnabled() const {
+  return loadFlagsAndAssertUnchanged().networkThrottlingEnabled;
+}
+
 bool InspectorFlags::getPerfIssuesEnabled() const {
   return loadFlagsAndAssertUnchanged().perfIssuesEnabled;
 }
@@ -77,6 +81,8 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
 #else
           false,
 #endif
+      .networkThrottlingEnabled =
+          ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled(),
       .perfIssuesEnabled = ReactNativeFeatureFlags::perfIssuesEnabled(),
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -51,6 +51,12 @@ class InspectorFlags {
   bool getFrameRecordingEnabled() const;
 
   /**
+   * Flag determining if simulated network throttling
+   * (Network.emulateNetworkConditions) is enabled.
+   */
+  bool getNetworkThrottlingEnabled() const;
+
+  /**
    * Flag determining if the V2 in-app Performance Monitor is enabled.
    */
   bool getPerfIssuesEnabled() const;
@@ -74,6 +80,7 @@ class InspectorFlags {
     bool frameRecordingEnabled;
     bool fuseboxEnabled;
     bool isProfilingBuild;
+    bool networkThrottlingEnabled;
     bool perfIssuesEnabled;
     bool operator==(const Values &) const = default;
   };

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -11,6 +11,7 @@
 #include "Utf8.h"
 
 #include <jsinspector-modern/network/NetworkHandler.h>
+#include <jsinspector-modern/network/NetworkThrottler.h>
 #include <react/utils/Base64.h>
 
 #include <sstream>
@@ -305,7 +306,56 @@ bool NetworkIOAgent::handleRequest(
     return true;
   }
 
+  // @cdp Network.emulateNetworkConditions support is experimental.
+  if (req.method == "Network.emulateNetworkConditions" &&
+      InspectorFlags::getInstance().getNetworkThrottlingEnabled()) {
+    handleEmulateNetworkConditions(req);
+    return true;
+  }
+
   return false;
+}
+
+void NetworkIOAgent::handleEmulateNetworkConditions(
+    const cdp::PreparsedRequest& req) {
+  long long requestId = req.id;
+  if (!req.params.isObject()) {
+    frontendChannel_(
+        cdp::jsonError(
+            requestId,
+            cdp::ErrorCode::InvalidParams,
+            "Invalid params: not an object."));
+    return;
+  }
+  if ((req.params.count("offline") == 0u) ||
+      !req.params.at("offline").isBool()) {
+    frontendChannel_(
+        cdp::jsonError(
+            requestId,
+            cdp::ErrorCode::InvalidParams,
+            "Invalid params: offline is missing or not a boolean."));
+    return;
+  }
+
+  auto numberParam = [&](const char* key) -> double {
+    auto it = req.params.find(key);
+    return it != req.params.items().end() && it->second.isNumber()
+        ? it->second.asDouble()
+        : 0;
+  };
+
+  // NOTE: packetLoss, packetQueueLength, packetReordering (WebRTC-only in
+  // Chrome) and connectionType are accepted and ignored. Negative throughput
+  // and latency values mean "no limit" and are normalized to 0.
+  NetworkThrottler::getInstance().updateConditions(
+      NetworkConditions{
+          .offline = req.params.at("offline").asBool(),
+          .latencyMs = numberParam("latency"),
+          .downloadThroughputBps = numberParam("downloadThroughput"),
+          .uploadThroughputBps = numberParam("uploadThroughput"),
+      });
+
+  frontendChannel_(cdp::jsonResult(requestId));
 }
 
 void NetworkIOAgent::handleLoadNetworkResource(

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -284,6 +284,11 @@ class NetworkIOAgent {
    * Handle a Network.getResponseBody CDP request.
    */
   void handleGetResponseBody(const cdp::PreparsedRequest &req);
+
+  /**
+   * Handle a Network.emulateNetworkConditions CDP request.
+   */
+  void handleEmulateNetworkConditions(const cdp::PreparsedRequest &req);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkConditions.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkConditions.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Simulated network conditions, set via the CDP method
+ * `Network.emulateNetworkConditions`. Mirrors Chrome's
+ * `network::NetworkConditions` value object.
+ *
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-emulateNetworkConditions
+ */
+struct NetworkConditions {
+  /** Whether to emulate a total network outage. */
+  bool offline{false};
+
+  /**
+   * Minimum request-to-response-headers duration, in milliseconds. NOTE:
+   * This is a floor on the observed duration measured from when the request
+   * finished sending, not an added delay. 0 = no latency emulation.
+   */
+  double latencyMs{0};
+
+  /** Maximal aggregated download throughput (bytes/sec). 0 = no limit. */
+  double downloadThroughputBps{0};
+
+  /** Maximal aggregated upload throughput (bytes/sec). 0 = no limit. */
+  double uploadThroughputBps{0};
+
+  /**
+   * Whether any throttling behavior is active under these conditions
+   * (excluding the offline state).
+   */
+  bool isThrottling() const
+  {
+    return !offline && (latencyMs > 0 || downloadThroughputBps > 0 || uploadThroughputBps > 0);
+  }
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkThrottler.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkThrottler.cpp
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NetworkThrottler.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+using DoubleSeconds = std::chrono::duration<double>;
+using DoubleMillis = std::chrono::duration<double, std::milli>;
+
+NetworkThrottler::Clock::duration latencyDuration(
+    const NetworkConditions& conditions) {
+  return std::chrono::duration_cast<NetworkThrottler::Clock::duration>(
+      DoubleMillis(std::max(0.0, conditions.latencyMs)));
+}
+
+} // namespace
+
+/* static */ NetworkThrottler& NetworkThrottler::getInstance() {
+  static NetworkThrottler instance;
+  return instance;
+}
+
+NetworkThrottler::NetworkThrottler()
+    : clock_(&Clock::now), useTimerThread_(true) {}
+
+NetworkThrottler::NetworkThrottler(ClockFunction clock)
+    : clock_(std::move(clock)), useTimerThread_(false) {}
+
+NetworkThrottler::~NetworkThrottler() {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    shutdown_ = true;
+  }
+  timerCv_.notify_all();
+  if (timerThread_.joinable()) {
+    timerThread_.join();
+  }
+}
+
+/* static */ double NetworkThrottler::tickLengthSeconds(double throughputBps) {
+  // 1 microsecond guards against division by zero; with no throughput limit,
+  // records complete on the next timer fire.
+  return throughputBps > 0 ? static_cast<double>(kPacketSize) / throughputBps
+                           : 1e-6;
+}
+
+void NetworkThrottler::updateConditions(const NetworkConditions& conditions) {
+  std::vector<PendingCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = clock_();
+
+    // Flush accounting under the old conditions
+    updateTickAccounting(now, callbacks);
+
+    // Normalize: negative values ("no limit" per CDP) are stored as 0
+    conditions_ = NetworkConditions{
+        .offline = conditions.offline,
+        .latencyMs = std::max(0.0, conditions.latencyMs),
+        .downloadThroughputBps =
+            std::max(0.0, conditions.downloadThroughputBps),
+        .uploadThroughputBps = std::max(0.0, conditions.uploadThroughputBps),
+    };
+
+    if (conditions_.offline || !conditions_.isThrottling()) {
+      // Immediately finish all queued and suspended records, with the
+      // disconnect error if going offline.
+      for (auto* queue : {&download_, &upload_, &suspended_}) {
+        for (auto& record : *queue) {
+          callbacks.emplace_back(
+              std::move(record.callback),
+              std::make_pair(conditions_.offline, record.bytes));
+        }
+        queue->clear();
+      }
+      timerDeadline_.reset();
+      timerCv_.notify_all();
+    } else {
+      offset_ = now;
+      downloadLastTick_ = 0;
+      uploadLastTick_ = 0;
+      downloadTickLength_ =
+          tickLengthSeconds(conditions_.downloadThroughputBps);
+      uploadTickLength_ = tickLengthSeconds(conditions_.uploadThroughputBps);
+      updateSuspended(now);
+      collectFinished(download_, callbacks);
+      collectFinished(upload_, callbacks);
+      armTimer(now);
+    }
+  }
+  firePendingCallbacks(callbacks);
+}
+
+NetworkConditions NetworkThrottler::getConditions() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return conditions_;
+}
+
+bool NetworkThrottler::isOffline() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return conditions_.offline;
+}
+
+bool NetworkThrottler::isThrottling() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return conditions_.isThrottling();
+}
+
+uint64_t NetworkThrottler::createRecordToken() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return nextToken_++;
+}
+
+NetworkThrottler::StartResult NetworkThrottler::startThrottle(
+    uint64_t token,
+    int64_t bytes,
+    TimePoint sendEnd,
+    bool isStart,
+    bool isUpload,
+    ThrottleCallback callback) {
+  std::vector<PendingCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = clock_();
+
+    if (conditions_.offline) {
+      // Downloads fail with a "not connected" error; uploads pass through
+      // with their real result.
+      return isUpload ? StartResult::PassThrough : StartResult::Disconnected;
+    }
+
+    double throughput = isUpload ? conditions_.uploadThroughputBps
+                                 : conditions_.downloadThroughputBps;
+
+    if (isStart && conditions_.latencyMs > 0) {
+      // Park until `latency` ms have elapsed since the request was actually
+      // sent. updateTickAccounting below may release it immediately.
+      suspended_.push_back(
+          ThrottleRecord{token, bytes, sendEnd, isUpload, std::move(callback)});
+      updateTickAccounting(now, callbacks);
+    } else if (throughput > 0) {
+      // Flush elapsed ticks first, so the new record gets no retroactive
+      // byte budget.
+      updateTickAccounting(now, callbacks);
+      (isUpload ? upload_ : download_)
+          .push_back(
+              ThrottleRecord{
+                  token, bytes, sendEnd, isUpload, std::move(callback)});
+    } else {
+      // No latency and no throughput for this direction and stage.
+      return StartResult::PassThrough;
+    }
+
+    armTimer(now);
+  }
+  firePendingCallbacks(callbacks);
+  return StartResult::Pending;
+}
+
+void NetworkThrottler::stopThrottle(uint64_t token) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto* queue : {&download_, &upload_, &suspended_}) {
+    queue->erase(
+        std::remove_if(
+            queue->begin(),
+            queue->end(),
+            [token](const ThrottleRecord& record) {
+              return record.token == token;
+            }),
+        queue->end());
+  }
+  armTimer(clock_());
+}
+
+int64_t NetworkThrottler::getReadBufLen(int64_t bufLen) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return conditions_.downloadThroughputBps > 0 ? std::min(bufLen, kPacketSize)
+                                               : bufLen;
+}
+
+int64_t NetworkThrottler::updateThrottledRecords(
+    TimePoint now,
+    std::vector<ThrottleRecord>& records,
+    int64_t lastTick,
+    double tickLengthSeconds) {
+  if (tickLengthSeconds <= 0) {
+    return lastTick;
+  }
+
+  auto newTick = static_cast<int64_t>(
+      std::floor(DoubleSeconds(now - offset_).count() / tickLengthSeconds));
+  int64_t ticks = newTick - lastTick;
+
+  auto n = static_cast<int64_t>(records.size());
+  if (n == 0) {
+    return newTick;
+  }
+
+  // Divide the elapsed ticks equally, round-robin, across every record.
+  int64_t shift = ticks % n;
+  for (int64_t i = 0; i < n; i++) {
+    records[i].bytes -=
+        (ticks / n) * kPacketSize + (i < shift ? kPacketSize : 0);
+  }
+  // Rotate so the remainder packets go to different records next time.
+  std::rotate(records.begin(), records.begin() + shift, records.end());
+
+  return newTick;
+}
+
+void NetworkThrottler::updateSuspended(TimePoint now) {
+  if (conditions_.offline) {
+    return;
+  }
+
+  TimePoint activationBaseline = now - latencyDuration(conditions_);
+  std::vector<ThrottleRecord> stillSuspended;
+  for (auto& record : suspended_) {
+    if (record.sendEnd <= activationBaseline) {
+      // Latency satisfied: release into the byte queue.
+      (record.isUpload ? upload_ : download_).push_back(std::move(record));
+    } else {
+      stillSuspended.push_back(std::move(record));
+    }
+  }
+  suspended_ = std::move(stillSuspended);
+}
+
+void NetworkThrottler::collectFinished(
+    std::vector<ThrottleRecord>& records,
+    std::vector<PendingCallback>& callbacks) {
+  // A record is finished when its byte debt goes strictly below zero. The
+  // negative remainder is passed back to be carried into the next operation.
+  auto it = records.begin();
+  while (it != records.end()) {
+    if (it->bytes < 0) {
+      callbacks.emplace_back(
+          std::move(it->callback), std::make_pair(false, it->bytes));
+      it = records.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+void NetworkThrottler::updateTickAccounting(
+    TimePoint now,
+    std::vector<PendingCallback>& callbacks) {
+  downloadLastTick_ = updateThrottledRecords(
+      now, download_, downloadLastTick_, downloadTickLength_);
+  uploadLastTick_ =
+      updateThrottledRecords(now, upload_, uploadLastTick_, uploadTickLength_);
+  updateSuspended(now);
+  collectFinished(download_, callbacks);
+  collectFinished(upload_, callbacks);
+}
+
+NetworkThrottler::TimePoint NetworkThrottler::calculateDesiredTime(
+    const std::vector<ThrottleRecord>& records,
+    int64_t lastTick,
+    double tickLengthSeconds) const {
+  int64_t minTicksLeft = INT64_MAX;
+  auto n = static_cast<int64_t>(records.size());
+  for (int64_t i = 0; i < n; i++) {
+    auto packetsLeft = static_cast<int64_t>(
+        std::ceil(static_cast<double>(records[i].bytes) / kPacketSize));
+    int64_t ticksLeft = (i + 1) + n * (packetsLeft - 1);
+    minTicksLeft = std::min(minTicksLeft, ticksLeft);
+  }
+  // At least one further tick must elapse before any record can go strictly
+  // negative; this also prevents scheduling in the past.
+  minTicksLeft = std::max<int64_t>(minTicksLeft, 1);
+  return offset_ +
+      std::chrono::duration_cast<Clock::duration>(DoubleSeconds(
+          static_cast<double>(lastTick + minTicksLeft) * tickLengthSeconds));
+}
+
+void NetworkThrottler::armTimer(TimePoint now) {
+  TimePoint desired = TimePoint::max();
+  if (!download_.empty()) {
+    desired = std::min(
+        desired,
+        calculateDesiredTime(
+            download_, downloadLastTick_, downloadTickLength_));
+  }
+  if (!upload_.empty()) {
+    desired = std::min(
+        desired,
+        calculateDesiredTime(upload_, uploadLastTick_, uploadTickLength_));
+  }
+  for (const auto& record : suspended_) {
+    desired = std::min(desired, record.sendEnd + latencyDuration(conditions_));
+  }
+
+  if (desired == TimePoint::max()) {
+    timerDeadline_.reset();
+    return;
+  }
+
+  timerDeadline_ = std::max(desired, now);
+  if (useTimerThread_ && !timerThread_.joinable()) {
+    // Lazily start the timer thread on first use, so no thread is created
+    // unless throttling is actually engaged.
+    timerThread_ = std::thread([this] { timerThreadLoop(); });
+  }
+  timerCv_.notify_all();
+}
+
+void NetworkThrottler::timerThreadLoop() {
+  std::unique_lock<std::mutex> lock(mutex_);
+  while (!shutdown_) {
+    if (!timerDeadline_) {
+      timerCv_.wait(lock);
+      continue;
+    }
+    auto deadline = *timerDeadline_;
+    if (Clock::now() < deadline) {
+      timerCv_.wait_until(lock, deadline);
+      // Re-evaluate: the deadline may have moved, or shutdown requested.
+      continue;
+    }
+    timerDeadline_.reset();
+    std::vector<PendingCallback> callbacks;
+    auto now = clock_();
+    updateTickAccounting(now, callbacks);
+    armTimer(now);
+    lock.unlock();
+    firePendingCallbacks(callbacks);
+    lock.lock();
+  }
+}
+
+void NetworkThrottler::onTimerFired() {
+  std::vector<PendingCallback> callbacks;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto now = clock_();
+    timerDeadline_.reset();
+    updateTickAccounting(now, callbacks);
+    armTimer(now);
+  }
+  firePendingCallbacks(callbacks);
+}
+
+std::optional<NetworkThrottler::TimePoint>
+NetworkThrottler::getTimerDeadlineForTest() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return timerDeadline_;
+}
+
+void NetworkThrottler::firePendingCallbacks(
+    std::vector<PendingCallback>& callbacks) {
+  for (auto& [callback, result] : callbacks) {
+    callback(result.first, result.second);
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkThrottler.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkThrottler.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "NetworkConditions.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * [Experimental] Simulated network throttling engine for CDP debugging.
+ *
+ * This is a port of Chrome's request-level throttling model
+ * (`services/network/throttling/throttling_network_interceptor.cc`). Real
+ * requests go out at full speed; the throttler delays the delivery of
+ * already-received bytes to the consumer. Time is quantized into ticks of
+ * one 1500-byte packet, with elapsed ticks divided equally, round-robin,
+ * across all in-flight transfers. Latency is a minimum duration for the
+ * response-headers stage, measured from when the request finished sending.
+ */
+class NetworkThrottler {
+ public:
+  using Clock = std::chrono::steady_clock;
+  using TimePoint = Clock::time_point;
+  using ClockFunction = std::function<TimePoint()>;
+
+  /**
+   * Callback invoked (from an arbitrary thread) when a pending throttled
+   * operation is released.
+   *
+   * \param disconnected Whether the operation was failed by going offline.
+   * The caller should fail the request with a platform "not connected" error
+   * and latch the failure for the rest of the request.
+   * \param bytes The remaining byte debt for the transaction, normally
+   * negative. The caller must carry this value into the `bytes` argument of
+   * its next `startThrottle` call for the same transaction, so quantization
+   * error does not accumulate.
+   */
+  using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+
+  /**
+   * Synchronous result of `startThrottle`.
+   */
+  enum class StartResult {
+    /** Not throttled. Deliver immediately; no callback will fire. */
+    PassThrough,
+    /** Offline. Fail the request immediately; no callback will fire. */
+    Disconnected,
+    /** Queued. The callback will fire when the operation is released. */
+    Pending,
+  };
+
+  /** The throttling quantum: tick budget and read buffer cap, in bytes. */
+  static constexpr int64_t kPacketSize = 1500;
+
+  /**
+   * Get the global throttler instance, backed by the real clock and an
+   * internal timer thread (started lazily on first use).
+   */
+  static NetworkThrottler &getInstance();
+
+  /**
+   * Create a throttler with an injected clock and no timer thread, for
+   * deterministic testing. Call `onTimerFired` manually to advance work.
+   */
+  explicit NetworkThrottler(ClockFunction clock);
+
+  ~NetworkThrottler();
+  NetworkThrottler(const NetworkThrottler &) = delete;
+  NetworkThrottler &operator=(const NetworkThrottler &) = delete;
+
+  /**
+   * Replace the current network conditions. Accounting for in-flight records
+   * is flushed under the old conditions first. If the new conditions are
+   * offline or non-throttling, all queued and suspended records are finished
+   * immediately (with `disconnected` = true if offline).
+   */
+  void updateConditions(const NetworkConditions &conditions);
+
+  NetworkConditions getConditions() const;
+
+  bool isOffline() const;
+
+  /** Whether any throttling behavior is currently active. */
+  bool isThrottling() const;
+
+  /**
+   * Create an opaque token identifying one pending throttled operation, for
+   * use with `startThrottle`/`stopThrottle`.
+   */
+  uint64_t createRecordToken();
+
+  /**
+   * Submit an operation for throttling.
+   *
+   * \param token Identifies the operation (see `createRecordToken`).
+   * \param bytes The transaction's cumulative outstanding byte debt: bytes
+   * newly received plus any (negative) remainder carried from the previous
+   * callback.
+   * \param sendEnd The real time at which the request finished being sent.
+   * Only meaningful when `isStart` is true.
+   * \param isStart Whether this is the response-headers stage (subject to
+   * the latency floor). Body reads must pass false.
+   * \param isUpload Whether this operation counts against upload throughput.
+   */
+  StartResult startThrottle(
+      uint64_t token,
+      int64_t bytes,
+      TimePoint sendEnd,
+      bool isStart,
+      bool isUpload,
+      ThrottleCallback callback);
+
+  /**
+   * Remove any pending record for `token` without firing its callback. Call
+   * on request cancellation or teardown.
+   */
+  void stopThrottle(uint64_t token);
+
+  /**
+   * Clamp a read buffer length to the packet size while download throttling
+   * is active, so response bodies are delivered in packet-sized increments.
+   */
+  int64_t getReadBufLen(int64_t bufLen) const;
+
+  /**
+   * Process elapsed ticks and release any completed or unsuspended records.
+   * Called by the internal timer thread; public for use in tests.
+   */
+  void onTimerFired();
+
+  /**
+   * The next scheduled timer deadline, if any. Exposed for tests.
+   */
+  std::optional<TimePoint> getTimerDeadlineForTest() const;
+
+ private:
+  struct ThrottleRecord {
+    uint64_t token;
+    int64_t bytes;
+    TimePoint sendEnd;
+    bool isUpload;
+    ThrottleCallback callback;
+  };
+
+  /** Constructs the shared instance (real clock + timer thread). */
+  NetworkThrottler();
+
+  using PendingCallback = std::pair<ThrottleCallback, std::pair<bool, int64_t>>;
+
+  int64_t updateThrottledRecords(
+      TimePoint now,
+      std::vector<ThrottleRecord> &records,
+      int64_t lastTick,
+      double tickLengthSeconds);
+  void updateSuspended(TimePoint now);
+  void collectFinished(std::vector<ThrottleRecord> &records, std::vector<PendingCallback> &callbacks);
+  void updateTickAccounting(TimePoint now, std::vector<PendingCallback> &callbacks);
+  TimePoint calculateDesiredTime(const std::vector<ThrottleRecord> &records, int64_t lastTick, double tickLengthSeconds)
+      const;
+  void armTimer(TimePoint now);
+  void timerThreadLoop();
+  void firePendingCallbacks(std::vector<PendingCallback> &callbacks);
+  static double tickLengthSeconds(double throughputBps);
+
+  ClockFunction clock_;
+  bool useTimerThread_{false};
+
+  mutable std::mutex mutex_;
+  NetworkConditions conditions_{};
+  TimePoint offset_{};
+  std::vector<ThrottleRecord> download_{};
+  std::vector<ThrottleRecord> upload_{};
+  std::vector<ThrottleRecord> suspended_{};
+  int64_t downloadLastTick_{0};
+  int64_t uploadLastTick_{0};
+  double downloadTickLength_{0};
+  double uploadTickLength_{0};
+  uint64_t nextToken_{1};
+
+  std::optional<TimePoint> timerDeadline_{};
+  std::condition_variable timerCv_;
+  std::thread timerThread_;
+  bool shutdown_{false};
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -360,7 +360,8 @@ TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
                                             "integrationName": "JsiIntegrationTest",
                                             "unstable_frameRecordingEnabled": false,
                                             "unstable_isProfilingBuild": false,
-                                            "unstable_networkInspectionEnabled": true
+                                            "unstable_networkInspectionEnabled": true,
+                                            "unstable_networkThrottlingEnabled": false
                                           }
                                         })"));
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkThrottlerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkThrottlerTest.cpp
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <jsinspector-modern/network/NetworkThrottler.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/**
+ * Records the result of a throttled operation for assertions.
+ */
+struct RecordedCallback {
+  bool released{false};
+  bool disconnected{false};
+  int64_t bytes{0};
+
+  NetworkThrottler::ThrottleCallback callback() {
+    return [this](bool disconnectedArg, int64_t bytesArg) {
+      released = true;
+      disconnected = disconnectedArg;
+      bytes = bytesArg;
+    };
+  }
+};
+
+} // namespace
+
+/**
+ * Tests for the throttling algorithm, driven by a fake clock. Scenarios
+ * mirror Chromium's throttling_controller_unittest.cc.
+ */
+class NetworkThrottlerTest : public ::testing::Test {
+ protected:
+  NetworkThrottlerTest() : throttler_([this] { return now_; }) {
+    now_ += 1h; // Arbitrary non-zero baseline
+  }
+
+  void advance(NetworkThrottler::Clock::duration duration) {
+    now_ += duration;
+    throttler_.onTimerFired();
+  }
+
+  NetworkThrottler::TimePoint now_{};
+  NetworkThrottler throttler_;
+};
+
+TEST_F(NetworkThrottlerTest, testUnthrottledPassThrough) {
+  RecordedCallback callback;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          1000,
+          now_,
+          true,
+          false,
+          callback.callback()),
+      NetworkThrottler::StartResult::PassThrough);
+  EXPECT_FALSE(callback.released);
+  EXPECT_FALSE(throttler_.isThrottling());
+  // No read clamp when download throttling is inactive
+  EXPECT_EQ(throttler_.getReadBufLen(65536), 65536);
+}
+
+TEST_F(NetworkThrottlerTest, testSingleDownloadCompletesAtThroughputRate) {
+  // 150,000 B/s = one 1500-byte packet per 10ms tick
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+  EXPECT_EQ(throttler_.getReadBufLen(65536), NetworkThrottler::kPacketSize);
+
+  RecordedCallback callback;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          15000,
+          now_,
+          false,
+          false,
+          callback.callback()),
+      NetworkThrottler::StartResult::Pending);
+
+  // 15,000 bytes at 150,000 B/s ≈ 100ms
+  advance(90ms);
+  EXPECT_FALSE(callback.released);
+  advance(30ms);
+  EXPECT_TRUE(callback.released);
+  EXPECT_FALSE(callback.disconnected);
+  EXPECT_LT(callback.bytes, 0);
+}
+
+TEST_F(NetworkThrottlerTest, testConcurrentDownloadsShareBandwidthEvenly) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  RecordedCallback first;
+  RecordedCallback second;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      15000,
+      now_,
+      false,
+      false,
+      first.callback());
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      15000,
+      now_,
+      false,
+      false,
+      second.callback());
+
+  // Two equal transfers at half bandwidth each ≈ 200ms; neither is starved.
+  advance(150ms);
+  EXPECT_FALSE(first.released);
+  EXPECT_FALSE(second.released);
+  advance(80ms);
+  EXPECT_TRUE(first.released);
+  EXPECT_TRUE(second.released);
+}
+
+TEST_F(NetworkThrottlerTest, testSmallTransferFinishesFirst) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  RecordedCallback small;
+  RecordedCallback large;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      3000,
+      now_,
+      false,
+      false,
+      small.callback());
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      30000,
+      now_,
+      false,
+      false,
+      large.callback());
+
+  // The small transfer needs ~3000B at half bandwidth ≈ 40ms.
+  advance(60ms);
+  EXPECT_TRUE(small.released);
+  EXPECT_FALSE(large.released);
+
+  // The large transfer then gets full bandwidth.
+  advance(200ms);
+  EXPECT_TRUE(large.released);
+}
+
+TEST_F(NetworkThrottlerTest, testLatencyIsAMinimumDurationFloor) {
+  throttler_.updateConditions(
+      NetworkConditions{.offline = false, .latencyMs = 500});
+
+  RecordedCallback callback;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          0,
+          now_,
+          true,
+          false,
+          callback.callback()),
+      NetworkThrottler::StartResult::Pending);
+
+  advance(250ms);
+  EXPECT_FALSE(callback.released);
+  advance(300ms);
+  // Released from suspension into the (unlimited-rate) byte queue.
+  advance(1ms);
+  EXPECT_TRUE(callback.released);
+  EXPECT_FALSE(callback.disconnected);
+}
+
+TEST_F(NetworkThrottlerTest, testSlowServerIsNotDelayedFurther) {
+  throttler_.updateConditions(
+      NetworkConditions{.offline = false, .latencyMs = 500});
+
+  // The request really finished sending 600ms ago: the latency floor is
+  // already satisfied.
+  RecordedCallback callback;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      0,
+      now_ - 600ms,
+      true,
+      false,
+      callback.callback());
+  advance(1ms);
+  EXPECT_TRUE(callback.released);
+}
+
+TEST_F(NetworkThrottlerTest, testLatencyDoesNotApplyToBodyReads) {
+  throttler_.updateConditions(
+      NetworkConditions{.offline = false, .latencyMs = 500});
+
+  // Non-start operations pass through when throughput is unlimited.
+  RecordedCallback callback;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          3000,
+          now_,
+          false,
+          false,
+          callback.callback()),
+      NetworkThrottler::StartResult::PassThrough);
+}
+
+TEST_F(NetworkThrottlerTest, testByteDebtCarriesAcrossReads) {
+  // One packet per 10ms tick
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  auto token = throttler_.createRecordToken();
+  RecordedCallback first;
+  throttler_.startThrottle(token, 1500, now_, false, false, first.callback());
+
+  // 1500 bytes goes strictly negative on the second tick.
+  advance(10ms);
+  EXPECT_FALSE(first.released);
+  advance(10ms);
+  EXPECT_TRUE(first.released);
+  EXPECT_EQ(first.bytes, -1500);
+
+  // Carrying the -1500 credit, the next 1500-byte read completes after a
+  // single further tick, keeping the aggregate rate accurate.
+  RecordedCallback second;
+  throttler_.startThrottle(
+      token, first.bytes + 1500, now_, false, false, second.callback());
+  advance(10ms);
+  EXPECT_TRUE(second.released);
+}
+
+TEST_F(NetworkThrottlerTest, testGoingOfflineFailsPendingDownloads) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  RecordedCallback callback;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      15000,
+      now_,
+      false,
+      false,
+      callback.callback());
+
+  throttler_.updateConditions(NetworkConditions{.offline = true});
+  EXPECT_TRUE(callback.released);
+  EXPECT_TRUE(callback.disconnected);
+
+  // New downloads fail synchronously; uploads pass through.
+  RecordedCallback download;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          100,
+          now_,
+          false,
+          false,
+          download.callback()),
+      NetworkThrottler::StartResult::Disconnected);
+  RecordedCallback upload;
+  EXPECT_EQ(
+      throttler_.startThrottle(
+          throttler_.createRecordToken(),
+          100,
+          now_,
+          false,
+          true,
+          upload.callback()),
+      NetworkThrottler::StartResult::PassThrough);
+}
+
+TEST_F(NetworkThrottlerTest, testDisablingThrottlingReleasesPendingRecords) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 500, .downloadThroughputBps = 150000});
+
+  RecordedCallback suspended;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      0,
+      now_,
+      true,
+      false,
+      suspended.callback());
+  RecordedCallback queued;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      15000,
+      now_,
+      false,
+      false,
+      queued.callback());
+
+  throttler_.updateConditions(NetworkConditions{});
+  EXPECT_TRUE(suspended.released);
+  EXPECT_FALSE(suspended.disconnected);
+  EXPECT_TRUE(queued.released);
+  EXPECT_FALSE(queued.disconnected);
+  EXPECT_FALSE(throttler_.getTimerDeadlineForTest().has_value());
+}
+
+TEST_F(NetworkThrottlerTest, testStopThrottleRemovesRecordWithoutCallback) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  RecordedCallback cancelled;
+  auto token = throttler_.createRecordToken();
+  throttler_.startThrottle(
+      token, 15000, now_, false, false, cancelled.callback());
+  throttler_.stopThrottle(token);
+  EXPECT_FALSE(throttler_.getTimerDeadlineForTest().has_value());
+
+  advance(1s);
+  EXPECT_FALSE(cancelled.released);
+}
+
+TEST_F(NetworkThrottlerTest, testConditionsChangeMidFlightAdjustsRate) {
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 150000});
+
+  RecordedCallback callback;
+  throttler_.startThrottle(
+      throttler_.createRecordToken(),
+      30000,
+      now_,
+      false,
+      false,
+      callback.callback());
+
+  // Half the transfer at the original rate (~100ms of 200ms total)
+  advance(100ms);
+  EXPECT_FALSE(callback.released);
+
+  // Double the rate: the remaining ~15,000 bytes take ~50ms, not 100ms.
+  throttler_.updateConditions(
+      NetworkConditions{
+          .offline = false, .latencyMs = 0, .downloadThroughputBps = 300000});
+  advance(40ms);
+  EXPECT_FALSE(callback.released);
+  advance(20ms);
+  EXPECT_TRUE(callback.released);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<acec83211036df307dd8711e96fcb80c>>
+ * @generated SignedSource<<75002029ba92161ef3db5fdd58d9d287>>
  */
 
 /**
@@ -260,6 +260,10 @@ bool ReactNativeFeatureFlags::fuseboxEnabledRelease() {
 
 bool ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled() {
   return getAccessor().fuseboxFrameRecordingEnabled();
+}
+
+bool ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled() {
+  return getAccessor().fuseboxNetworkThrottlingEnabled();
 }
 
 bool ReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e437a03ac130e2f24a857a64b3677490>>
+ * @generated SignedSource<<e85eed6a07d00c458ea2fd7e194a9458>>
  */
 
 /**
@@ -333,6 +333,11 @@ class ReactNativeFeatureFlags {
    * Enable frame timings and screenshots support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
    */
   RN_EXPORT static bool fuseboxFrameRecordingEnabled();
+
+  /**
+   * Enable simulated network throttling (Network.emulateNetworkConditions) in the React Native DevTools CDP backend.
+   */
+  RN_EXPORT static bool fuseboxNetworkThrottlingEnabled();
 
   /**
    * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c1a9ad1347a455ab5973df3231ac8cb4>>
+ * @generated SignedSource<<3e96a9225b47467301fa3497bc3b16f6>>
  */
 
 /**
@@ -1091,6 +1091,24 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxFrameRecordingEnabled() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::fuseboxNetworkThrottlingEnabled() {
+  auto flagValue = fuseboxNetworkThrottlingEnabled_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(59, "fuseboxNetworkThrottlingEnabled");
+
+    flagValue = currentProvider_->fuseboxNetworkThrottlingEnabled();
+    fuseboxNetworkThrottlingEnabled_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
   auto flagValue = fuseboxScreenshotCaptureEnabled_.load();
 
@@ -1100,7 +1118,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(59, "fuseboxScreenshotCaptureEnabled");
+    markFlagAsAccessed(60, "fuseboxScreenshotCaptureEnabled");
 
     flagValue = currentProvider_->fuseboxScreenshotCaptureEnabled();
     fuseboxScreenshotCaptureEnabled_ = flagValue;
@@ -1118,7 +1136,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxWebSocketEventsEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(60, "fuseboxWebSocketEventsEnabled");
+    markFlagAsAccessed(61, "fuseboxWebSocketEventsEnabled");
 
     flagValue = currentProvider_->fuseboxWebSocketEventsEnabled();
     fuseboxWebSocketEventsEnabled_ = flagValue;
@@ -1136,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "optimizedAnimatedPropUpdates");
+    markFlagAsAccessed(62, "optimizedAnimatedPropUpdates");
 
     flagValue = currentProvider_->optimizedAnimatedPropUpdates();
     optimizedAnimatedPropUpdates_ = flagValue;
@@ -1154,7 +1172,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(63, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1172,7 +1190,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "perfIssuesEnabled");
+    markFlagAsAccessed(64, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1190,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "perfMonitorV2Enabled");
+    markFlagAsAccessed(65, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1208,7 +1226,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "preparedTextCacheSize");
+    markFlagAsAccessed(66, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1226,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(67, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1244,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "redBoxV2Android");
+    markFlagAsAccessed(68, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1262,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "redBoxV2IOS");
+    markFlagAsAccessed(69, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1280,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(70, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1298,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(71, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1316,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(72, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1334,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(73, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1352,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(74, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1370,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(75, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1388,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(76, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1406,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(77, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1424,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useFabricInterop");
+    markFlagAsAccessed(78, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1442,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(79, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1460,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(80, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1478,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useSharedAnimatedBackend");
+    markFlagAsAccessed(81, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1496,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(82, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1514,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useTurboModuleInterop");
+    markFlagAsAccessed(83, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1532,7 +1550,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewCullingOutsetRatio");
+    markFlagAsAccessed(84, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1550,7 +1568,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewTransitionEnabled");
+    markFlagAsAccessed(85, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1568,7 +1586,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(86, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1586,7 +1604,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(87, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c08fb696ba1dc5b90155163ca690f218>>
+ * @generated SignedSource<<f610474335cc0a13f2556dbe49b58c32>>
  */
 
 /**
@@ -91,6 +91,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool fuseboxAssertSingleHostState();
   bool fuseboxEnabledRelease();
   bool fuseboxFrameRecordingEnabled();
+  bool fuseboxNetworkThrottlingEnabled();
   bool fuseboxScreenshotCaptureEnabled();
   bool fuseboxWebSocketEventsEnabled();
   bool optimizedAnimatedPropUpdates();
@@ -130,7 +131,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 88> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -191,6 +192,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> fuseboxAssertSingleHostState_;
   std::atomic<std::optional<bool>> fuseboxEnabledRelease_;
   std::atomic<std::optional<bool>> fuseboxFrameRecordingEnabled_;
+  std::atomic<std::optional<bool>> fuseboxNetworkThrottlingEnabled_;
   std::atomic<std::optional<bool>> fuseboxScreenshotCaptureEnabled_;
   std::atomic<std::optional<bool>> fuseboxWebSocketEventsEnabled_;
   std::atomic<std::optional<bool>> optimizedAnimatedPropUpdates_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcc09eb60ab85de9bc72410e93c2a1c>>
+ * @generated SignedSource<<aaa545c628290f1bd225a7af452299cd>>
  */
 
 /**
@@ -260,6 +260,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool fuseboxFrameRecordingEnabled() override {
+    return false;
+  }
+
+  bool fuseboxNetworkThrottlingEnabled() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<340aadae79b8e4f77daa915e9ab397a1>>
+ * @generated SignedSource<<c7c3017cc97d07e76fad270175568a09>>
  */
 
 /**
@@ -574,6 +574,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::fuseboxFrameRecordingEnabled();
+  }
+
+  bool fuseboxNetworkThrottlingEnabled() override {
+    auto value = values_["fuseboxNetworkThrottlingEnabled"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::fuseboxNetworkThrottlingEnabled();
   }
 
   bool fuseboxScreenshotCaptureEnabled() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<988feef999c2b900926fe5ba47fc313b>>
+ * @generated SignedSource<<0b4af2ec5e9d85ff4588a12ee86e401e>>
  */
 
 /**
@@ -84,6 +84,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool fuseboxAssertSingleHostState() = 0;
   virtual bool fuseboxEnabledRelease() = 0;
   virtual bool fuseboxFrameRecordingEnabled() = 0;
+  virtual bool fuseboxNetworkThrottlingEnabled() = 0;
   virtual bool fuseboxScreenshotCaptureEnabled() = 0;
   virtual bool fuseboxWebSocketEventsEnabled() = 0;
   virtual bool optimizedAnimatedPropUpdates() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b67c8966cce4fef1d3478cd9f1afdbc0>>
+ * @generated SignedSource<<2cdeccc252cafbd7fb9186581ffeb127>>
  */
 
 /**
@@ -337,6 +337,11 @@ bool NativeReactNativeFeatureFlags::fuseboxEnabledRelease(
 bool NativeReactNativeFeatureFlags::fuseboxFrameRecordingEnabled(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::fuseboxFrameRecordingEnabled();
+}
+
+bool NativeReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::fuseboxNetworkThrottlingEnabled();
 }
 
 bool NativeReactNativeFeatureFlags::fuseboxScreenshotCaptureEnabled(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c65d5fea853b54322321f86c1d5ce440>>
+ * @generated SignedSource<<cc693386674be32169122a779bc23b87>>
  */
 
 /**
@@ -153,6 +153,8 @@ class NativeReactNativeFeatureFlags
   bool fuseboxEnabledRelease(jsi::Runtime& runtime);
 
   bool fuseboxFrameRecordingEnabled(jsi::Runtime& runtime);
+
+  bool fuseboxNetworkThrottlingEnabled(jsi::Runtime& runtime);
 
   bool fuseboxScreenshotCaptureEnabled(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -679,6 +679,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'canary',
     },
+    fuseboxNetworkThrottlingEnabled: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2026-07-13',
+        description:
+          'Enable simulated network throttling (Network.emulateNetworkConditions) in the React Native DevTools CDP backend.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     fuseboxScreenshotCaptureEnabled: {
       defaultValue: true,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bafad194115f60dcf22f64015fe64856>>
+ * @generated SignedSource<<1fb6bb69e323c1dded71cb37d12f0502>>
  * @flow strict
  * @noformat
  */
@@ -107,6 +107,7 @@ export type ReactNativeFeatureFlags = Readonly<{
   fuseboxAssertSingleHostState: Getter<boolean>,
   fuseboxEnabledRelease: Getter<boolean>,
   fuseboxFrameRecordingEnabled: Getter<boolean>,
+  fuseboxNetworkThrottlingEnabled: Getter<boolean>,
   fuseboxScreenshotCaptureEnabled: Getter<boolean>,
   fuseboxWebSocketEventsEnabled: Getter<boolean>,
   optimizedAnimatedPropUpdates: Getter<boolean>,
@@ -442,6 +443,10 @@ export const fuseboxEnabledRelease: Getter<boolean> = createNativeFlagGetter('fu
  * Enable frame timings and screenshots support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
  */
 export const fuseboxFrameRecordingEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxFrameRecordingEnabled', false);
+/**
+ * Enable simulated network throttling (Network.emulateNetworkConditions) in the React Native DevTools CDP backend.
+ */
+export const fuseboxNetworkThrottlingEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxNetworkThrottlingEnabled', false);
 /**
  * Enable Page.captureScreenshot CDP method support in the React Native DevTools CDP backend. This flag is global and should not be changed across React Host lifetimes.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9b62a9e25b6088e25d9c39be7650a1d2>>
+ * @generated SignedSource<<d3680c29cd3dd1479998663aae0f4b48>>
  * @flow strict
  * @noformat
  */
@@ -84,6 +84,7 @@ export interface Spec extends TurboModule {
   readonly fuseboxAssertSingleHostState?: () => boolean;
   readonly fuseboxEnabledRelease?: () => boolean;
   readonly fuseboxFrameRecordingEnabled?: () => boolean;
+  readonly fuseboxNetworkThrottlingEnabled?: () => boolean;
   readonly fuseboxScreenshotCaptureEnabled?: () => boolean;
   readonly fuseboxWebSocketEventsEnabled?: () => boolean;
   readonly optimizedAnimatedPropUpdates?: () => boolean;

--- a/packages/rn-tester/js/examples/NetworkThrottling/NetworkThrottlingExample.js
+++ b/packages/rn-tester/js/examples/NetworkThrottling/NetworkThrottlingExample.js
@@ -1,0 +1,478 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/**
+ * NetworkThrottlingExample
+ * ------------------------
+ * Validates the two properties of `Network.emulateNetworkConditions` that
+ * matter most: `latency` and `downloadThroughput`.
+ *
+ * Throttling is set in DevTools; this screen is the observer. It loads a small
+ * grid of images concurrently over XHR and reports:
+ *
+ *   Latency mode     — tiny payloads, so duration ≈ latency. Every request's
+ *                      TTFB should be at least the preset's latency.
+ *   Throughput mode  — large payloads, so duration ≈ bytes / throughput.
+ *                      Effective rate should land on the preset's figure.
+ *
+ * Both modes also make the fair-share behaviour visible for free: Chrome splits
+ * bandwidth evenly, round-robin, across in-flight requests, so the bars advance
+ * in lockstep and the tiles finish together rather than one after another.
+ *
+ * Endpoint: https://picsum.photos — public, auth-free, real JPEGs.
+ */
+
+import type {
+  RNTesterModule,
+  RNTesterModuleExample,
+} from '../../types/RNTesterTypes';
+
+import * as React from 'react';
+import {useCallback, useEffect, useReducer, useRef, useState} from 'react';
+import {Image, Platform, Pressable, StyleSheet, Text, View} from 'react-native';
+
+const PICSUM = 'https://picsum.photos';
+
+/**
+ * Concurrency. Platforms cap requests per host (NSURLSession ~4; OkHttp's
+ * Dispatcher 5), so above ~4 the grid loads in waves and the fair-share
+ * behaviour stops being legible. That's the client, not the throttler.
+ */
+const COUNT = 4;
+
+/**
+ * Progress events arrive roughly every 1.5 kB once throttling is on (Chrome
+ * clamps reads to one 1500-byte packet), so a 200 kB image fires ~130 of them.
+ * Setting state per event would make the JS thread — not the throttler — the
+ * bottleneck and corrupt the measurement. Buffer in refs, flush on a timer.
+ */
+const FLUSH_MS = 100;
+
+type Mode = {
+  key: 'latency' | 'throughput',
+  label: string,
+  px: number,
+  blurb: string,
+};
+
+const MODES: Mode[] = [
+  {
+    key: 'latency',
+    label: 'Latency',
+    px: 48,
+    blurb:
+      'Near-empty payloads, so bytes are irrelevant. Each request should take at least the preset latency.',
+  },
+  {
+    key: 'throughput',
+    label: 'Download throughput',
+    px: 1200,
+    blurb:
+      'Large payloads. Bandwidth is shared evenly across the 4 requests, so they should all land at ~latency + (total bytes / throughput).',
+  },
+];
+
+type Req = {
+  id: string,
+  url: string,
+  label: string,
+  startedAt: number,
+  /** Response headers received — where Chrome releases the latency-suspended
+   * record, so this is the number `latency` is supposed to govern. */
+  ttfbAt: number | null,
+  doneAt: number | null,
+  loaded: number,
+  total: number,
+  error: string | null,
+  running: boolean,
+};
+
+type Run = {startedAt: number, endedAt: number | null, reqs: Req[]};
+
+/** Fresh cache-buster per run. Without it, every run after the first is served
+ * from cache and the demo is a lie. (`Network.setCacheDisabled` is not wired
+ * up in RN, so we cannot rely on the DevTools "Disable cache" checkbox.) */
+const bust = () => Math.random().toString(36).slice(2, 8);
+
+const kb = (bytes: number) => `${(bytes / 1024).toFixed(0)} kB`;
+const secs = (ms: number) => `${(ms / 1000).toFixed(2)} s`;
+const rate = (bps: number) => `${(bps / 1024).toFixed(0)} kB/s`;
+
+function NetworkThrottling() {
+  const [mode, setMode] = useState(MODES[0]);
+  const [, forceRender] = useReducer<number, void>((c: number) => c + 1, 0);
+
+  const runRef = useRef<Run | null>(null);
+  const xhrsRef = useRef<XMLHttpRequest[]>([]);
+  const flushRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const cancel = useCallback(() => {
+    xhrsRef.current.forEach(xhr => xhr.abort());
+    xhrsRef.current = [];
+    if (flushRef.current != null) {
+      clearInterval(flushRef.current);
+      flushRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  const start = useCallback(() => {
+    cancel();
+
+    const seed = bust();
+    const startedAt = Date.now();
+    const run: Run = {
+      startedAt,
+      endedAt: null,
+      reqs: Array.from({length: COUNT}, (_, i) => ({
+        id: `${seed}-${i}`,
+        label: `#${i + 1}`,
+        url: `${PICSUM}/seed/${seed}-${i}/${mode.px}/${mode.px}?random=${seed}${i}`,
+        startedAt,
+        ttfbAt: null,
+        doneAt: null,
+        loaded: 0,
+        total: 0,
+        error: null,
+        running: true,
+      })),
+    };
+    runRef.current = run;
+
+    const settle = () => {
+      if (run.reqs.every(r => !r.running)) {
+        run.endedAt = Date.now();
+        cancel();
+        forceRender();
+      }
+    };
+
+    run.reqs.forEach(req => {
+      const xhr = new XMLHttpRequest();
+      xhrsRef.current.push(xhr);
+
+      xhr.open('GET', req.url);
+      // We only want the byte counts, never the payload — `blob` keeps the
+      // bytes native-side rather than decoding a JPEG into a JS string.
+      xhr.responseType = 'blob';
+
+      // NB: RN only requests incremental (progress) events from native when
+      // `onprogress` or `onreadystatechange` is assigned *before* send().
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState === xhr.HEADERS_RECEIVED && req.ttfbAt == null) {
+          req.ttfbAt = Date.now();
+        }
+      };
+      xhr.onprogress = (event: ProgressEvent) => {
+        req.loaded = event.loaded;
+        if (event.lengthComputable) {
+          req.total = event.total;
+        }
+      };
+      xhr.onload = () => {
+        req.running = false;
+        req.doneAt = Date.now();
+        if (xhr.status >= 400) {
+          req.error = `HTTP ${xhr.status}`;
+        }
+        // Release the native blob rather than waiting for GC.
+        const blob: {close?: () => void} | null = xhr.response;
+        blob?.close?.();
+        settle();
+      };
+      const fail = (message: string) => () => {
+        if (!req.running) {
+          return;
+        }
+        req.running = false;
+        req.doneAt = Date.now();
+        req.error = message;
+        settle();
+      };
+      xhr.onerror = fail('Network request failed');
+      xhr.ontimeout = fail('Timed out');
+      xhr.onabort = fail('Aborted');
+
+      xhr.send();
+    });
+
+    flushRef.current = setInterval(forceRender, FLUSH_MS);
+    forceRender();
+  }, [cancel, mode]);
+
+  const run = runRef.current;
+  const running = run != null && run.endedAt == null;
+
+  return (
+    <View style={styles.root}>
+      <Text style={styles.hint}>
+        Set a throttling preset in the DevTools Network panel, then run. The app
+        can't read the active CDP conditions itself, so compare the timings
+        below against the preset you picked.
+      </Text>
+
+      <Text style={styles.heading}>What to measure</Text>
+      <View style={styles.row}>
+        {MODES.map(m => (
+          <Chip
+            key={m.key}
+            label={m.label}
+            active={m.key === mode.key}
+            onPress={() => setMode(m)}
+          />
+        ))}
+      </View>
+      <Text style={styles.hint}>{mode.blurb}</Text>
+
+      <Pressable
+        onPress={start}
+        disabled={running}
+        style={({pressed}) => [
+          styles.button,
+          (pressed || running) && styles.buttonDim,
+        ]}>
+        <Text style={styles.buttonLabel}>
+          {running ? 'Loading…' : `Load ${COUNT} images`}
+        </Text>
+      </Pressable>
+
+      {run != null ? (
+        <>
+          <View style={styles.grid}>
+            {run.reqs.map(req => (
+              <Tile key={req.id} req={req} />
+            ))}
+          </View>
+          <Summary run={run} mode={mode} />
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+function Tile({req}: {req: Req}) {
+  const pct =
+    req.total > 0 ? Math.min(1, req.loaded / req.total) : req.running ? 0 : 1;
+  const elapsed = (req.doneAt ?? Date.now()) - req.startedAt;
+
+  return (
+    <View style={styles.tile}>
+      <View style={styles.track}>
+        <View
+          style={[
+            styles.fill,
+            {width: `${pct * 100}%`},
+            req.error != null && styles.fillError,
+          ]}
+        />
+      </View>
+      <View style={styles.imageWrap}>
+        {/* Rendered only once the measured request has finished, so the image
+            pipeline's own fetch never competes for bandwidth during the window
+            we're measuring. */}
+        {req.doneAt != null && req.error == null ? (
+          <Image
+            source={{uri: req.url}}
+            style={styles.image}
+            resizeMode="cover"
+          />
+        ) : null}
+      </View>
+      <Text style={styles.tileLabel}>{req.label}</Text>
+      <Text style={styles.mono}>
+        {req.error ??
+          `${kb(req.loaded)}${req.total > 0 ? ` / ${kb(req.total)}` : ''}`}
+      </Text>
+      <Text style={styles.monoDim}>
+        {req.ttfbAt != null
+          ? `ttfb ${secs(req.ttfbAt - req.startedAt)} · ${secs(elapsed)}`
+          : 'waiting…'}
+      </Text>
+    </View>
+  );
+}
+
+function Summary({run, mode}: {run: Run, mode: Mode}) {
+  const end = run.endedAt ?? Date.now();
+  const wallMs = end - run.startedAt;
+  const totalBytes = run.reqs.reduce((sum, r) => sum + r.loaded, 0);
+  const effectiveBps = wallMs > 0 ? (totalBytes / wallMs) * 1000 : 0;
+
+  const ttfbs = run.reqs
+    .filter(r => r.ttfbAt != null)
+    .map(r => (r.ttfbAt ?? 0) - r.startedAt);
+  const minTtfb = ttfbs.length > 0 ? Math.min(...ttfbs) : null;
+
+  const completions = run.reqs
+    .filter(r => r.doneAt != null)
+    .map(r => (r.doneAt ?? 0) - run.startedAt);
+  const spread =
+    completions.length > 1
+      ? Math.max(...completions) - Math.min(...completions)
+      : 0;
+
+  return (
+    <View style={styles.card}>
+      {mode.key === 'latency' && minTtfb != null ? (
+        <Row
+          k="Fastest TTFB"
+          hint="Should be at least the preset latency"
+          v={secs(minTtfb)}
+        />
+      ) : null}
+
+      {mode.key === 'throughput' ? (
+        <Row
+          k="Effective rate"
+          hint="Should land on the preset download throughput"
+          v={rate(effectiveBps)}
+        />
+      ) : null}
+
+      <Row k="Wall time" v={secs(wallMs)} />
+      <Row k="Bytes" v={kb(totalBytes)} />
+      <Row
+        k="Completion spread"
+        hint="Round-robin fair share ⇒ near zero for equal payloads"
+        v={secs(spread)}
+      />
+    </View>
+  );
+}
+
+function Row({k, v, hint}: {k: string, v: string, hint?: string}) {
+  return (
+    <View style={styles.summaryRow}>
+      <View style={styles.summaryKey}>
+        <Text style={styles.label}>{k}</Text>
+        {hint != null ? <Text style={styles.hint}>{hint}</Text> : null}
+      </View>
+      <Text style={styles.mono}>{v}</Text>
+    </View>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string,
+  active: boolean,
+  onPress: () => void,
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[styles.chip, active && styles.chipActive]}>
+      <Text style={[styles.chipLabel, active && styles.chipLabelActive]}>
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {gap: 8, paddingHorizontal: 16, paddingTop: 16, paddingBottom: 24},
+  heading: {fontWeight: '600', fontSize: 13, marginTop: 8},
+  row: {flexDirection: 'row', flexWrap: 'wrap', gap: 8},
+  hint: {fontSize: 11, color: '#6b6b70', lineHeight: 15},
+  label: {fontSize: 13},
+  grid: {flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 12},
+  tile: {
+    width: '47%',
+    gap: 2,
+    padding: 8,
+    borderRadius: 6,
+    backgroundColor: '#f2f2f7',
+  },
+  track: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#d8d8de',
+    overflow: 'hidden',
+  },
+  fill: {height: 8, backgroundColor: '#0b6cf5'},
+  fillError: {backgroundColor: '#c2261a'},
+  imageWrap: {
+    width: '100%',
+    height: 88,
+    borderRadius: 4,
+    marginTop: 6,
+    overflow: 'hidden',
+    backgroundColor: '#d8d8de',
+  },
+  image: {width: '100%', height: '100%'},
+  tileLabel: {fontWeight: '600', fontSize: 12, marginTop: 4},
+  card: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#c7c7cc',
+    borderRadius: 8,
+    padding: 12,
+    marginTop: 12,
+    gap: 8,
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  summaryKey: {flexShrink: 1},
+  mono: {
+    fontSize: 12,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  monoDim: {
+    fontSize: 11,
+    color: '#6b6b70',
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  button: {
+    backgroundColor: '#0b6cf5',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    alignSelf: 'flex-start',
+    marginTop: 8,
+  },
+  buttonDim: {opacity: 0.5},
+  buttonLabel: {color: 'white', fontWeight: '600'},
+  chip: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    backgroundColor: '#f2f2f7',
+  },
+  chipActive: {backgroundColor: '#0b6cf5'},
+  chipLabel: {fontSize: 12, color: '#1c1c1e'},
+  chipLabelActive: {color: 'white', fontWeight: '600'},
+});
+
+const examples: RNTesterModuleExample[] = [
+  {
+    title: 'Latency and download throughput',
+    name: 'throttling',
+    scrollable: true,
+    description:
+      'Loads 4 images concurrently and reports TTFB and the aggregate download rate.',
+    render: () => <NetworkThrottling />,
+  },
+];
+
+export default {
+  title: 'Network Throttling',
+  category: 'Basic',
+  documentationURL: 'https://reactnative.dev/docs/react-native-devtools',
+  description:
+    'Validates Network.emulateNetworkConditions (latency, downloadThroughput).',
+  examples,
+} as RNTesterModule;

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -362,6 +362,12 @@ const APIs: Array<RNTesterModuleInfo> = (
       module: require('../examples/Vibration/VibrationExample'),
     },
     {
+      key: 'NetworkThrottlingExample',
+      category: 'Basic',
+      module: require('../examples/NetworkThrottling/NetworkThrottlingExample')
+        .default,
+    },
+    {
       key: 'WebSocketExample',
       category: 'Basic',
       module: require('../examples/WebSocket/WebSocketExample'),

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -355,6 +355,12 @@ const APIs: Array<RNTesterModuleInfo> = (
       module: require('../examples/Vibration/VibrationExample'),
     },
     {
+      key: 'NetworkThrottlingExample',
+      category: 'Basic',
+      module: require('../examples/NetworkThrottling/NetworkThrottlingExample')
+        .default,
+    },
+    {
       key: 'WebSocketExample',
       module: require('../examples/WebSocket/WebSocketExample'),
     },

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -10825,6 +10825,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -11011,6 +11012,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -11216,6 +11246,14 @@ class facebook::react::jsinspector_modern::JCxxInspectorPackagerConnectionDelega
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -10438,6 +10438,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -10624,6 +10625,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -10829,6 +10859,14 @@ class facebook::react::jsinspector_modern::JCxxInspectorPackagerConnectionDelega
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -10669,6 +10669,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -10855,6 +10856,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -11060,6 +11090,14 @@ class facebook::react::jsinspector_modern::JCxxInspectorPackagerConnectionDelega
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1238,6 +1238,17 @@ interface RCTInputAccessoryComponentView : public RCTViewComponentView {
 interface RCTInputAccessoryContentView : public UIView {
 }
 
+interface RCTInspectorNetworkEmulationGate : public NSObject {
+  public virtual instancetype initWithDeliveryQueue:onDisconnected:(dispatch_queue_t deliveryQueue, dispatch_block_t onDisconnected);
+  public virtual static BOOL isActive();
+  public virtual static BOOL isOffline();
+  public virtual void cancel();
+  public virtual void noteRequestSent();
+  public virtual void throttleCompletionDelivery:(dispatch_block_t deliver);
+  public virtual void throttleDataDelivery:deliver:(NSData* data, void(^)(NSData* chunk) deliver);
+  public virtual void throttleResponseDelivery:(dispatch_block_t deliver);
+}
+
 interface RCTInspectorNetworkHelper : public NSObject {
   public virtual instancetype init();
   public virtual void loadNetworkResourceWithParams:executor:(const RCTInspectorLoadNetworkResourceRequest& params, RCTInspectorNetworkExecutor executor);
@@ -12711,6 +12722,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -12838,6 +12850,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -13030,6 +13071,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1238,6 +1238,17 @@ interface RCTInputAccessoryComponentView : public RCTViewComponentView {
 interface RCTInputAccessoryContentView : public UIView {
 }
 
+interface RCTInspectorNetworkEmulationGate : public NSObject {
+  public virtual instancetype initWithDeliveryQueue:onDisconnected:(dispatch_queue_t deliveryQueue, dispatch_block_t onDisconnected);
+  public virtual static BOOL isActive();
+  public virtual static BOOL isOffline();
+  public virtual void cancel();
+  public virtual void noteRequestSent();
+  public virtual void throttleCompletionDelivery:(dispatch_block_t deliver);
+  public virtual void throttleDataDelivery:deliver:(NSData* data, void(^)(NSData* chunk) deliver);
+  public virtual void throttleResponseDelivery:(dispatch_block_t deliver);
+}
+
 interface RCTInspectorNetworkHelper : public NSObject {
   public virtual instancetype init();
   public virtual void loadNetworkResourceWithParams:executor:(const RCTInspectorLoadNetworkResourceRequest& params, RCTInspectorNetworkExecutor executor);
@@ -12390,6 +12401,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -12517,6 +12529,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -12709,6 +12750,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1238,6 +1238,17 @@ interface RCTInputAccessoryComponentView : public RCTViewComponentView {
 interface RCTInputAccessoryContentView : public UIView {
 }
 
+interface RCTInspectorNetworkEmulationGate : public NSObject {
+  public virtual instancetype initWithDeliveryQueue:onDisconnected:(dispatch_queue_t deliveryQueue, dispatch_block_t onDisconnected);
+  public virtual static BOOL isActive();
+  public virtual static BOOL isOffline();
+  public virtual void cancel();
+  public virtual void noteRequestSent();
+  public virtual void throttleCompletionDelivery:(dispatch_block_t deliver);
+  public virtual void throttleDataDelivery:deliver:(NSData* data, void(^)(NSData* chunk) deliver);
+  public virtual void throttleResponseDelivery:(dispatch_block_t deliver);
+}
+
 interface RCTInspectorNetworkHelper : public NSObject {
   public virtual instancetype init();
   public virtual void loadNetworkResourceWithParams:executor:(const RCTInspectorLoadNetworkResourceRequest& params, RCTInspectorNetworkExecutor executor);
@@ -12565,6 +12576,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -12692,6 +12704,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -12884,6 +12925,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -7822,6 +7822,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -7949,6 +7950,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -8141,6 +8171,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -7646,6 +7646,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -7773,6 +7774,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -7965,6 +7995,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -7813,6 +7813,7 @@ class facebook::react::jsinspector_modern::InspectorFlags {
   public bool getFrameRecordingEnabled() const;
   public bool getFuseboxEnabled() const;
   public bool getIsProfilingBuild() const;
+  public bool getNetworkThrottlingEnabled() const;
   public bool getPerfIssuesEnabled() const;
   public bool getScreenshotCaptureEnabled() const;
   public facebook::react::jsinspector_modern::InspectorFlags& operator=(const facebook::react::jsinspector_modern::InspectorFlags&) = delete;
@@ -7940,6 +7941,35 @@ class facebook::react::jsinspector_modern::NetworkRequestListener {
   public virtual void onHeaders(uint32_t httpStatusCode, const facebook::react::jsinspector_modern::Headers& headers) = 0;
   public virtual void setCancelFunction(std::function<void()> cancelFunction) = 0;
   public virtual ~NetworkRequestListener() = default;
+}
+
+class facebook::react::jsinspector_modern::NetworkThrottler {
+  public NetworkThrottler(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public NetworkThrottler(facebook::react::jsinspector_modern::NetworkThrottler::ClockFunction clock);
+  public bool isOffline() const;
+  public bool isThrottling() const;
+  public facebook::react::jsinspector_modern::NetworkConditions getConditions() const;
+  public facebook::react::jsinspector_modern::NetworkThrottler& operator=(const facebook::react::jsinspector_modern::NetworkThrottler&) = delete;
+  public facebook::react::jsinspector_modern::NetworkThrottler::StartResult startThrottle(uint64_t token, int64_t bytes, facebook::react::jsinspector_modern::NetworkThrottler::TimePoint sendEnd, bool isStart, bool isUpload, facebook::react::jsinspector_modern::NetworkThrottler::ThrottleCallback callback);
+  public int64_t getReadBufLen(int64_t bufLen) const;
+  public static constexpr int64_t kPacketSize;
+  public static facebook::react::jsinspector_modern::NetworkThrottler& getInstance();
+  public std::optional<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint> getTimerDeadlineForTest() const;
+  public uint64_t createRecordToken();
+  public using Clock = std::chrono::steady_clock;
+  public using ClockFunction = std::function<facebook::react::jsinspector_modern::NetworkThrottler::TimePoint()>;
+  public using ThrottleCallback = std::function<void(bool disconnected, int64_t bytes)>;
+  public using TimePoint = facebook::react::jsinspector_modern::NetworkThrottler::Clock::time_point;
+  public void onTimerFired();
+  public void stopThrottle(uint64_t token);
+  public void updateConditions(const facebook::react::jsinspector_modern::NetworkConditions& conditions);
+  public ~NetworkThrottler();
+}
+
+enum facebook::react::jsinspector_modern::NetworkThrottler::StartResult {
+  Disconnected,
+  PassThrough,
+  Pending,
 }
 
 class facebook::react::jsinspector_modern::NotImplementedException : public std::exception {
@@ -8132,6 +8162,14 @@ struct facebook::react::jsinspector_modern::InspectorTargetCapabilities {
 
 struct facebook::react::jsinspector_modern::LoadNetworkResourceRequest {
   public std::string url;
+}
+
+struct facebook::react::jsinspector_modern::NetworkConditions {
+  public bool isThrottling() const;
+  public bool offline;
+  public double downloadThroughputBps;
+  public double latencyMs;
+  public double uploadThroughputBps;
 }
 
 struct facebook::react::jsinspector_modern::NetworkResource {


### PR DESCRIPTION
Summary:
NOTE: **🚧 Experimental feature exported for reference. No ETA, no committed plan to ship this.**

Adds a "Network Throttling" example to RNTester that exercises and validates `Network.emulateNetworkConditions` (latency and download throughput) from React Native DevTools. The screen loads a small grid of images concurrently over XHR and reports observed timings (TTFB against the preset latency floor, effective rate against the preset throughput, and completion spread to make round-robin fair sharing visible), comparing them against the analytic expectation for the preset selected in the UI.

Registered in the `APIs` list for all four platforms (iOS, Android, macOS, Windows).

Changelog: [Internal]

Differential Revision: D111725570
