### PR TITLE
Cover `react/renderer/consistency:consistency` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
@@ -12,5 +12,7 @@ file(GLOB react_renderer_consistency_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_consistency OBJECT ${react_renderer_consistency_SRC})
 
 target_include_directories(react_renderer_consistency PUBLIC ${REACT_COMMON_DIR})
+
+target_link_libraries(react_renderer_consistency react_cxxstableapi)
 target_compile_reactnative_options(react_renderer_consistency PRIVATE)
 target_compile_options(react_renderer_consistency PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
@@ -40,5 +40,7 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_rendererconsistency")
 
+  s.dependency "React-cxxstableapi"
+
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/consistency/ScopedShadowTreeRevisionLock.h
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/ScopedShadowTreeRevisionLock.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 namespace facebook::react {
 
 /**


### PR DESCRIPTION
Summary:
Classifies `react/renderer/consistency:consistency` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to both headers in the module and declares the guard dependency in BUCK, CMake and the podspec.

Changelog: [Internal]

Differential Revision: D116601683


