### PR TITLE
Cover `react/timing:timing` with Stable API guards (#58026)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -285,6 +285,7 @@ val preparePrefab by
                       ),
                       // react_timing
                       Pair("../ReactCommon/react/timing/", "react/timing/"),
+                      Pair("../ReactCommon/react/timing/React/", "React/"),
                       // yoga
                       Pair("../ReactCommon/yoga/", ""),
                       Pair("src/main/jni/first-party/yogajni/jni", ""),

--- a/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
@@ -11,7 +11,10 @@ include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 add_library(react_timing INTERFACE)
 
 target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR})
+target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR}/react/timing)
+
 target_link_libraries(react_timing INTERFACE
+        react_cxxstableapi
         react_debug)
 target_compile_reactnative_options(react_timing INTERFACE)
 target_compile_options(react_timing INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -19,7 +19,7 @@ end
 header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
-  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\"" # this is needed to allow the target access its own files
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\"" # ReactCommon, for the target's own files and <react/cxxstableapi/...>
 end
 
 Pod::Spec.new do |s|
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = podspec_sources("*.{cpp,h}", "**/*.h")
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/timing"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
@@ -40,6 +40,13 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_timing")
 
   add_dependency(s, "React-debug")
+  s.dependency "React-cxxstableapi"
+
+  s.subspec "timingUmbrella" do |ss|
+    ss.source_files         = "React/*.h"
+    ss.header_dir           = "React"
+    ss.header_mappings_dir  = "React"
+  end
 
   s.resource_bundles = {'React-timing_privacy' => 'PrivacyInfo.xcprivacy'}
 

--- a/packages/react-native/ReactCommon/react/timing/React/Timing.h
+++ b/packages/react-native/ReactCommon/react/timing/React/Timing.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/timing` module - public entry point.
+//
+//   #include <React/Timing.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/timing/...>` includes; only
+// outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
+// this block so later *direct* includes in the same TU are still caught.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/timing/primitives.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/flags.h>
 #include <chrono>
 #include <cmath>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -568,6 +568,23 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
     ],
   },
   'React.podspec': {disabled: true},
+  'ReactCommon/react/timing/React-timing.podspec': {
+    name: 'React-timing',
+    headerPatterns: [],
+    headerDir: '',
+    subSpecs: [
+      {
+        name: 'timing',
+        headerPatterns: ['*.h'],
+        headerDir: 'react/timing',
+      },
+      {
+        name: 'timingUmbrella',
+        headerPatterns: ['React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'Libraries/PushNotificationIOS/React-RCTPushNotification.podspec': {
     disabled: true,
   },


### PR DESCRIPTION
Summary:

Classifies `react/timing:timing` as a public target under the C++ stable API three-tier visibility model and introduces the module umbrella `React/Timing.h` as its public entry point.

Wires into all the environments that need it: the guard dependency and the umbrella glob in BUCK, `react_cxxstableapi` in CMake, a `React-cxxstableapi` dependency plus a `timingUmbrella` subspec in the podspec, a header-staging entry for the iOS prebuild, and a prefab export for Android. SwiftPM needs no change.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog:
[General][Added] - Add `<React/Timing.h>` umbrella header as the public entry point for `react/timing`

Differential Revision: D116769152


