### PR TITLE
[iOS][swiftpm] Honor a library's spm.name when scaffolding its Package.swift

### DIFF
--- a/packages/react-native/scripts/spm/__tests__/scaffold-package-swift-test.js
+++ b/packages/react-native/scripts/spm/__tests__/scaffold-package-swift-test.js
@@ -140,6 +140,37 @@ describe('translatePodspecToSpmTarget', () => {
     expect(spec.coreReactNative).toBe(true);
   });
 
+  it('uses the resolved swiftName (spm.name override) so the manifest matches what the autolinker registers', () => {
+    const model = podspec({name: 'react-native-worklets'});
+    const spec = translatePodspecToSpmTarget(
+      model,
+      autolinkedDep({name: 'react-native-worklets', swiftName: 'worklets'}),
+    );
+    expect(spec.swiftName).toBe('worklets');
+  });
+
+  it('falls back to toSwiftName when the dep carries no resolved name', () => {
+    const spec = translatePodspecToSpmTarget(
+      podspec(),
+      autolinkedDep({name: 'react-native-foo'}),
+    );
+    expect(spec.swiftName).toBe('ReactNativeFoo');
+  });
+
+  it('resolves each sibling through the same overrides, not through toSwiftName', () => {
+    const model = podspec({dependencies: ['RNWorklets']});
+    const spec = translatePodspecToSpmTarget(
+      model,
+      autolinkedDep({name: 'react-native-reanimated', swiftName: 'reanimated'}),
+      new Map([['RNWorklets', 'react-native-worklets']]),
+      new Map([['react-native-worklets', 'worklets']]),
+    );
+    expect(spec.siblingNames).toEqual(['react-native-worklets']);
+    expect(spec.siblingSwiftNames).toEqual({
+      'react-native-worklets': 'worklets',
+    });
+  });
+
   it('does not self-wire when a pod dependency maps back to the dep itself', () => {
     const model = podspec({dependencies: ['RNReanimated']});
     const spec = translatePodspecToSpmTarget(
@@ -604,6 +635,18 @@ describe('emitScaffoldedPackageSwift', () => {
     );
   });
 
+  it('emits the sibling override name for both the package and the product', () => {
+    const out = emitScaffoldedPackageSwift(
+      baseSpec({
+        siblingNames: ['react-native-worklets'],
+        siblingSwiftNames: {'react-native-worklets': 'worklets'},
+      }),
+    );
+    expect(out).toContain('.package(name: "worklets", path: "../worklets")');
+    expect(out).toContain('.product(name: "worklets", package: "worklets")');
+    expect(out).not.toContain('ReactNativeWorklets');
+  });
+
   it('-includes the ObjC prefix header in c/cxx settings when needsObjCPrefix is set', () => {
     const withPrefix = emitScaffoldedPackageSwift(
       baseSpec({needsObjCPrefix: true}),
@@ -744,6 +787,21 @@ end
       ...overrides,
     };
   }
+
+  it('names the scaffolded package with the spm.name override the autolinker resolved', () => {
+    makePodspec();
+    const result = scaffoldPackageSwiftForDep(
+      makeDep({swiftName: 'foo'}),
+      makeCtx(),
+    );
+    expect(result.status).toBe('written');
+    const content = fs.readFileSync(
+      path.join(depRoot, 'Package.swift'),
+      'utf8',
+    );
+    expect(content).toContain('name: "foo"');
+    expect(content).not.toContain('ReactNativeFoo');
+  });
 
   it('writes Package.swift into the dep root on the happy path', () => {
     makePodspec();

--- a/packages/react-native/scripts/spm/scaffold-package-swift.js
+++ b/packages/react-native/scripts/spm/scaffold-package-swift.js
@@ -235,14 +235,18 @@ function translatePodspecToSpmTarget(
   // `s.dependency "RNWorklets"` — a pod-style name the `react-native-*`
   // heuristic can't recognize — to the right sibling package. Empty by default.
   podToNpm /*: Map<string, string> */ = new Map(),
+  // npm name → resolved Swift name for every autolinked dep, so a sibling
+  // reference honors that sibling's `spm.name` instead of re-deriving it.
+  swiftNameByNpm /*: Map<string, string> */ = new Map(),
 ) /*: SpmScaffoldSpec */ {
   const warnings = [...model.warnings];
 
-  // Swift target name: ALWAYS toSwiftName(npm-name). The autolinker
-  // registers each autolinked dep under that name in its aggregator (and in
-  // any sibling spm.dependencies refs), so the scaffolded Package.swift's
-  // product/library name must match — otherwise SPM resolution fails with
-  // a name mismatch on `.product(name: "X", package: "X")`.
+  // Swift target name: whatever the autolinker resolved for this dep — its
+  // `spm.name` override when set, else toSwiftName(npm-name). The autolinker
+  // registers the dep under that name in its aggregator (and in any sibling
+  // spm.dependencies refs), so the scaffolded Package.swift's product/library
+  // name must match it exactly — otherwise SPM resolution fails with a name
+  // mismatch on `.product(name: "X", package: "X")`.
   //
   // The podspec's `header_dir` is captured separately: when it changes the
   // include surface (e.g. `<reanimated/...>` instead of `<ReactNativeReanimated/...>`),
@@ -251,10 +255,8 @@ function translatePodspecToSpmTarget(
   // `<react/renderer/components/safeareacontext/...>` resolve through
   // `-I common/cpp/`). Module-style includes that NEED the target name to
   // match (e.g. reanimated's `<reanimated/X.h>` via SwiftPM's auto-generated
-  // module map) require an explicit `spm.name` override in
-  // react-native.config.js — handled by the existing autolinker flow, not
-  // here.
-  const swiftName = toSwiftName(dep.name);
+  // module map) are what `spm.name` is for.
+  const swiftName = dep.swiftName ?? toSwiftName(dep.name);
 
   // Header search paths — substitute Xcode build-setting tokens against the
   // dep root. Anything we can't substitute is dropped + warned (avoids
@@ -512,6 +514,14 @@ function translatePodspecToSpmTarget(
     );
   }
 
+  const siblingSwiftNames /*: {[npmName: string]: string} */ = {};
+  for (const npmName of siblingNames) {
+    const resolved = swiftNameByNpm.get(npmName);
+    if (resolved != null) {
+      siblingSwiftNames[npmName] = resolved;
+    }
+  }
+
   return {
     swiftName,
     sources: expandedSources,
@@ -520,6 +530,7 @@ function translatePodspecToSpmTarget(
     needsObjCPrefix,
     coreReactNative,
     siblingNames,
+    siblingSwiftNames,
     extraFrameworks: model.frameworks,
     weakFrameworks: model.weakFrameworks,
     compilerFlags: model.compilerFlags,
@@ -687,7 +698,8 @@ function emitScaffoldedPackageSwift(
     );
   }
   for (const siblingName of spec.siblingNames) {
-    const swiftSibling = toSwiftName(siblingName);
+    const swiftSibling =
+      spec.siblingSwiftNames?.[siblingName] ?? toSwiftName(siblingName);
     // The autolinker references each self-managed (scaffolded) dep through a
     // `libs/<SwiftName>` symlink, and SPM resolves a manifest's relative
     // package paths against that symlink location — so a sibling lives at
@@ -787,6 +799,9 @@ type ScaffoldContext = {
   // podspec-name → npm-name index over all autolinked deps, so pod-style
   // `s.dependency` names (e.g. "RNWorklets") wire to the right sibling.
   podToNpm?: Map<string, string>,
+  // npm-name → resolved Swift name over all autolinked deps, so sibling
+  // references honor each sibling's `spm.name`.
+  swiftNameByNpm?: Map<string, string>,
 };
 */
 
@@ -945,6 +960,7 @@ function scaffoldPackageSwiftForDep(
     model,
     dep,
     ctx.podToNpm ?? new Map(),
+    ctx.swiftNameByNpm ?? new Map(),
   );
 
   // Mixed-language fail-closed: SPM can't compile Swift + C-family in one
@@ -1167,6 +1183,13 @@ function scaffoldAll(
     }
   }
 
+  const swiftNameByNpm /*: Map<string, string> */ = new Map();
+  for (const dep of allDeps) {
+    if (dep.swiftName != null) {
+      swiftNameByNpm.set(dep.name, dep.swiftName);
+    }
+  }
+
   const ctx /*: ScaffoldContext */ = {
     appRoot,
     projectRoot,
@@ -1175,6 +1198,7 @@ function scaffoldAll(
     dryRun: opts.dryRun === true,
     cacheSlotLabel: opts.cacheSlotLabel ?? null,
     podToNpm,
+    swiftNameByNpm,
   };
   const skipSet /*: Set<string> */ = new Set(opts.skipDeps ?? []);
 

--- a/packages/react-native/scripts/spm/spm-types.js
+++ b/packages/react-native/scripts/spm/spm-types.js
@@ -482,10 +482,13 @@ export type SpmScaffoldSpec = {
   // Bucketed dependency references — pre-computed by the translation layer.
   // `coreReactNative` is true when ANY React-* / RCT* / RCT-Folly / glog
   // dep is present (so we add React's invariant header products).
-  // `siblingNames` are npm names that match other autolinked deps — resolved
-  // to Swift names by the scaffold orchestrator before emit.
+  // `siblingNames` are npm names that match other autolinked deps.
+  // `siblingSwiftNames` carries each one's resolved Swift name (honoring the
+  // sibling's `spm.name`); a sibling absent from it falls back to
+  // toSwiftName(npmName) at emit time.
   coreReactNative: boolean,
   siblingNames: Array<string>,
+  siblingSwiftNames?: {[npmName: string]: string},
   // Extra frameworks beyond the autolinker's default UIKit/Foundation/CoreGraphics
   // set. Merged with the defaults at emit time.
   extraFrameworks: Array<string>,


### PR DESCRIPTION
## Summary:

The scaffolder derived every target name with `toSwiftName(dep.name)`, ignoring the `spm.name` override in the library's own react-native.config.js. 

A library setting that override got a manifest whose product name differed from the name the autolinker registers it under, and SPM failed resolution on `.product(name: "X", package: "X")` — the exact mismatch the override exists to prevent.

This setting is documented - but not followed up in the implementation.

Use the name the autolinker already resolved (`dep.swiftName`), falling back to `toSwiftName` when a caller runs the translation without it. Sibling references resolve the same way, through the new `SpmScaffoldSpec.siblingSwiftNames`.

Fixed after community feedback here: https://github.com/powersync-ja/powersync-js/pull/1076

## Changelog:

[IOS] [FIXED] - Fixed not reading spm.name from react-native.config.js when scaffolding the Swift manifest

## Test Plan:

✅ unit tests