### PR TITLE
Cover `react/runtime/hermes:hermes` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -34,6 +34,7 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../", module_name: "React_RuntimeHermes")
 
+  s.dependency "React-cxxstableapi"
   s.dependency "React-jsitracing"
   s.dependency "React-jsi"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(bridgelesshermes
         jsi
         jsitooling
         jsinspector
+        react_cxxstableapi
         ${reactnative}
 )
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <cxxreact/MessageQueueThread.h>
 #include <hermes/hermes.h>
 #include <jsi/jsi.h>


### PR DESCRIPTION
Summary:
Classifies `react/runtime/hermes:hermes` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guard is inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D116926134


