### PR TITLE
Drop unused Hermes import from RCTAppSetupUtils (#58056)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -13,10 +13,6 @@
 
 #import <memory>
 
-#if USE_THIRD_PARTY_JSC != 1
-#import <reacthermes/HermesExecutorFactory.h>
-#endif
-
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <jsireact/JSIExecutor.h>
 


### PR DESCRIPTION
Summary:

`RCTAppSetupUtils.h` imports `<reacthermes/HermesExecutorFactory.h>` but names nothing from it, so the import and the conditional that wrapped only it are removed. This unblocks classifying the Hermes executor as a private target under the three-tier C++ stable API visibility model, which it cannot be while a public header reaches it. Code that relied on reaching `HermesExecutorFactory` through this header should import it directly.

Changelog:
[iOS][Changed] - `RCTAppSetupUtils.h` no longer transitively imports `HermesExecutorFactory.h`

Differential Revision: D116934198


