### PR TITLE
Move ReactPerfettoCategories to its own submodule (#58024)

### DIFF
--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(reactperflogger OBJECT ${reactperflogger_SRC})
 target_include_directories(reactperflogger PUBLIC .)
 
 target_link_libraries(reactperflogger
+        react_cxxstableapi
         react_timing
         folly_runtime
 )

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -37,6 +37,8 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
   }
 
+  s.dependency "React-cxxstableapi"
+
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_PERFETTO
 
 #include <perfetto.h>


### PR DESCRIPTION
Summary:

Changelog: [Internal]

Under the C++ Stable API RFC, `cxxreact:tracesection` is classified as "for frameworks", while transitively exposing a header from `reactperflogger:reactperflogger`, classified as "private".

To avoid this issue, this diff moves that header (`ReactPerfettoCategories.h`) to a separate module - `reactperflogger:perfettocategories`, and classifies it as "for frameworks".

Differential Revision: D116626009


