### PR TITLE
[iOS][swiftpm] Read both export styles from a library's react-native.config.js

### DIFF
--- a/packages/react-native/scripts/spm/__docs__/spm-scripts.md
+++ b/packages/react-native/scripts/spm/__docs__/spm-scripts.md
@@ -376,6 +376,22 @@ library's target can import it.
 This is a **library-author** surface, like the podspec dependency it replaces —
 apps don't normally set it.
 
+### Config module format
+
+`react-native.config.js` may be CommonJS or ESM, and both named and default
+exports are read. A key defined twice — as a named export and on the default
+export — resolves to the named one. Avoid that shape anyway: the Community CLI
+has two loaders that disagree about it, a sync one that sees named exports and
+an async one that takes only the default export. For maximum compatibility,
+prefer the one-line CommonJS form:
+
+```js
+module.exports = {dependency: {platforms: {ios: {}}}, spm: {name: 'worklets'}};
+```
+
+If the config fails to load, a warning names the file and the reason — the `spm`
+settings in it are ignored rather than silently applied.
+
 ## Self-managed community packages
 
 A community library that ships its own `Package.swift` is referenced directly by

--- a/packages/react-native/scripts/spm/__tests__/expand-spm-dependencies-test.js
+++ b/packages/react-native/scripts/spm/__tests__/expand-spm-dependencies-test.js
@@ -34,10 +34,14 @@
  */
 
 const {
+  defaultReadConfig,
   expandSpmDependencies,
   resolveSwiftName,
 } = require('../expand-spm-dependencies');
 const {toSwiftName} = require('../spm-utils');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
 function makeReadConfig(configs /*: {[string]: ?Object} */) {
   return (root /*: string */) =>
@@ -389,5 +393,114 @@ describe('expandSpmDependencies', () => {
     expect(resolveSwiftName('a', {spm: {name: 'react_native_foo'}})).toBe(
       'react_native_foo',
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultReadConfig
+//
+// The community CLI's own loaders disagree — sync reads named exports, async
+// reads the default one — so a config that sets only `export default` must not
+// be invisible here. Fixtures are transpiled by babel, so they present the
+// `__esModule`/`default` interop shape; a Node namespace object from
+// `require(ESM)` has no `__esModule` but exposes `.default` alongside
+// enumerable named keys the same way, which is what the merge reads.
+// ---------------------------------------------------------------------------
+
+describe('defaultReadConfig', () => {
+  let tmpRoot;
+
+  beforeAll(() => {
+    tmpRoot = fs.mkdtempSync(
+      path.join(fs.realpathSync(os.tmpdir()), 'spm-read-config-'),
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpRoot, {recursive: true, force: true});
+  });
+
+  function writeConfig(name, source) {
+    const root = path.join(tmpRoot, name);
+    fs.mkdirSync(root, {recursive: true});
+    fs.writeFileSync(path.join(root, 'package.json'), JSON.stringify({name}));
+    fs.writeFileSync(path.join(root, 'react-native.config.js'), source);
+    return root;
+  }
+
+  it('returns null when the library ships no config', () => {
+    const root = path.join(tmpRoot, 'no-config');
+    fs.mkdirSync(root, {recursive: true});
+    expect(defaultReadConfig(root)).toBeNull();
+  });
+
+  it('reads a CommonJS config', () => {
+    const root = writeConfig('cjs', "module.exports = {spm: {name: 'Cjs'}};\n");
+    expect(defaultReadConfig(root).spm.name).toBe('Cjs');
+  });
+
+  it('unwraps an ESM config that only has a default export', () => {
+    const root = writeConfig(
+      'esm-default',
+      "export default {spm: {name: 'EsmDefault'}};\n",
+    );
+    expect(defaultReadConfig(root).spm.name).toBe('EsmDefault');
+  });
+
+  it('reads an ESM config that only has named exports', () => {
+    const root = writeConfig(
+      'esm-named',
+      "export const spm = {name: 'EsmNamed'};\n",
+    );
+    expect(defaultReadConfig(root).spm.name).toBe('EsmNamed');
+  });
+
+  it('prefers the named export when a config ships both (the PowerSync shape)', () => {
+    const root = writeConfig(
+      'esm-both',
+      "export const spm = {name: 'Named'};\n" +
+        "export default {spm: {name: 'Default'}, dependency: {platforms: {ios: {}}}};\n",
+    );
+    const config = defaultReadConfig(root);
+    expect(config.spm.name).toBe('Named');
+    // Only the merge satisfies this: `dependency` exists on the default export
+    // alone, so reading the module raw would miss it.
+    expect(config.dependency.platforms.ios).toEqual({});
+  });
+
+  it('keeps sibling keys of the default export (dependency.platforms.ios)', () => {
+    const root = writeConfig(
+      'esm-siblings',
+      "export default {dependency: {platforms: {ios: {}}}, spm: {name: 'Siblings'}};\n",
+    );
+    const config = defaultReadConfig(root);
+    expect(config.dependency.platforms.ios).toEqual({});
+    expect(config.spm.name).toBe('Siblings');
+  });
+
+  it('passes a function-style config through unchanged (module.exports = () => ({...}))', () => {
+    const root = writeConfig(
+      'fn-style',
+      "module.exports = () => ({spm: {name: 'FnStyle'}});\n",
+    );
+    const config = defaultReadConfig(root);
+    expect(typeof config).toBe('function');
+    expect(config().spm.name).toBe('FnStyle');
+  });
+
+  it('warns with the config path and the reason when the config fails to load, and returns null', () => {
+    const root = writeConfig(
+      'broken',
+      "require('a-dev-dependency-that-is-not-installed');\n",
+    );
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(defaultReadConfig(root)).toBeNull();
+      const message = warnSpy.mock.calls.map(call => call.join(' ')).join('\n');
+      expect(message).toContain(path.join(root, 'react-native.config.js'));
+      expect(message).toContain('a-dev-dependency-that-is-not-installed');
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/react-native/scripts/spm/expand-spm-dependencies.js
+++ b/packages/react-native/scripts/spm/expand-spm-dependencies.js
@@ -10,9 +10,11 @@
 
 'use strict';
 
-const {toSwiftName} = require('./spm-utils');
+const {makeLogger, toSwiftName} = require('./spm-utils');
 const fs = require('node:fs');
 const path = require('node:path');
+
+const {warn} = makeLogger('expand-spm-dependencies');
 
 /**
  * expand-spm-dependencies.js — Resolves transitive native deps declared via
@@ -188,8 +190,34 @@ function defaultReadConfig(root /*: string */) /*: ?RnConfig */ {
   }
   try {
     // $FlowFixMe[unsupported-syntax]
-    return require(configPath);
-  } catch {
+    const mod = require(configPath);
+    // Read both export styles, because the community CLI's two loaders
+    // disagree with each other: its sync path (`loadConfig`) requires the
+    // module and sees named exports at top level, its async path
+    // (`loadConfigAsync`) takes the default export only. Merging covers both,
+    // with named exports winning — the shape the sync path already resolves.
+    // Every sibling key of the default export is preserved
+    // (`dependency.platforms.ios` is read from this result too).
+    // A function-style config (`module.exports = () => ({...})`) and other
+    // non-objects pass through untouched — there is no default export to
+    // unwrap, and nulling them would hide a config that used to be read.
+    if (mod == null || typeof mod !== 'object') {
+      return mod;
+    }
+    const dflt = mod.default;
+    if (dflt == null || typeof dflt !== 'object') {
+      return mod;
+    }
+    const {default: _unused, ...named} = mod;
+    return {...dflt, ...named};
+  } catch (e) {
+    // A config can fail to load for reasons unrelated to SPM (it may import a
+    // devDependency absent in a consumer install), so this stays a warning —
+    // but a silent null turns a dropped `spm` block into a link error much
+    // later.
+    warn(
+      `Failed to load ${configPath}: ${e.message}. Any 'spm' settings in it are ignored.`,
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary:

When saving settings in `react-native.config.js`, we should support all styles of exported data:

```js
module.exports = { spm: { name: 'worklets' } };   // old style
export const spm = { name: 'worklets' };          // new style, with a label
export default { spm: { name: 'worklets' } };     // new style, no label — "just this"
```

We only read the two first in the SwiftPM pipeline, silently ignoring anything written with `export default`.

This PR fixes this by adding a catch that tries to decode the default export.

Fixed after community feedback here: https://github.com/powersync-ja/powersync-js/pull/1076

## Changelog:

[IOS] [FIXED] - SwiftPM pipeline now reads react-native.config.js with default exports correctly

## Test Plan:

✅ Added and ran unit tests.