### PR TITLE
Restore `ECOSYSTEM.md` as Foundation redirect

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -1,0 +1,5 @@
+# The React Native Ecosystem
+
+The React Native project is now part of the [React Foundation](https://react.foundation/).
+
+The ecosystem information previously maintained in this document has been superseded by the [React Foundation website](https://react.foundation/). Visit the website for current information about the React Native ecosystem.


### PR DESCRIPTION
Summary:
Restore `ECOSYSTEM.md` so existing GitHub links continue to resolve. Explain that React Native is now part of the React Foundation and direct readers to the Foundation website for current ecosystem information.

Changelog: [Internal]

Differential Revision: D116920238


