### PR TITLE
Cover `react/nativemodule/featureflags` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_nativemodule_featureflags PUBLIC ${REACT_COMMON
 target_link_libraries(react_nativemodule_featureflags
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
         react_featureflags
 )
 target_compile_reactnative_options(react_nativemodule_featureflags PRIVATE)

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c65d5fea853b54322321f86c1d5ce440>>
+ * @generated SignedSource<<40d25fafea07a23f9d4e146973c65cb5>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/PrivateGuard.h>
 
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-featureflags"
+  s.dependency "React-cxxstableapi"
 
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.h-template.js
@@ -27,6 +27,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else


### PR DESCRIPTION
Summary:
Classifies `react/nativemodule/featureflags:featureflags` as a private target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its header directly; without that flag the guard is inert, so no existing build changes behaviour.

`NativeReactNativeFeatureFlags.h` is generated, so the guard is added to its template and the file regenerated with `yarn featureflags --update` rather than edited in place.

Changelog: [Internal]

Differential Revision: D116916158


