### PR TITLE
Cover `jsc:JSCRuntime` with Stable API guards (#58023)

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.h
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 #include <memory.h>
 


### PR DESCRIPTION
Summary:

Classifies `jsc:JSCRuntime` as a for-frameworks target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's only header, `JSCRuntime.h`, and declares the guard dependency in BUCK. Consumers that opt into `RN_STRICT_API` now get a suppressible warning if they include it directly, silenced by defining `RN_ALLOW_FRAMEWORKS`; without that flag the guard is inert, so no existing build changes behaviour.

There is no CMake or podspec wiring to update — the module has no `CMakeLists.txt` and no podspec compiles it.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D116601629


