### PR TITLE
Cover `jsinspector-modern/cdp:jsinspector_cdp` with Stable API guards (#58042)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(jsinspector_cdp PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_cdp
         folly_runtime
+        react_cxxstableapi
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <string>

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -46,5 +46,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
+  s.dependency "React-cxxstableapi"
+
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(jsinspector_tracing
         jsi
         jsinspector_network
         oscompat
+        react_cxxstableapi
         react_timing
         react_utils
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <utility>
 
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
+  s.dependency "React-cxxstableapi"
   s.dependency "React-jsi"
   s.dependency "React-oscompat"
   s.dependency "React-timing"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>


### PR DESCRIPTION
Summary:

Classifies `jsinspector-modern/cdp:jsinspector_cdp` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D116917710


