### PR TITLE
fix: render dotted and dashed outlines on iOS views without border radii

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1191,7 +1191,10 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _outlineLayer.frame = CGRectInset(
         layer.bounds, -_props->outlineOffset - _props->outlineWidth, -_props->outlineOffset - _props->outlineWidth);
 
-    if (areBorderRadiiCircular(borderMetrics.borderRadii) && borderMetrics.borderRadii.topLeft.horizontal == 0) {
+    // Core Animation can only draw solid contours, so dotted and dashed outlines
+    // have to be drawn with Core Graphics, the same way non-solid borders are.
+    if (_props->outlineStyle == OutlineStyle::Solid && areBorderRadiiCircular(borderMetrics.borderRadii) &&
+        borderMetrics.borderRadii.topLeft.horizontal == 0) {
       UIColor *outlineColor = RCTUIColorFromSharedColor(_props->outlineColor);
       _outlineLayer.borderWidth = _props->outlineWidth;
       _outlineLayer.borderColor = outlineColor.CGColor;

--- a/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Mounting/RCTViewComponentViewTests.mm
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <react/renderer/components/view/ViewProps.h>
 #import <react/renderer/components/view/ViewShadowNode.h>
+#import <react/renderer/graphics/Color.h>
 
 using namespace facebook::react;
 
@@ -235,6 +236,49 @@ static RCTViewComponentView *makeViewWithRole(bool accessible, const std::string
 {
   RCTViewComponentView *view = makeViewWithRole(true, "");
   XCTAssertFalse(view.canBecomeFocused);
+}
+
+#pragma mark - outline style on square corners (#57841)
+
+static RCTViewComponentView *makeViewWithOutlineStyle(OutlineStyle outlineStyle)
+{
+  RCTViewComponentView *view = [RCTViewComponentView new];
+  view.frame = CGRectMake(0, 0, 100, 100);
+
+  auto props = std::make_shared<ViewProps>();
+  props->outlineWidth = 8;
+  props->outlineColor = colorFromRGBA(255, 165, 0, 255);
+  props->outlineStyle = outlineStyle;
+
+  [view updateProps:props oldProps:ViewShadowNode::defaultSharedProps()];
+  [view finalizeUpdates:RNComponentViewUpdateMaskProps];
+
+  return view;
+}
+
+- (void)testSquareSolidOutlineUsesCoreAnimationBorder
+{
+  // Solid outlines keep the cheaper Core Animation path.
+  RCTViewComponentView *view = makeViewWithOutlineStyle(OutlineStyle::Solid);
+  CALayer *outlineLayer = [view valueForKey:@"_outlineLayer"];
+
+  XCTAssertNotNil(outlineLayer);
+  XCTAssertEqualWithAccuracy(outlineLayer.borderWidth, 8.0, 0.001);
+  XCTAssertNil(outlineLayer.contents);
+}
+
+- (void)testSquareDottedAndDashedOutlinesAreDrawnWithCoreGraphics
+{
+  // A view without border radii used to take the Core Animation path, which can
+  // only render solid contours, so `outlineStyle` was silently dropped.
+  for (OutlineStyle outlineStyle : {OutlineStyle::Dotted, OutlineStyle::Dashed}) {
+    RCTViewComponentView *view = makeViewWithOutlineStyle(outlineStyle);
+    CALayer *outlineLayer = [view valueForKey:@"_outlineLayer"];
+
+    XCTAssertNotNil(outlineLayer);
+    XCTAssertEqualWithAccuracy(outlineLayer.borderWidth, 0.0, 0.001);
+    XCTAssertNotNil(outlineLayer.contents);
+  }
 }
 
 @end

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -541,6 +541,33 @@ function BoxShadowExample(): React.Node {
   );
 }
 
+function OutlineStyleExample({
+  outlineStyle,
+  borderRadius,
+  label,
+}: {
+  outlineStyle: 'solid' | 'dashed' | 'dotted',
+  borderRadius: number,
+  label: string,
+}): React.Node {
+  return (
+    <View style={{alignItems: 'center', gap: 8}}>
+      <View
+        style={{
+          width: 50,
+          height: 50,
+          backgroundColor: 'lightgray',
+          borderRadius,
+          outlineWidth: 3,
+          outlineColor: 'purple',
+          outlineStyle,
+        }}
+      />
+      <RNTesterText style={{fontSize: 11}}>{label}</RNTesterText>
+    </View>
+  );
+}
+
 function OutlineExample(): React.Node {
   const defaultStyleSize = {width: 50, height: 50};
 
@@ -664,6 +691,36 @@ function OutlineExample(): React.Node {
             outlineColor: 'orange',
           },
         ]}
+      />
+      <OutlineStyleExample
+        outlineStyle="solid"
+        borderRadius={0}
+        label="square solid"
+      />
+      <OutlineStyleExample
+        outlineStyle="dashed"
+        borderRadius={0}
+        label="square dashed"
+      />
+      <OutlineStyleExample
+        outlineStyle="dotted"
+        borderRadius={0}
+        label="square dotted"
+      />
+      <OutlineStyleExample
+        outlineStyle="solid"
+        borderRadius={12}
+        label="rounded solid"
+      />
+      <OutlineStyleExample
+        outlineStyle="dashed"
+        borderRadius={12}
+        label="rounded dashed"
+      />
+      <OutlineStyleExample
+        outlineStyle="dotted"
+        borderRadius={12}
+        label="rounded dotted"
       />
     </View>
   );


### PR DESCRIPTION
## Summary:

Fixes #57841.

`outlineStyle: 'dotted'` and `'dashed'` render as solid on iOS. Android renders all three correctly, and the documented API lists all three values with no platform caveat.

### Root cause

`-[RCTViewComponentView invalidateLayer]` draws the outline through one of two paths:

- **Core Animation** — sets `_outlineLayer.borderWidth` / `.borderColor`. Cheap, but `CALayer` can only stroke a *solid* border.
- **Core Graphics** — `RCTAddContourEffectToLayer`, which forwards `outlineStyle` to `RCTGetBorderImage` and does honour dotted/dashed.

The branch choosing between them only looked at the border radii:

```objc
if (areBorderRadiiCircular(borderMetrics.borderRadii) && borderMetrics.borderRadii.topLeft.horizontal == 0) {
```

Every view **without a border radius** therefore took the Core Animation path, and its `outlineStyle` was silently dropped. Rounded views fell through to Core Graphics — which is why a dotted or dashed outline starts working as soon as a `borderRadius` is set.

The equivalent branch for *borders*, ~80 lines above, already gets this right: `useCoreAnimationBorderRendering` includes `borderMetrics.borderStyles.left == BorderStyle::Solid`, so a non-solid border falls through to Core Graphics. The outline branch never got the matching check when `outline` was implemented in #46444.

### Fix

Add the missing `outlineStyle == OutlineStyle::Solid` term, so non-solid outlines fall through to Core Graphics exactly as non-solid borders already do. Solid outlines keep the cheaper Core Animation path, so there is no cost for the common case.

### Why it went unnoticed

The only RNTester examples using `outlineStyle: 'dotted'` / `'dashed'` also set a `borderRadius`, so they only ever exercised the working path. This PR adds the square-cornered cases next to them, labelled, so all six combinations of `{square, rounded} × {solid, dashed, dotted}` are visible at once.

### Note on #57837

#57837 (open) rewrites the two `UIColor *outlineColor = ...` lines in this same block to resolve
dynamic colors against the trait collection. This change deliberately leaves those two lines
untouched — it only adds a term to the surrounding `if` — so the two patches touch disjoint lines
and should merge without conflict in either order.

## Changelog:

[IOS] [FIXED] - Render `outlineStyle: 'dotted'` and `'dashed'` on views without border radii

## Test Plan:

### Manual verification

RNTester → Components → View → Outline, iPhone 17 Pro Simulator (iOS 26.1), New Architecture, built from source (`RCT_USE_PREBUILT_RNCORE=0`).

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/neutronm/react-native/960889bd70d6cb18839f9d3586690908b0d8207d/assets/57841/before.png" width="420"> | <img src="https://raw.githubusercontent.com/neutronm/react-native/960889bd70d6cb18839f9d3586690908b0d8207d/assets/57841/after.png" width="420"> |
| `square dashed` and `square dotted` render solid | all six render correctly |

The rounded cases and every pre-existing example in the Outline screen are pixel-identical before and after; only the two square non-solid outlines change.

### Automated

| Command | Result |
| --- | --- |
| `yarn jest` | 222/223 suites, 5713 tests pass |
| `yarn flow-check` | `Found 0 errors` |
| `yarn lint` (`eslint --max-warnings 0 .`) | clean |
| `node ./scripts/clang-format.js <changed .mm files>` | no changes |
| `yarn build-types --validate` | `PASS  API snapshot is up to date.` |
| `tsc -p packages/react-native/__typetests__/tsconfig.json` | clean |
| `yarn test-ios` (`RNTesterUnitTests`) | `** TEST SUCCEEDED **` — 167 tests, 16 skipped, 0 failures |

The one Jest suite that did not pass in the full run (`GenerateComponentDescriptorH-test.js`) was a worker `SIGSEGV`, not an assertion failure; it passes 18/18 when run on its own.

### Unit tests

`React/Tests/Mounting/RCTViewComponentViewTests.mm` gains two cases next to the existing ones:

- `testSquareSolidOutlineUsesCoreAnimationBorder` — a square solid outline still uses `CALayer.borderWidth` (the fast path is not regressed).
- `testSquareDottedAndDashedOutlinesAreDrawnWithCoreGraphics` — square dotted and dashed outlines are drawn into `layer.contents` with `borderWidth == 0`.

`React/Tests/**` is excluded from the `React-Core` podspec, so these are not built by the OSS `RNTesterUnitTests` target. They were verified to compile against the installed pod headers with `clang -fsyntax-only -x objective-c++ -std=c++20`.
