### PR TITLE
[0.86] Use macOS 26 runners for iOS E2E tests

### DIFF
--- a/.github/workflow-scripts/__tests__/maestro-ios-test.js
+++ b/.github/workflow-scripts/__tests__/maestro-ios-test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+  spawn: jest.fn(),
+}));
+const childProcess = require('child_process');
+
+const {findAvailableSimulator} = require('../maestro-ios');
+
+describe('Maestro iOS runner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selects an iPhone Pro simulator from the latest runtime', () => {
+    childProcess.execSync.mockReturnValue(
+      JSON.stringify({
+        devices: {
+          'iOS 18.5': [{name: 'iPhone 16 Pro', udid: 'old-pro'}],
+          'iOS 26.5': [
+            {name: 'iPhone 17 Pro Max', udid: 'new-pro-max'},
+            {name: 'iPhone 17 Pro', udid: 'new-pro'},
+          ],
+        },
+      }),
+    );
+
+    expect(findAvailableSimulator()).toEqual({
+      name: 'iPhone 17 Pro',
+      udid: 'new-pro',
+    });
+  });
+});

--- a/.github/workflow-scripts/maestro-ios.js
+++ b/.github/workflow-scripts/maestro-ios.js
@@ -23,25 +23,28 @@ node maestro-android.js <path to app> <app_id> <maestro_flow> <flavor> <working_
 ==============
 `;
 
-const args = process.argv.slice(2);
-
-if (args.length !== 6) {
-  throw new Error(`Invalid number of arguments.\n${usage}`);
-}
-
-const APP_PATH = args[0];
-const APP_ID = args[1];
-const MAESTRO_FLOW = args[2];
-const JS_ENGINE = args[3];
-const IS_DEBUG = args[4] === 'Debug';
-const WORKING_DIRECTORY = args[5];
-
 const MAX_ATTEMPTS = 5;
 
-function launchSimulator(simulatorName) {
-  console.log(`Launching simulator ${simulatorName}`);
+function findAvailableSimulator() {
+  const output = childProcess.execSync(
+    'xcrun simctl list devices available -j',
+  );
+  const devices = Object.values(JSON.parse(String(output)).devices)
+    .flat()
+    .reverse();
+  const simulator = devices.find(device => /^iPhone .* Pro$/.test(device.name));
+
+  if (simulator == null) {
+    throw new Error('Unable to find an available iPhone Pro simulator');
+  }
+
+  return simulator;
+}
+
+function launchSimulator(simulator) {
+  console.log(`Launching simulator ${simulator.name} (${simulator.udid})`);
   try {
-    childProcess.execSync(`xcrun simctl boot "${simulatorName}"`);
+    childProcess.execSync(`xcrun simctl boot "${simulator.udid}"`);
   } catch (error) {
     if (
       !error.message.includes('Unable to boot device in current state: Booted')
@@ -54,14 +57,6 @@ function launchSimulator(simulatorName) {
 function installAppOnSimulator(appPath) {
   console.log(`Installing app at path ${appPath}`);
   childProcess.execSync(`xcrun simctl install booted "${appPath}"`);
-}
-
-function extractSimulatorUDID() {
-  console.log('Retrieving device UDID');
-  const command = `xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid'`;
-  const udid = String(childProcess.execSync(command)).trim();
-  console.log(`UDID is ${udid}`);
-  return udid;
 }
 
 function bringSimulatorInForeground() {
@@ -151,26 +146,42 @@ function executeTestsWithRetries(
   }
 }
 
-async function main() {
+async function main(args = process.argv.slice(2)) {
+  if (args.length !== 6) {
+    throw new Error(`Invalid number of arguments.\n${usage}`);
+  }
+
+  const appPath = args[0];
+  const appId = args[1];
+  const maestroFlow = args[2];
+  const jsengine = args[3];
+  const isDebug = args[4] === 'Debug';
+  const workingDirectory = args[5];
+
   console.info('\n==============================');
   console.info('Running tests for iOS with the following parameters:');
-  console.info(`APP_PATH: ${APP_PATH}`);
-  console.info(`APP_ID: ${APP_ID}`);
-  console.info(`MAESTRO_FLOW: ${MAESTRO_FLOW}`);
-  console.info(`JS_ENGINE: ${JS_ENGINE}`);
-  console.info(`IS_DEBUG: ${IS_DEBUG}`);
-  console.info(`WORKING_DIRECTORY: ${WORKING_DIRECTORY}`);
+  console.info(`APP_PATH: ${appPath}`);
+  console.info(`APP_ID: ${appId}`);
+  console.info(`MAESTRO_FLOW: ${maestroFlow}`);
+  console.info(`JS_ENGINE: ${jsengine}`);
+  console.info(`IS_DEBUG: ${isDebug}`);
+  console.info(`WORKING_DIRECTORY: ${workingDirectory}`);
   console.info('==============================\n');
 
-  const simulatorName = 'iPhone 16 Pro';
-  launchSimulator(simulatorName);
-  installAppOnSimulator(APP_PATH);
-  const udid = extractSimulatorUDID();
+  const simulator = findAvailableSimulator();
+  launchSimulator(simulator);
+  installAppOnSimulator(appPath);
   bringSimulatorInForeground();
-  await launchAppOnSimulator(APP_ID, udid, IS_DEBUG);
-  executeTestsWithRetries(APP_ID, udid, MAESTRO_FLOW, JS_ENGINE, 1);
+  await launchAppOnSimulator(appId, simulator.udid, isDebug);
+  executeTestsWithRetries(appId, simulator.udid, maestroFlow, jsengine, 1);
   console.log('Test finished');
   process.exit(0);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  findAvailableSimulator,
+};

--- a/.github/workflows/e2e-ios-rntester.yml
+++ b/.github/workflows/e2e-ios-rntester.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15-large
+    runs-on: macos-26-large
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:
@@ -35,8 +35,6 @@ jobs:
           path: /tmp/RNTesterBuild/RNTester.app
       - name: Check downloaded folder content
         run: ls -lR /tmp/RNTesterBuild
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
       - name: Run E2E Tests
         id: run-tests
         continue-on-error: true

--- a/.github/workflows/e2e-ios-templateapp.yml
+++ b/.github/workflows/e2e-ios-templateapp.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15-large
+    runs-on: macos-26-large
     outputs:
       status: ${{ steps.report-status.outputs.status }}
     strategy:
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Setup xcode
-        uses: ./.github/actions/setup-xcode
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn


### PR DESCRIPTION
Summary:
Backports #57993 to `0.86-stable`.

Moves the RNTester and template app iOS E2E jobs from `macos-15-large` to `macos-26-large`, which provides the Xcode 26 environment now required by `idb-companion`. The workflows use the image default Xcode so the hosted simulator platform is available.

The Maestro runner now discovers an available iPhone Pro simulator from the newest installed runtime and boots it by UDID instead of depending on the `iPhone 16 Pro` device name. Since this stable branch predates the Maestro flow-runner refactor from `main`, the conflict was resolved by preserving its existing retry behavior and adding a focused simulator-selection test.

## Changelog:

[INTERNAL] [FIXED] - Run iOS E2E tests on macOS 26 runners with Xcode 26.

Test Plan:
- `git diff --check origin/0.86-stable...HEAD`
- `node --check .github/workflow-scripts/maestro-ios.js`
- Prettier check for the four changed files
- Ruby YAML parse for both changed workflows
- `yarn jest .github/workflow-scripts/__tests__/maestro-ios-test.js --runInBand --config '{"testEnvironment":"node","transform":{}}'`
