### PR TITLE
Cover the Hermes executor with Stable API guards (#58055)

### DIFF
--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(hermes_executor_common
         hermes_inspector_modern
         jsi
         jsireact
+        react_cxxstableapi
         ${reactnative}
 )
 

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <hermes/hermes.h>
 #include <jsireact/JSIExecutor.h>
 #include <utility>


### PR DESCRIPTION
Summary:

Classifies `hermes/executor:executor` as a private target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its headers directly; without that flag the guards are inert, so no existing build changes behaviour. No podspec edit is needed — `React-hermes`, the pod that compiles this module, is already configured.

Changelog: [Internal]

Differential Revision: D116934196


