### PR TITLE
Add umbrella for `react/renderer/graphics` subtree

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -160,6 +160,7 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/scheduler/", "react/renderer/scheduler/"),
                       // react_renderer_uimanager
                       Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
+                      Pair("../ReactCommon/react/renderer/uimanager/React/", "React/"),
                       // react_utils
                       Pair("../ReactCommon/react/utils/", "react/utils/"),
                       // rrc_image

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -186,6 +186,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/root/",
                           "react/renderer/components/root/",
                       ),
+                      Pair(
+                          "../ReactCommon/react/renderer/components/root/React/",
+                          "React/",
+                      ),
                       // runtimeexecutor
                       Pair("../ReactCommon/runtimeexecutor/", ""),
                       // react_renderer_textlayoutmanager

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -252,6 +252,7 @@ val preparePrefab by
                           "react/renderer/leakchecker/",
                       ),
                       Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/"),
+                      Pair("../ReactCommon/react/renderer/mapbuffer/React/", "React/"),
                       Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
                       Pair(
                           "../ReactCommon/react/renderer/runtimescheduler/",

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -147,6 +147,7 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/debug/", "react/renderer/debug/"),
                       // react_renderer_graphics
                       Pair("../ReactCommon/react/renderer/graphics/", "react/renderer/graphics/"),
+                      Pair("../ReactCommon/react/renderer/graphics/React/", "React/"),
                       Pair("../ReactCommon/react/renderer/graphics/platform/android/", ""),
                       // react_renderer_imagemanager
                       Pair(

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -128,8 +128,14 @@ Pod::Spec.new do |s|
   s.subspec "components" do |ss|
     ss.subspec "root" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/root/**/*.{m,mm,cpp,h}", "react/renderer/components/root/**/*.{h}")
-      sss.exclude_files        = "react/renderer/components/root/tests"
+      sss.exclude_files        = ["react/renderer/components/root/tests", "react/renderer/components/root/React"]
       sss.header_dir           = "react/renderer/components/root"
+    end
+
+    ss.subspec "rootUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/root/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/root/React"
     end
 
     ss.subspec "view" do |sss|
@@ -148,7 +154,13 @@ Pod::Spec.new do |s|
     ss.subspec "scrollview" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/scrollview/**/*.{m,mm,cpp,h}", "react/renderer/components/scrollview/**/*.{h}")
       sss.header_dir           = "react/renderer/components/scrollview"
-      sss.exclude_files        = "react/renderer/components/scrollview/tests", "react/renderer/components/scrollview/platform/android"
+      sss.exclude_files        = "react/renderer/components/scrollview/tests", "react/renderer/components/scrollview/platform/android", "react/renderer/components/scrollview/React"
+    end
+
+    ss.subspec "scrollviewUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/scrollview/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/scrollview/React"
     end
 
     ss.subspec "legacyviewmanagerinterop" do |sss|

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -250,6 +250,12 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/uimanager"
   end
 
+  s.subspec "uimanagerUmbrella" do |ss|
+    ss.source_files         = "react/renderer/uimanager/React/*.h"
+    ss.header_dir           = "React"
+    ss.header_mappings_dir  = "react/renderer/uimanager/React"
+  end
+
   s.subspec "leakchecker" do |ss|
     ss.source_files         = podspec_sources("react/renderer/leakchecker/**/*.{cpp,h}", "react/renderer/leakchecker/**/*.h")
     ss.exclude_files        = "react/renderer/leakchecker/tests"

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -95,6 +95,12 @@ Pod::Spec.new do |s|
       sss.header_dir           = "react/renderer/components/modal"
     end
 
+    ss.subspec "modalUmbrella" do |sss|
+      sss.source_files         = "react/renderer/components/modal/React/*.h"
+      sss.header_dir           = "React"
+      sss.header_mappings_dir  = "react/renderer/components/modal/React"
+    end
+
     ss.subspec "safeareaview" do |sss|
       sss.source_files         = podspec_sources("react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}", "react/renderer/components/safeareaview/**/*.h")
       # Exclude tests to avoid conflicts with the react-native-safe-area-context package

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -26,14 +26,21 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = podspec_sources("react/renderer/mapbuffer/*.{cpp,h}", "react/renderer/mapbuffer/*.h")
-  s.exclude_files          = "react/renderer/mapbuffer/tests"
+  s.exclude_files          = ["react/renderer/mapbuffer/tests", "react/renderer/mapbuffer/React"]
   s.public_header_files    = 'react/renderer/mapbuffer/*.h'
   s.header_dir             = "react/renderer/mapbuffer"
   s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
+  s.subspec "MapBufferUmbrella" do |ss|
+    ss.source_files        = "react/renderer/mapbuffer/React/*.h"
+    ss.header_dir          = "React"
+    ss.header_mappings_dir = "react/renderer/mapbuffer/React"
+  end
+
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_Mapbuffer")
 
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(react_performance_cdpmetrics PUBLIC ${REACT_COMMON_DI
 target_link_libraries(react_performance_cdpmetrics
         folly_runtime
         jsi
+        react_cxxstableapi
         react_performance_timeline
         react_timing
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string_view>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancecdpmetrics")
 
+  s.dependency "React-cxxstableapi"
+
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-jsi"
   s.dependency "React-performancetimeline"

--- a/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(react_performance_timeline
         jsinspector
         jsinspector_tracing
         reactperflogger
+        react_cxxstableapi
         react_featureflags
         react_timing
         folly_runtime)

--- a/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <vector>
 #include "PerformanceEntry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "CircularBuffer.h"
 #include "PerformanceEntryBuffer.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <optional>
 #include <unordered_map>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryCircularBuffer.h"
 #include "PerformanceEntryKeyedBuffer.h"
 #include "PerformanceEntryReporterListeners.h"

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntry.h"
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryBuffer.h"
 #include "PerformanceObserverRegistry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <set>

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancetimeline")
 
+  s.dependency "React-cxxstableapi"
+
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/components/inputaccessory/InputAccessoryShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/inputaccessory/InputAccessoryState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/inputaccessory/InputAccessoryState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(rrc_legacyviewmanagerinterop
         glog_init
         folly_runtime
         jsi
+        react_cxxstableapi
         react_renderer_core
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #import <memory>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/platform/ios/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_COMPONENT_INTEROP
 
 #include <react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(rrc_modal
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_renderer_componentregistry
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <glog/logging.h>
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/modal/ModalHostViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 #include "ModalHostViewUtils.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Size.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/modal` module - public
+// entry point.
+//
+//   #include <React/Modal.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/modal/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
+#include <react/renderer/components/modal/ModalHostViewShadowNode.h>
+#include <react/renderer/components/modal/ModalHostViewState.h>
+#include <react/renderer/components/modal/ModalHostViewUtils.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(rrc_progressbar
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include "AndroidProgressBarMeasurementsManager.h"
 #include "AndroidProgressBarShadowNode.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(rrc_root
         folly_runtime
         glog
         glog_init
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/root` module - public
+// entry point.
+//
+//   #include <React/Root.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/root/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/root/RootComponentDescriptor.h>
+#include <react/renderer/components/root/RootProps.h>
+#include <react/renderer/components/root/RootShadowNode.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/root/RootProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/safeareaview/SafeAreaViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/safeareaview/SafeAreaViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/SafeAreaViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/graphics/RectangleEdges.h>
 
 #ifdef ANDROID

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(rrc_scrollview
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/scrollview` module -
+// public entry point.
+//
+//   #include <React/ScrollView.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained
+// `<react/renderer/components/scrollview/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/components/scrollview/BaseScrollViewProps.h>
+#include <react/renderer/components/scrollview/HostPlatformScrollViewProps.h>
+#include <react/renderer/components/scrollview/ScrollEvent.h>
+#include <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
+#include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
+#include <react/renderer/components/scrollview/ScrollViewProps.h>
+#include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
+#include <react/renderer/components/scrollview/ScrollViewState.h>
+#include <react/renderer/components/scrollview/conversions.h>
+#include <react/renderer/components/scrollview/primitives.h>
+
+#ifdef ANDROID
+#include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h>
+#include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventPayload.h>
 #include <react/renderer/debug/DebugStringConvertible.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/components/scrollview/ScrollEvent.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/HostPlatformScrollViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
 #include <react/renderer/components/scrollview/ScrollViewProps.h>
 #include <react/renderer/components/scrollview/ScrollViewState.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/Rect.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/AndroidHorizontalScrollContentViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/ScrollViewEventEmitter.h>
 #include <react/renderer/components/scrollview/ScrollViewState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/BaseScrollViewProps.h>
 #include <react/renderer/components/scrollview/primitives.h>
 #include <react/renderer/components/view/ViewProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/cxx/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/cxx/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/scrollview/BaseScrollViewProps.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <tuple>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
         folly_runtime
         glog_init
         react_codegen_rncore
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "AndroidSwitchMeasurementsManager.h"
 #include "AndroidSwitchShadowNode.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "AndroidSwitchMeasurementsManager.h"
 
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(rrc_unimplementedview
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/unimplementedview/UnimplementedViewProps.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/virtualview/VirtualViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/virtualview/VirtualViewShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/LinearGradient.h>
 #include <react/renderer/graphics/RadialGradient.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundPosition.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundPosition.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ValueUnit.h>
 #include <optional>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundRepeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundRepeat.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 enum class BackgroundRepeatStyle {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundSize.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundSize.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ValueUnit.h>
 #include <variant>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BlendMode.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BlendMode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(react_renderer_graphics
         glog
         ${fbjni}
         folly_runtime
+        react_cxxstableapi
         react_debug
         react_renderer_debug
         react_utils

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/renderer/graphics/HostPlatformColor.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorComponents.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 enum class ColorSpace { sRGB, DisplayP3 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Isolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Isolation.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/ColorStop.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 #include <react/utils/hash_combine.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/ColorStop.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -31,11 +31,18 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = podspec_sources(source_files, ["*.h", "platform/ios/**/*.h"])
+  s.exclude_files          = "React"
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
 
   if ENV['USE_FRAMEWORKS']
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
+  end
+
+  s.subspec "GraphicsUmbrella" do |ss|
+    ss.source_files        = "React/*.h"
+    ss.header_dir          = "React"
+    ss.header_mappings_dir = "React"
   end
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_graphics")
@@ -50,6 +57,7 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   s.dependency "React-utils"
   s.dependency "React-rendererdebug"
+  s.dependency "React-cxxstableapi"
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React/Graphics.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React/Graphics.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/graphics` module - public entry
+// point.
+//
+//   #include <React/Graphics.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/graphics/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/graphics/BackgroundImage.h>
+#include <react/renderer/graphics/BackgroundPosition.h>
+#include <react/renderer/graphics/BackgroundRepeat.h>
+#include <react/renderer/graphics/BackgroundSize.h>
+#include <react/renderer/graphics/BlendMode.h>
+#include <react/renderer/graphics/BoxShadow.h>
+#include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/ColorComponents.h>
+#include <react/renderer/graphics/ColorStop.h>
+#include <react/renderer/graphics/Filter.h>
+#include <react/renderer/graphics/Float.h>
+#include <react/renderer/graphics/HostPlatformColor.h>
+#include <react/renderer/graphics/Isolation.h>
+#include <react/renderer/graphics/LinearGradient.h>
+#include <react/renderer/graphics/PlatformColorParser.h>
+#include <react/renderer/graphics/Point.h>
+#include <react/renderer/graphics/RadialGradient.h>
+#include <react/renderer/graphics/Rect.h>
+#include <react/renderer/graphics/RectangleCorners.h>
+#include <react/renderer/graphics/RectangleEdges.h>
+#include <react/renderer/graphics/Size.h>
+#include <react/renderer/graphics/Transform.h>
+#include <react/renderer/graphics/TransformUtils.h>
+#include <react/renderer/graphics/ValueUnit.h>
+#include <react/renderer/graphics/Vector.h>
+#include <react/renderer/graphics/fromRawValueShared.h>
+#include <react/renderer/graphics/rounding.h>
+
+#ifdef ANDROID
+#include <react/renderer/graphics/configurePlatformColorCacheInvalidationHook.h>
+#endif
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Rect.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <algorithm>
 #include <tuple>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleCorners.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <tuple>
 
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RectangleEdges.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <tuple>
 
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Size.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <tuple>
 
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <array>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/TransformUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/TransformUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/graphics/Transform.h>
 #include <react/renderer/graphics/ValueUnit.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/debug/flags.h>
 #include <string>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Vector.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Vector.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/fromRawValueShared.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/fromRawValueShared.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 using parsePlatformColorFn = SharedColor (*)(const ContextContainer &, int32_t, const RawValue &);
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/Float.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <limits>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ColorComponents.h>
 #include <cmath>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include "configurePlatformColorCacheInvalidationHook.h"
 
 #include <fbjni/fbjni.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/configurePlatformColorCacheInvalidationHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/configurePlatformColorCacheInvalidationHook.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <limits>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ColorComponents.h>
 #include <cmath>
 #include <cstdint>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/PlatformColorParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/graphics/Color.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/Float.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <CoreGraphics/CoreGraphics.h>
 #include <limits>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/utils/hash_combine.h>
 #include <cmath>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/graphics/Color.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #import <UIKit/UIKit.h>
 #import <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/rounding.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/rounding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/UmbrellaCompileTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/UmbrellaCompileTest.cpp
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <React/Graphics.h>

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -11,6 +11,6 @@ file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
 target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_renderer_mapbuffer glog glog_init react_debug)
+target_link_libraries(react_renderer_mapbuffer glog glog_init react_cxxstableapi react_debug)
 target_compile_reactnative_options(react_renderer_mapbuffer PRIVATE)
 target_compile_options(react_renderer_mapbuffer PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 
 #include <glog/logging.h>

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/debug/react_native_assert.h>
 #include <vector>
 #include "MapBuffer.h"

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/mapbuffer` module - public entry point.
+//
+//   #include <React/MapBuffer.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/mapbuffer/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/mapbuffer/MapBuffer.h>
+#include <react/renderer/mapbuffer/MapBufferBuilder.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -9,7 +9,6 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/hermes-interfaces.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/SchedulerPriorityUtils.h>
 #include <react/renderer/runtimescheduler/Task.h>
@@ -19,6 +18,8 @@
 #include "RuntimeSchedulerResizeObserverDelegate.h"
 
 namespace facebook::react {
+
+class PerformanceEntryReporter;
 
 using RuntimeSchedulerRenderingUpdate = std::function<void()>;
 using SurfaceId = int32_t;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -11,6 +11,7 @@
 #include <cxxreact/TraceSection.h>
 #include <jsinspector-modern/tracing/EventLoopReporter.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
 #include <react/utils/OnScopeExit.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -13,12 +13,16 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
+#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/LayoutEventEmitter.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -44,12 +48,14 @@ Scheduler::Scheduler(
 
   if (ReactNativeFeatureFlags::enableBridgelessArchitecture() &&
       ReactNativeFeatureFlags::cdpInteractionMetricsEnabled()) {
-    cdpMetricsReporter_.emplace(CdpMetricsReporter{runtimeExecutor_});
+    cdpMetricsReporter_ =
+        std::make_unique<CdpMetricsReporter>(runtimeExecutor_);
     performanceEntryReporter_->addEventListener(&*cdpMetricsReporter_);
   }
 
   if (ReactNativeFeatureFlags::perfIssuesEnabled()) {
-    cdpPerfIssuesReporter_.emplace(CdpPerfIssuesReporter{runtimeExecutor_});
+    cdpPerfIssuesReporter_ =
+        std::make_unique<CdpPerfIssuesReporter>(runtimeExecutor_);
     performanceEntryReporter_->addEventListener(&*cdpPerfIssuesReporter_);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -12,16 +12,12 @@
 #include <vector>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
-#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
-#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/scheduler/InspectorData.h>
 #include <react/renderer/scheduler/SchedulerDelegate.h>
 #include <react/renderer/scheduler/SchedulerToolbox.h>
@@ -33,6 +29,11 @@
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class CdpMetricsReporter;
+class CdpPerfIssuesReporter;
+class EventPerformanceLogger;
+class PerformanceEntryReporter;
 
 /*
  * Scheduler coordinates Shadow Tree updates and event flows.
@@ -145,8 +146,8 @@ class Scheduler final : public UIManagerDelegate {
   std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   std::shared_ptr<PerformanceEntryReporter> performanceEntryReporter_;
-  std::optional<CdpMetricsReporter> cdpMetricsReporter_;
-  std::optional<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
+  std::unique_ptr<CdpMetricsReporter> cdpMetricsReporter_;
+  std::unique_ptr<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
   std::shared_ptr<EventPerformanceLogger> eventPerformanceLogger_;
 
   /**

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/AppRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/AppRegistryBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 #include <react/renderer/core/ReactPrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(react_renderer_uimanager
         folly_runtime
         jsi
         react_cxxreact
+        react_cxxstableapi
         react_debug
         react_featureflags
         react_renderer_componentregistry

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutAnimationStatusDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutAnimationStatusDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 class LayoutAnimationStatusDelegate {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/LayoutEventEmitter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 
 #include <jsi/jsi.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 #include <initializer_list>
 #include <memory>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/React/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/React/UIManager.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/uimanager` module - public entry
+// point.
+//
+//   #include <React/UIManager.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/uimanager/...>` includes;
+// only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/uimanager/AppRegistryBinding.h>
+#include <react/renderer/uimanager/LayoutAnimationStatusDelegate.h>
+#include <react/renderer/uimanager/LayoutEventEmitter.h>
+#include <react/renderer/uimanager/PointerEventsProcessor.h>
+#include <react/renderer/uimanager/PointerHoverTracker.h>
+#include <react/renderer/uimanager/UIManager.h>
+#include <react/renderer/uimanager/UIManagerAnimationBackend.h>
+#include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
+#include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/uimanager/UIManagerCommitHook.h>
+#include <react/renderer/uimanager/UIManagerDelegate.h>
+#include <react/renderer/uimanager/UIManagerMountHook.h>
+#include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
+#include <react/renderer/uimanager/UIManagerViewTransitionDelegate.h>
+#include <react/renderer/uimanager/primitives.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <ReactCommon/CallInvoker.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <chrono>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/uimanager/PointerEventsProcessor.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/MountingCoordinator.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerMountHook.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include "UIManager.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerViewTransitionDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/graphics/Float.h>
 #include <functional>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -18,6 +18,7 @@
 #include <jsi/instrumentation.h>
 #include <jsinspector-modern/HostTarget.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/runtime/JSRuntimeBindings.h>
 #include <react/timing/primitives.h>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -101,8 +101,17 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
           {
             name: 'root',
             headerPatterns: ['react/renderer/components/root/**/*.h'],
-            excludePatterns: ['react/renderer/components/root/tests'],
+            excludePatterns: [
+              'react/renderer/components/root/tests',
+              'react/renderer/components/root/React',
+            ],
             headerDir: 'react/renderer/components/root',
+          },
+
+          {
+            name: 'rootUmbrella',
+            headerPatterns: ['react/renderer/components/root/React/*.h'],
+            headerDir: 'React',
           },
           {
             name: 'view',
@@ -126,7 +135,14 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
             excludePatterns: [
               'react/renderer/components/scrollview/tests',
               'react/renderer/components/scrollview/platform/android',
+              'react/renderer/components/scrollview/React',
             ],
+          },
+
+          {
+            name: 'scrollviewUmbrella',
+            headerPatterns: ['react/renderer/components/scrollview/React/*.h'],
+            headerDir: 'React',
           },
 
           {
@@ -330,6 +346,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
             headerPatterns: ['react/renderer/components/modal/*.h'],
             excludePatterns: ['react/renderer/components/modal/tests'],
             headerDir: 'react/renderer/components/modal',
+          },
+
+          {
+            name: 'modalUmbrella',
+            headerPatterns: ['react/renderer/components/modal/React/*.h'],
+            headerDir: 'React',
           },
 
           {

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -466,6 +466,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-Mapbuffer.podspec': {
+    name: 'React-Mapbuffer',
+    headerPatterns: ['react/renderer/mapbuffer/**/*.h'],
+    excludePatterns: [
+      'react/renderer/mapbuffer/tests',
+      'react/renderer/mapbuffer/React',
+    ],
+    headerDir: 'react/renderer/mapbuffer',
+    subSpecs: [
+      {
+        name: 'MapBufferUmbrella',
+        headerPatterns: ['react/renderer/mapbuffer/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'ReactCommon/React-FabricImage.podspec': {
     name: 'React-FabricImage',
     headerPatterns: ['react/renderer/components/image/**/*.h'],

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -232,6 +232,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
 
       {
+        name: 'uimanagerUmbrella',
+        headerPatterns: ['react/renderer/uimanager/React/*.h'],
+        headerDir: 'React',
+      },
+
+      {
         name: 'leakchecker',
         headerPatterns: ['react/renderer/leakchecker/**/*.h'],
         excludePatterns: ['react/renderer/leakchecker/tests'],

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -504,6 +504,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/react/renderer/graphics/React-graphics.podspec': {
+    name: 'React-graphics',
+    headerPatterns: ['react/renderer/graphics/**/*.h'],
+    excludePatterns: [
+      'react/renderer/graphics/tests',
+      'react/renderer/graphics/React',
+    ],
+    headerDir: 'react/renderer/graphics',
+    subSpecs: [
+      {
+        name: 'GraphicsUmbrella',
+        headerPatterns: ['react/renderer/graphics/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'React-Core.podspec': {
     name: 'React-Core',
     headerPatterns: [],


### PR DESCRIPTION
Summary:
Rolls the umbrella-header + include-guard mechanism across the
`react/renderer/graphics` module, classifying the target as public.

- Adds `<React/Graphics.h>`, re-exporting the module's public interface headers.
- Adds `<react/cxxstableapi/UmbrellaGuard.h>` to 24 root headers and all 18
  platform headers.
- Wires the umbrella header directory into the Buck, CMake, CocoaPods, Gradle,
  and iOS prebuild header configurations.

`conversions.h` and `Geometry.h` are deliberately left unguarded. Both are
deprecation shims whose only content is a `#warning` redirecting to their
replacements.

`PlatformColorParser.h` and `fromRawValueShared.h` include
`react/renderer/core/RawValue.h`, which was only reachable on Apple platforms
because `react/renderer/core:rawValue` was restricted to `platforms = APPLE`.
No source inside the graphics target included those headers off-Apple, so the
breakage was latent and invisible; reaching them through the umbrella surfaces
it.

Changelog:
[Internal]

Differential Revision: D116779866
