### PR TITLE
Fix DimensionValue props crashing ViewManagers on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.view.View
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.bridge.DimensionPropConverter
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
@@ -18,6 +19,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
+import com.facebook.yoga.YogaValue
 import java.lang.reflect.Method
 
 /**
@@ -190,6 +192,15 @@ internal object ViewManagersPropertyCache {
       }
       return ColorPropConverter.getColor(value, context)
     }
+  }
+
+  private class DimensionPropSetter(prop: ReactProp, setter: Method) :
+      PropSetter(prop, "mixed", setter) {
+
+    // A DimensionValue arrives from JS as either a number (points) or a string
+    // (e.g. "100%"), and is nullable, so the conversion is delegated wholesale.
+    override fun getValueOrDefault(value: Any?, context: Context): Any? =
+        DimensionPropConverter.getDimension(value)
   }
 
   private class BooleanPropSetter(
@@ -399,6 +410,7 @@ internal object ViewManagersPropertyCache {
             }
         ReadableArray::class.java -> ArrayPropSetter(annotation, method)
         ReadableMap::class.java -> MapPropSetter(annotation, method)
+        YogaValue::class.java -> DimensionPropSetter(annotation, method)
         else ->
             throw RuntimeException(
                 "Unrecognized type: $propTypeClass for method: ${method.declaringClass.name}#${method.name}",

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
@@ -16,6 +16,8 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
+import com.facebook.yoga.YogaUnit
+import com.facebook.yoga.YogaValue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,6 +42,8 @@ class ReactPropAnnotationSetterTest {
     fun onBoxedBooleanSetterCalled(value: Boolean?)
 
     fun onBoxedIntSetterCalled(value: Int?)
+
+    fun onDimensionSetterCalled(value: YogaValue?)
 
     fun onArraySetterCalled(value: ReadableArray?)
 
@@ -126,6 +130,11 @@ class ReactPropAnnotationSetterTest {
     @ReactProp(name = "boxedIntProp")
     fun setBoxedIntProp(v: View?, value: Int?) {
       viewManagerUpdatesReceiver.onBoxedIntSetterCalled(value)
+    }
+
+    @ReactProp(name = "dimensionProp")
+    fun setDimensionProp(v: View?, value: YogaValue?) {
+      viewManagerUpdatesReceiver.onDimensionSetterCalled(value)
     }
 
     @ReactProp(name = "arrayProp")
@@ -312,6 +321,27 @@ class ReactPropAnnotationSetterTest {
     Mockito.verify(updatesReceiverMock).onBoxedIntSetterCalled(null)
     Mockito.verifyNoMoreInteractions(updatesReceiverMock)
     Mockito.reset(updatesReceiverMock)
+  }
+
+  @Test
+  fun testDimensionSetter() {
+    viewManager.updateProperties(targetView, buildStyles("dimensionProp", 10.5))
+    Mockito.verify(updatesReceiverMock).onDimensionSetterCalled(YogaValue(10.5f, YogaUnit.POINT))
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+    viewManager.updateProperties(targetView, buildStyles("dimensionProp", "100%"))
+    Mockito.verify(updatesReceiverMock).onDimensionSetterCalled(YogaValue(100f, YogaUnit.PERCENT))
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+    viewManager.updateProperties(targetView, buildStyles("dimensionProp", null))
+    Mockito.verify(updatesReceiverMock).onDimensionSetterCalled(null)
+    Mockito.verifyNoMoreInteractions(updatesReceiverMock)
+    Mockito.reset(updatesReceiverMock)
+  }
+
+  @Test(expected = JSApplicationIllegalArgumentException::class)
+  fun testFailToUpdateDimensionPropWithArray() {
+    viewManager.updateProperties(targetView, buildStyles("dimensionProp", JavaOnlyArray()))
   }
 
   @Test


### PR DESCRIPTION
## Summary:

A Fabric component whose spec declares a `DimensionValue` prop:

```js
type NativeProps = Readonly<{
  ...ViewProps,
  marginBack?: DimensionValue,
}>;
```

crashes the app while React Native is collecting view manager constants, as soon
as the `ViewManager` implements that prop with `@ReactProp`:

```
java.lang.RuntimeException: Unrecognized type: class com.facebook.yoga.YogaValue
  for method: MyNativeViewManager#setMarginBack
  at ViewManagersPropertyCache.createPropSetter(...)
  at ViewManagerPropertyUpdater$FallbackViewManagerSetter.<init>(...)
  at ViewManager.getNativeProps(...)
  at UIManagerModuleConstantsHelper.internal_createConstantsForViewManager(...)
```

### Root cause

Codegen maps `DimensionValue` to the `DimensionPrimitive` reserved type and emits
a boxed `@Nullable YogaValue` setter on the generated ViewManager interface — this
is covered by a committed snapshot:

```java
// GeneratePropsJavaInterface-test.js.snap
public interface DimensionPropNativeComponentManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
  void setMarginBack(T view, @Nullable YogaValue value);
}
```

`ViewManagersPropertyCache.createPropSetter` has no branch for `YogaValue`, so it
falls through to the `else` and throws.

The conversion logic already exists — `DimensionPropConverter` handles exactly the
three shapes a `DimensionValue` arrives in (`null`, a `Double` in points, a `String`
like `"100%"`) and has its own unit tests. But it is only referenced by generated
delegate code (`GeneratePropsJavaDelegate.js`), never by the `@ReactProp` path.
Compare `ColorPropConverter`, which is wired into *both* paths — that asymmetry is
the bug.

This adds the missing `DimensionPropSetter`, modelled on `ColorPropSetter`, which
delegates wholesale to the existing converter. It reports `mixed` as its prop type
because a dimension may be a number or a string, matching how colors are reported.

Note the blast radius: `getNativePropSettersForViewManagerClass` builds the setter
map for an entire ViewManager class in one pass, so a single unbindable prop takes
down every other prop on that manager, and `createConstantsForViewManager` reads
`viewManager.nativeProps` unconditionally. That is why this surfaces as a startup
crash rather than a failure when the prop is first set.

This is the same class of gap as #55350 (`@Nullable Float`). With both fixed, every
Java type `GeneratePropsJavaInterface` can emit is bindable through `@ReactProp`.

## Changelog:

[ANDROID] [FIXED] - Fix `RuntimeException: Unrecognized type: class com.facebook.yoga.YogaValue` when a `ViewManager` implements a `DimensionValue` prop with `@ReactProp`

## Test Plan:

Added `testDimensionSetter` and `testFailToUpdateDimensionPropWithArray` to
`ReactPropAnnotationSetterTest`, plus a `dimensionProp` on the ViewManager under
test. They drive `viewManager.updateProperties(...)` — the same
`FallbackViewManagerSetter` -> `getNativePropSettersForViewManagerClass` ->
`createPropSetter` path as the crash — and assert the setter receives
`YogaValue(10.5f, POINT)` for a number, `YogaValue(100f, PERCENT)` for `"100%"`,
and `null` for `null`, and that an unsupported value still surfaces as a
`JSApplicationIllegalArgumentException` rather than escaping raw.

```
$ ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest \
    --tests "com.facebook.react.uimanager.ReactPropAnnotationSetterTest"

BUILD SUCCESSFUL
tests=19 failures=0 errors=0
  ok testDimensionSetter                    <- new
  ok testFailToUpdateDimensionPropWithArray <- new
  ... (19/19)
```

Reverting only `ViewManagersPropertyCache.kt` and keeping the new tests reproduces
the crash:

```
tests=19 failures=19

java.lang.RuntimeException: Unrecognized type: class com.facebook.yoga.YogaValue
  for method: ReactPropAnnotationSetterTest$ViewManagerUnderTest#setDimensionProp
```

All 19 fail rather than only the two new ones, for the reason described above: the
setter map is built for the whole ViewManager class at once.

Formatting — `./gradlew ktfmtFormat` leaves both changed files byte-identical.

`ViewManagersPropertyCache` is an `internal object` and `DimensionPropSetter` is a
`private class`, so `ReactAndroid.api` is unchanged.

