### PR TITLE
Add umbrella for `react/renderer/uimanager` subtree (#58025)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -160,6 +160,7 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/scheduler/", "react/renderer/scheduler/"),
                       // react_renderer_uimanager
                       Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
+                      Pair("../ReactCommon/react/renderer/uimanager/React/", "React/"),
                       // react_utils
                       Pair("../ReactCommon/react/utils/", "react/utils/"),
                       // rrc_image

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -252,6 +252,7 @@ val preparePrefab by
                           "react/renderer/leakchecker/",
                       ),
                       Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/"),
+                      Pair("../ReactCommon/react/renderer/mapbuffer/React/", "React/"),
                       Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
                       Pair(
                           "../ReactCommon/react/renderer/runtimescheduler/",

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -250,6 +250,12 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/uimanager"
   end
 
+  s.subspec "uimanagerUmbrella" do |ss|
+    ss.source_files         = "react/renderer/uimanager/React/*.h"
+    ss.header_dir           = "React"
+    ss.header_mappings_dir  = "react/renderer/uimanager/React"
+  end
+
   s.subspec "leakchecker" do |ss|
     ss.source_files         = podspec_sources("react/renderer/leakchecker/**/*.{cpp,h}", "react/renderer/leakchecker/**/*.h")
     ss.exclude_files        = "react/renderer/leakchecker/tests"

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -26,14 +26,21 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = podspec_sources("react/renderer/mapbuffer/*.{cpp,h}", "react/renderer/mapbuffer/*.h")
-  s.exclude_files          = "react/renderer/mapbuffer/tests"
+  s.exclude_files          = ["react/renderer/mapbuffer/tests", "react/renderer/mapbuffer/React"]
   s.public_header_files    = 'react/renderer/mapbuffer/*.h'
   s.header_dir             = "react/renderer/mapbuffer"
   s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
+  s.subspec "MapBufferUmbrella" do |ss|
+    ss.source_files        = "react/renderer/mapbuffer/React/*.h"
+    ss.header_dir          = "React"
+    ss.header_mappings_dir = "react/renderer/mapbuffer/React"
+  end
+
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_Mapbuffer")
 
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -11,6 +11,6 @@ file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
 target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_renderer_mapbuffer glog glog_init react_debug)
+target_link_libraries(react_renderer_mapbuffer glog glog_init react_cxxstableapi react_debug)
 target_compile_reactnative_options(react_renderer_mapbuffer PRIVATE)
 target_compile_options(react_renderer_mapbuffer PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 
 #include <glog/logging.h>

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 #include <vector>
 #include "MapBuffer.h"

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/mapbuffer` module - public entry point.
+//
+//   #include <React/MapBuffer.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/mapbuffer/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/AppRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/AppRegistryBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(react_renderer_uimanager
         folly_runtime
         jsi
         react_cxxreact
+        react_cxxstableapi
         react_debug
         react_featureflags
         react_renderer_componentregistry

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutAnimationStatusDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutAnimationStatusDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 class LayoutAnimationStatusDelegate {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 
 #include <jsi/jsi.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 #include <initializer_list>
 #include <memory>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/React/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/React/UIManager.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/uimanager` module - public entry
+// point.
+//
+//   #include <React/UIManager.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/uimanager/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/uimanager/AppRegistryBinding.h>
+#include <react/renderer/uimanager/LayoutAnimationStatusDelegate.h>
+#include <react/renderer/uimanager/LayoutEventEmitter.h>
+#include <react/renderer/uimanager/PointerEventsProcessor.h>
+#include <react/renderer/uimanager/PointerHoverTracker.h>
+#include <react/renderer/uimanager/UIManager.h>
+#include <react/renderer/uimanager/UIManagerAnimationBackend.h>
+#include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
+#include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/uimanager/UIManagerCommitHook.h>
+#include <react/renderer/uimanager/UIManagerDelegate.h>
+#include <react/renderer/uimanager/UIManagerMountHook.h>
+#include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
+#include <react/renderer/uimanager/UIManagerViewTransitionDelegate.h>
+#include <react/renderer/uimanager/primitives.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <ReactCommon/CallInvoker.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <chrono>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/uimanager/PointerEventsProcessor.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/MountingCoordinator.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include "UIManager.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/graphics/Float.h>
 #include <functional>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -466,6 +466,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-Mapbuffer.podspec': {
+    name: 'React-Mapbuffer',
+    headerPatterns: ['react/renderer/mapbuffer/**/*.h'],
+    excludePatterns: [
+      'react/renderer/mapbuffer/tests',
+      'react/renderer/mapbuffer/React',
+    ],
+    headerDir: 'react/renderer/mapbuffer',
+    subSpecs: [
+      {
+        name: 'MapBufferUmbrella',
+        headerPatterns: ['react/renderer/mapbuffer/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'ReactCommon/React-FabricImage.podspec': {
     name: 'React-FabricImage',
     headerPatterns: ['react/renderer/components/image/**/*.h'],

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -232,6 +232,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
 
       {
+        name: 'uimanagerUmbrella',
+        headerPatterns: ['react/renderer/uimanager/React/*.h'],
+        headerDir: 'React',
+      },
+
+      {
         name: 'leakchecker',
         headerPatterns: ['react/renderer/leakchecker/**/*.h'],
         excludePatterns: ['react/renderer/leakchecker/tests'],


### PR DESCRIPTION
Summary:

Rolls the umbrella-header + include-guard mechanism across the
`react/renderer/uimanager` module, classifying the target as public.

- Adds `<React/UIManager.h>`, re-exporting the module's public interface headers.
- Adds `<react/cxxstableapi/UmbrellaGuard.h>` to the module's public headers.
- Wires the umbrella header directory into the Buck, CMake, CocoaPods, Gradle,
  and iOS prebuild header configurations.
- Deprecated `SurfaceRegistryBinding.h` does not include umbrella guard because it will fail anyway when included directly (it includes AppRegistryBinding that does include guard).

React Native's own sources keep using the fine-grained
`<react/renderer/uimanager/...>` includes; only outside consumers use the
umbrella.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116763079


