### PR TITLE
Fix Android text measurement to use the rendering TextView default typeface

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -557,6 +557,7 @@ public class FabricUIManager
         TextLayoutManager.measureLines(
             mReactApplicationContext.getAssets(),
             ReactTypefaceUtils.getFontWeightAdjustment(mReactApplicationContext),
+            mReactApplicationContext,
             attributedString,
             paragraphAttributes,
             PixelUtil.toPixelFromDIP(width),
@@ -646,6 +647,7 @@ public class FabricUIManager
     return TextLayoutManager.measureText(
         mReactApplicationContext.getAssets(),
         ReactTypefaceUtils.getFontWeightAdjustment(mReactApplicationContext),
+        mReactApplicationContext,
         attributedString,
         paragraphAttributes,
         getYogaSize(minWidth, maxWidth),
@@ -674,6 +676,7 @@ public class FabricUIManager
     return TextLayoutManager.createPreparedLayout(
         mReactApplicationContext.getAssets(),
         ReactTypefaceUtils.getFontWeightAdjustment(mReactApplicationContext),
+        mReactApplicationContext,
         attributedString,
         paragraphAttributes,
         getYogaSize(minWidth, maxWidth),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -7,7 +7,9 @@
 
 package com.facebook.react.views.text
 
+import android.content.Context
 import android.content.res.AssetManager
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Build
@@ -24,6 +26,7 @@ import android.text.TextUtils
 import android.util.LayoutDirection
 import android.view.Gravity
 import android.view.View
+import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import com.facebook.common.logging.FLog
 import com.facebook.infer.annotation.Assertions
@@ -885,6 +888,7 @@ internal object TextLayoutManager {
       baseTextAttributes: TextAttributeProps,
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
   ) {
     if (baseTextAttributes.fontSize != ReactConstants.UNSET) {
       paint.textSize = baseTextAttributes.fontSize.toFloat()
@@ -921,10 +925,38 @@ internal object TextLayoutManager {
       val typeface = ReactTypefaceUtils.applyFontWeightAdjustment(null, fontWeightAdjustment)
       if (typeface != null) {
         paint.setTypeface(typeface)
+      } else {
+        // ReactTextView renders text with a plain TextView, whose default typeface
+        // inherits the system/theme font configuration (e.g. a bold system font or a
+        // font-replacement app). Measurement uses a bare TextPaint whose default
+        // typeface is Typeface.DEFAULT; when these diverge, auto-width <Text> is
+        // measured narrower than it renders, clipping the last glyphs. Use the same
+        // default typeface the rendering TextView uses.
+        paint.setTypeface(getSystemDefaultTypeface(context))
       }
     }
 
     ReactTypefaceUtils.applyFontVariationSettings(paint, baseTextAttributes.fontVariationSettings)
+  }
+
+  private var sSystemDefaultTypeface: Typeface? = null
+  private var sSystemDefaultTypefaceConfiguration: Configuration? = null
+
+  @Synchronized
+  private fun getSystemDefaultTypeface(context: Context): Typeface {
+    val config = context.resources.configuration
+    if (
+        sSystemDefaultTypeface == null ||
+            sSystemDefaultTypefaceConfiguration?.equals(config) != true
+    ) {
+      // Create a single TextView (no per-measure allocation) from the application
+      // context so we read the same default typeface the rendering TextView uses,
+      // including system/theme-level font replacements. Re-resolve whenever the
+      // Configuration (fontScale, fontWeightAdjustment, locale, ...) changes.
+      sSystemDefaultTypeface = TextView(context.applicationContext).typeface
+      sSystemDefaultTypefaceConfiguration = Configuration(config)
+    }
+    return checkNotNull(sSystemDefaultTypeface)
   }
 
   /**
@@ -935,13 +967,14 @@ internal object TextLayoutManager {
       baseTextAttributes: TextAttributeProps,
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
   ): TextPaint {
     val paint = checkNotNull(textPaintInstance.get())
     paint.setTypeface(null)
     paint.textSize = 12f
     paint.isFakeBoldText = false
     paint.textSkewX = 0f
-    updateTextPaint(paint, baseTextAttributes, assets, fontWeightAdjustment)
+    updateTextPaint(paint, baseTextAttributes, assets, fontWeightAdjustment, context)
     return paint
   }
 
@@ -949,9 +982,10 @@ internal object TextLayoutManager {
       baseTextAttributes: TextAttributeProps,
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
   ): TextPaint {
     val paint = TextPaint(TextPaint.ANTI_ALIAS_FLAG)
-    updateTextPaint(paint, baseTextAttributes, assets, fontWeightAdjustment)
+    updateTextPaint(paint, baseTextAttributes, assets, fontWeightAdjustment, context)
     return paint
   }
 
@@ -959,6 +993,7 @@ internal object TextLayoutManager {
   private fun createLayoutForMeasurement(
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -982,7 +1017,8 @@ internal object TextLayoutManager {
     } else {
       val baseTextAttributes =
           TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES))
-      paint = scratchPaintWithAttributes(baseTextAttributes, assets, fontWeightAdjustment)
+      paint =
+          scratchPaintWithAttributes(baseTextAttributes, assets, fontWeightAdjustment, context)
     }
 
     return createLayout(
@@ -1089,6 +1125,7 @@ internal object TextLayoutManager {
   @OptIn(UnstableReactNativeAPI::class)
   fun createPreparedLayout(
       assets: AssetManager,
+      context: Context,
       attributedString: ReadableMapBuffer,
       paragraphAttributes: ReadableMapBuffer,
       width: Float,
@@ -1100,6 +1137,7 @@ internal object TextLayoutManager {
   ): PreparedLayout = createPreparedLayout(
       assets,
       0,
+      context,
       attributedString,
       paragraphAttributes,
       width,
@@ -1115,6 +1153,7 @@ internal object TextLayoutManager {
   fun createPreparedLayout(
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
       attributedString: ReadableMapBuffer,
       paragraphAttributes: ReadableMapBuffer,
       width: Float,
@@ -1138,7 +1177,7 @@ internal object TextLayoutManager {
         TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES))
     val result = createLayout(
         text,
-        newPaintWithAttributes(baseTextAttributes, assets, fontWeightAdjustment),
+        newPaintWithAttributes(baseTextAttributes, assets, fontWeightAdjustment, context),
         attributedString,
         paragraphAttributes,
         width,
@@ -1279,6 +1318,7 @@ internal object TextLayoutManager {
   @OptIn(UnstableReactNativeAPI::class)
   fun measureText(
       assets: AssetManager,
+      context: Context,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1291,6 +1331,7 @@ internal object TextLayoutManager {
   ): Long = measureText(
       assets,
       0,
+      context,
       attributedString,
       paragraphAttributes,
       width,
@@ -1307,6 +1348,7 @@ internal object TextLayoutManager {
   fun measureText(
       assets: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1321,6 +1363,7 @@ internal object TextLayoutManager {
     val layout = createLayoutForMeasurement(
         assets,
         fontWeightAdjustment,
+        context,
         attributedString,
         paragraphAttributes,
         width,
@@ -1580,6 +1623,7 @@ internal object TextLayoutManager {
   @OptIn(UnstableReactNativeAPI::class)
   fun measureLines(
       assetManager: AssetManager,
+      context: Context,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1589,6 +1633,7 @@ internal object TextLayoutManager {
   ): WritableArray = measureLines(
       assetManager,
       0,
+      context,
       attributedString,
       paragraphAttributes,
       width,
@@ -1602,6 +1647,7 @@ internal object TextLayoutManager {
   fun measureLines(
       assetManager: AssetManager,
       fontWeightAdjustment: Int,
+      context: Context,
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
@@ -1612,6 +1658,7 @@ internal object TextLayoutManager {
     val layout = createLayoutForMeasurement(
         assetManager,
         fontWeightAdjustment,
+        context,
         attributedString,
         paragraphAttributes,
         width,

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerFontWeightAdjustmentTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerFontWeightAdjustmentTest.kt
@@ -11,6 +11,7 @@ import android.graphics.Paint
 import android.graphics.Typeface
 import android.os.Build
 import android.text.TextPaint
+import android.widget.TextView
 import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.uimanager.DisplayMetricsHolder
@@ -55,13 +56,14 @@ class TextLayoutManagerFontWeightAdjustmentTest {
         textAttributes,
         RuntimeEnvironment.getApplication().assets,
         FONT_WEIGHT_ADJUSTMENT_BOLD_TEXT,
+        RuntimeEnvironment.getApplication(),
     )
 
     assertThat(paint.typeface).isNotNull
   }
 
   @Test
-  fun `plain text paint keeps default typeface unset without font weight adjustment`() {
+  fun `plain text paint uses rendering TextView default typeface without font weight adjustment`() {
     val paint = TextPaint(TextPaint.ANTI_ALIAS_FLAG)
     val textAttributes = TextAttributeProps.fromReadableMap(ReactStylesDiffMap(JavaOnlyMap()))
 
@@ -70,9 +72,15 @@ class TextLayoutManagerFontWeightAdjustmentTest {
         textAttributes,
         RuntimeEnvironment.getApplication().assets,
         0,
+        RuntimeEnvironment.getApplication(),
     )
 
-    assertThat(paint.typeface).isNull()
+    // Matches the typeface the rendering TextView (ReactTextView) would use, so
+    // measurement and rendering stay in sync even when the system default font is
+    // replaced (e.g. a bold system font).
+    assertThat(paint.typeface)
+        .isNotNull
+        .isEqualTo(TextView(RuntimeEnvironment.getApplication()).typeface)
   }
 
   @Test
@@ -88,6 +96,7 @@ class TextLayoutManagerFontWeightAdjustmentTest {
         textAttributes,
         RuntimeEnvironment.getApplication().assets,
         0,
+        RuntimeEnvironment.getApplication(),
     )
 
     assertThat(paint.fontVariationSettings).isNull()


### PR DESCRIPTION
## Summary

Auto-width `<Text>` can clip its last glyph(s) on devices where the system default font is replaced/bolded at the theme level (e.g. Xiaomi HyperOS "全加粗" / a font replacement app). Measurement uses a bare `TextPaint` whose default typeface is `Typeface.DEFAULT` (the static normal font), while `ReactTextView` renders with the `TextView` default typeface that inherits the system font configuration. When those diverge, the measured width is narrower than what is actually drawn, so the trailing glyph(s) are pushed out of the view.

Fixes #57950.

## Root cause

`TextLayoutManager.updateTextPaint()` leaves the typeface unset (→ `Typeface.DEFAULT`) when no explicit font family/weight/style is present:

```kotlin
} else {
  val typeface = ReactTypefaceUtils.applyFontWeightAdjustment(null, fontWeightAdjustment)
  if (typeface != null) {
    paint.setTypeface(typeface)
  }
}
```

On stock Android this works because the accessibility "bold text" setting (`fontWeightAdjustment`) updates the process-wide `Typeface.DEFAULT`, so the bare measurement paint picks up the same bold metrics. OEM font replacements applied at the **TextView/theme level without updating `Typeface.DEFAULT`** (as HyperOS "full bold" does) are not visible to the measurement paint, causing the mismatch.

On-device measurement (48px text, Xiaomi with MiSans "full bold"):

| | ascent | descent | line height |
|---|---|---|---|
| measurement paint (`Typeface.DEFAULT`) | -45 | 3 | 1.0em |
| rendering TextView (system bold) | -50 | 14 | 1.33em |

`English` (7 glyphs): measured 53.33dp (6 glyphs laid out) vs drawn 56.67dp (7 glyphs) — the final `h` is dropped.

## Change

When no explicit font family/weight/style is set **and** there is no font weight adjustment, resolve the default typeface from the same source the rendering `TextView` uses:

```kotlin
} else {
  val typeface = ReactTypefaceUtils.applyFontWeightAdjustment(null, fontWeightAdjustment)
  if (typeface != null) {
    paint.setTypeface(typeface)
  } else {
    paint.setTypeface(getSystemDefaultTypeface(context))
  }
}
```

`getSystemDefaultTypeface()` reads the typeface of a single cached `TextView` created from the application context (no per-measure allocation, no activity leak) and re-resolves it whenever the `Configuration` changes (fontScale / fontWeightAdjustment / locale). A `Context` is threaded from `FabricUIManager` (which already threads `assets` and `fontWeightAdjustment`) down to `updateTextPaint`.

On unmodified systems the `TextView` default typeface is the same normal face, so behavior and measurements are unchanged.

## Test plan

- Updated `TextLayoutManagerFontWeightAdjustmentTest` to assert that, without font weight adjustment, the measurement typeface equals the rendering `TextView` default typeface.
- Verified on 5 Android devices including 3 Xiaomi phones/tablets with the bold system font enabled: `English` measures 57dp == drawn 56.67dp, all 7 glyphs present; time/CJK text unaffected; layouts remain correct.

## Notes for reviewers

- The typeface is read from the application context's default theme, which reproduces the rendering `TextView` on the affected devices. Devices that apply theme-dependent default fonts per-Activity may need the themed context instead.
- Static caching is invalidated on `Configuration` change; a live font-family replacement that does not change `Configuration` would still need an app restart to re-apply, which is the normal case.
- This change only affects measurement; it does not change rendering. The maintainer offered to collaborate on the verification path since this is hard to reproduce on stock emulators.
