### PR TITLE
Cover `react/nativemodule/microtasks:microtasks` with Stable API guards (#58027)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_nativemodule_microtasks PUBLIC ${REACT_COMMON_D
 target_link_libraries(react_nativemodule_microtasks
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
 )
 target_compile_reactnative_options(react_nativemodule_microtasks PRIVATE)
 target_compile_options(react_nativemodule_microtasks PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/NativeMicrotasks.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/NativeMicrotasks.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   add_rncore_dependency(s)
 
   s.dependency "ReactCommon/turbomodule/core"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
 
   mark_as_react_native_build(s)


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/microtasks:microtasks` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's only header, `NativeMicrotasks.h`, and declares the guard dependency in BUCK, CMake, and the podspec. Consumers that opt into `RN_STRICT_API` now get a hard error if they include it directly, with no escape hatch; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D116612641


