### PR TITLE
Cover `react/runtime/nativeviewconfig` with Stable API guards (#58045)

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
   add_rncore_dependency(s)
 
   s.dependency "React-jsinspector"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
 
   mark_as_react_native_build(s)

--- a/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/CMakeLists.txt
@@ -16,5 +16,5 @@ add_library(
 )
 target_include_directories(bridgelessnativeviewconfig PUBLIC .)
 
-target_link_libraries(bridgelessnativeviewconfig jsi)
+target_link_libraries(bridgelessnativeviewconfig jsi react_cxxstableapi)
 target_compile_reactnative_options(bridgelessnativeviewconfig PRIVATE)

--- a/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/LegacyUIManagerConstantsProviderBinding.h
+++ b/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/LegacyUIManagerConstantsProviderBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react::LegacyUIManagerConstantsProviderBinding {


### PR DESCRIPTION
Summary:

Classifies `react/runtime/nativeviewconfig:nativeviewconfig` as a private target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its header directly; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D116918780


