### PR TITLE
Fix nullable float props crashing ViewManagers on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
@@ -259,6 +259,18 @@ internal object ViewManagersPropertyCache {
     }
   }
 
+  private class BoxedFloatPropSetter(prop: ReactProp, setter: Method) :
+      PropSetter(prop, "number", setter) {
+
+    override fun getValueOrDefault(value: Any?, context: Context): Any? {
+      if (value != null) {
+        // All numbers from JS are Doubles which can't be simply cast to Float
+        return if (value is Double) value.toFloat() else value as Float
+      }
+      return null
+    }
+  }
+
   private class BoxedIntPropSetter : PropSetter {
 
     constructor(prop: ReactProp, setter: Method) : super(prop, "number", setter)
@@ -391,6 +403,7 @@ internal object ViewManagersPropertyCache {
             DoublePropSetter(annotation, method, annotation.defaultDouble)
         String::class.java -> StringPropSetter(annotation, method)
         java.lang.Boolean::class.java -> BoxedBooleanPropSetter(annotation, method)
+        java.lang.Float::class.java -> BoxedFloatPropSetter(annotation, method)
         java.lang.Integer::class.java ->
             if ("Color" == annotation.customType) {
               BoxedColorPropSetter(annotation, method)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
@@ -39,6 +39,8 @@ class ReactPropAnnotationSetterTest {
 
     fun onBoxedBooleanSetterCalled(value: Boolean?)
 
+    fun onBoxedFloatSetterCalled(value: Float?)
+
     fun onBoxedIntSetterCalled(value: Int?)
 
     fun onArraySetterCalled(value: ReadableArray?)
@@ -126,6 +128,11 @@ class ReactPropAnnotationSetterTest {
     @ReactProp(name = "boxedIntProp")
     fun setBoxedIntProp(v: View?, value: Int?) {
       viewManagerUpdatesReceiver.onBoxedIntSetterCalled(value)
+    }
+
+    @ReactProp(name = "boxedFloatProp")
+    fun setBoxedFloatProp(v: View?, value: Float?) {
+      viewManagerUpdatesReceiver.onBoxedFloatSetterCalled(value)
     }
 
     @ReactProp(name = "arrayProp")
@@ -310,6 +317,22 @@ class ReactPropAnnotationSetterTest {
     Mockito.reset(updatesReceiverMock)
     viewManager.updateProperties(targetView, buildStyles("boxedIntProp", null))
     Mockito.verify(updatesReceiverMock).onBoxedIntSetterCalled(null)
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+  }
+
+  @Test
+  fun testBoxedFloatSetter() {
+    viewManager.updateProperties(targetView, buildStyles("boxedFloatProp", 3.5))
+    Mockito.verify(updatesReceiverMock).onBoxedFloatSetterCalled(3.5f)
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+    viewManager.updateProperties(targetView, buildStyles("boxedFloatProp", -7.0))
+    Mockito.verify(updatesReceiverMock).onBoxedFloatSetterCalled(-7.0f)
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+    viewManager.updateProperties(targetView, buildStyles("boxedFloatProp", null))
+    Mockito.verify(updatesReceiverMock).onBoxedFloatSetterCalled(null)
     Mockito.verifyNoMoreInteractions(updatesReceiverMock)
     Mockito.reset(updatesReceiverMock)
   }


### PR DESCRIPTION
## Summary:

Fixes #55350.

A codegen'd Fabric component that declares an optional float prop:

```js
type NativeProps = Readonly<{
  ...ViewProps,
  testFloatNullable?: WithDefault<CodegenTypes.Float, null>,
}>;
```

crashes the app at startup as soon as the `ViewManager` implements it with a `@ReactProp` annotation:

```
java.lang.RuntimeException: Unrecognized type: class java.lang.Float
  for method: MyNativeViewManager#setTestFloatNullable
  at ViewManagersPropertyCache.createPropSetter(...)
  at ViewManagerPropertyUpdater$FallbackViewManagerSetter.<init>(...)
  at ViewManager.getNativeProps(...)
```

`WithDefault<Float, null>` is the only way to express a genuinely nullable float in a codegen spec — a plain optional `CodegenTypes.Float` is emitted as a primitive `float` defaulting to `0f`. So codegen generates a `@Nullable Float` setter in the ViewManager interface, and then the runtime refuses to bind it.

### Root cause

`GeneratePropsJavaInterface` emits exactly four boxed (nullable) prop types:

| Codegen type annotation | Emitted Java type | Handled by `ViewManagersPropertyCache` |
| --- | --- | --- |
| `BooleanTypeAnnotation` with `default: null` | `@Nullable Boolean` | `BoxedBooleanPropSetter` |
| `ReservedPropTypeAnnotation` / `ColorPrimitive` | `@Nullable Integer` | `BoxedColorPropSetter` |
| `Int32EnumTypeAnnotation` | `@Nullable Integer` | `BoxedIntPropSetter` |
| `FloatTypeAnnotation` with `default: null` | `@Nullable Float` | **nothing — falls through to `else`** |

`createPropSetter` maps `java.lang.Boolean` and `java.lang.Integer`, but has no branch for `java.lang.Float`, so it hits the `else` and throws. This adds the missing `BoxedFloatPropSetter`, mirroring `BoxedIntPropSetter`: unbox `Double` (all JS numbers arrive as `Double`) to `Float`, and pass `null` straight through so the setter actually receives the absent value.

`DoubleTypeAnnotation` is deliberately not covered — codegen always emits it as a primitive `double`, never boxed, so there is no nullable-double setter to bind.

Note this only affects ViewManagers that use `@ReactProp`. A codegen'd ViewManager that routes props through its generated delegate never reaches `ViewManagersPropertyCache`, which is why the crash looks intermittent — the annotation is what pulls in `FallbackViewManagerSetter`.

## Changelog:

[ANDROID] [FIXED] - Fix `RuntimeException: Unrecognized type: class java.lang.Float` when a `ViewManager` implements a nullable float prop (`WithDefault<Float, null>`) with `@ReactProp`

## Test Plan:

Added `testBoxedFloatSetter` to `ReactPropAnnotationSetterTest`, alongside the existing `testBoxedBooleanSetter` / `testBoxedIntSetter`, plus a `boxedFloatProp` on the ViewManager under test. It drives `viewManager.updateProperties(...)`, which is the same `FallbackViewManagerSetter` → `getNativePropSettersForViewManagerClass` → `createPropSetter` path as the crash stack trace, and asserts the setter receives `3.5f`, `-7.0f` and `null`.

```
$ ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest \
    --tests "com.facebook.react.uimanager.ReactPropAnnotationSetterTest"

BUILD SUCCESSFUL in 3m 16s

tests=18 failures=0 errors=0 skipped=0
  ok testBoxedBooleanSetter
  ok testBoxedFloatSetter      <- new
  ok testBoxedIntSetter
  ok testFloatSetter
  ... (18/18)
```

Reverting only `ViewManagersPropertyCache.kt` and keeping the new test reproduces the reported crash verbatim:

```
tests=18 failures=18 errors=0

java.lang.RuntimeException: Unrecognized type: class java.lang.Float
  for method: ReactPropAnnotationSetterTest$ViewManagerUnderTest#setBoxedFloatProp
```

All 18 fail rather than just the new one, and that is the bug's real shape:
`getNativePropSettersForViewManagerClass` builds the setter map for the entire
ViewManager class in one pass and caches it, so a single unbindable prop takes
down every other prop on that manager. That is why the reported crash happens at
startup, while `getNativeProps()` is collecting view manager constants, rather
than when the offending prop is first set.

Kotlin formatting:

```
$ ./gradlew ktfmtCheck
BUILD SUCCESSFUL
```

`ViewManagersPropertyCache` is an `internal object` and `BoxedFloatPropSetter` is
a `private class`, so `ReactAndroid.api` is unchanged.

