### PR TITLE
Cover `jsinspector-modern/tracing` with Stable API guards (#58043)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(jsinspector_cdp PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_cdp
         folly_runtime
+        react_cxxstableapi
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <string>

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -46,5 +46,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
+  s.dependency "React-cxxstableapi"
+
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(jsinspector_tracing
         jsi
         jsinspector_network
         oscompat
+        react_cxxstableapi
         react_timing
         react_utils
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ConsoleTimeStamp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ConsoleTimeStamp.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #if defined(REACT_NATIVE_DEBUGGER_ENABLED)
 #include <react/timing/primitives.h>
 #endif

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/FrameTimingSequence.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/FrameTimingSequence.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceEvent.h"
 
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTracingProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "FrameTimingSequence.h"
 #include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTracingProfileSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTracingProfileSerializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "FrameTimingSequence.h"
 #include "HostTracingProfile.h"
 #include "TraceEvent.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceEvent.h"
 
 namespace facebook::react::jsinspector_modern::tracing {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "ConsoleTimeStamp.h"
 #include "TraceEvent.h"
 #include "TraceEventProfile.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracerSection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracerSection.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 
 #include <jsinspector-modern/tracing/PerformanceTracer.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <utility>
 
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
+  s.dependency "React-cxxstableapi"
   s.dependency "React-jsi"
   s.dependency "React-oscompat"
   s.dependency "React-timing"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceEvent.h"
 
 #include <memory>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "RuntimeSamplingProfile.h"
 
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceRecordingState.h"
 
 namespace facebook::react::jsinspector_modern::tracing {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TimeWindowedBuffer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TimeWindowedBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <algorithm>
 #include <functional>
 #include <optional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/Timing.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/Timing.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <cassert>
 
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsinspector-modern/tracing/TracingCategory.h>
 #include <react/timing/primitives.h>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventGenerator.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventGenerator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceEvent.h"
 
 #include <jsinspector-modern/tracing/FrameTimingSequence.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceEvent.h"
 #include "TraceEventProfile.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
 #include "TracingMode.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/container/small_vector.h>
 
 #include <optional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingMode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingMode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 namespace facebook::react::jsinspector_modern::tracing {
 
 enum class Mode {


### PR DESCRIPTION
Summary:

Classifies `jsinspector-modern/tracing:jsinspector_tracing` and `jsinspector-modern/tracing:traceevent` as "for frameworks" targets under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include their headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D116917707


