### PR TITLE
Cover the resize observer modules with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_nativemodule_resizeobserver PUBLIC ${REACT_COMM
 target_link_libraries(react_nativemodule_resizeobserver
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
         react_renderer_bridging
         react_renderer_core
         react_renderer_graphics

--- a/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/NativeResizeObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/NativeResizeObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/React-resizeobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/resizeobserver/React-resizeobservernativemodule.podspec
@@ -61,8 +61,10 @@ Pod::Spec.new do |s|
   s.dependency "React-Fabric/bridging"
   s.dependency "React-Fabric/observers/resize"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
 
+  mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/observers/resize/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/resize/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_renderer_observers_resize PUBLIC ${REACT_COMMON
 target_link_libraries(react_renderer_observers_resize
       react_cxxreact
       react_bridging
+      react_cxxstableapi
       react_renderer_core
       react_renderer_graphics
       react_renderer_mounting

--- a/packages/react-native/ReactCommon/react/renderer/observers/resize/ResizeObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/resize/ResizeObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/graphics/Rect.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/resize/ResizeObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/resize/ResizeObserverManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/mounting/ShadowTree.h>


### PR DESCRIPTION
Summary:
Classifies `react/renderer/observers/resize:resize` and `react/nativemodule/resizeobserver:resizeobserver` as private targets under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include their headers directly; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D116912836


