### PR TITLE
[iOS][swiftpm] Drop the unused publicHeadersPath from spm.modules

### DIFF
--- a/packages/react-native/scripts/spm/__docs__/spm-scripts.md
+++ b/packages/react-native/scripts/spm/__docs__/spm-scripts.md
@@ -342,7 +342,6 @@ module.exports = {
         name: 'MyNativeModule',
         path: 'ios/MyNativeModule', // relative to app root
         exclude: ['*.podspec'], // optional
-        publicHeadersPath: '.', // optional
       },
     ],
   },

--- a/packages/react-native/scripts/spm/generate-spm-autolinking.js
+++ b/packages/react-native/scripts/spm/generate-spm-autolinking.js
@@ -232,7 +232,6 @@ function readAutolinkingJson(
  *         name: "MyNativeModule",
  *         path: "ios/MyNativeModule",            // relative to appRoot
  *         exclude: ["*.js", "*.podspec"],        // optional
- *         publicHeadersPath: ".",                // optional
  *       }
  *     ]
  *   }
@@ -1334,7 +1333,9 @@ function main(argv /*:: ?: Array<string> */) /*: void */ {
         name: mod.name,
         path: relPath,
         exclude: mod.exclude ?? [],
-        publicHeadersPath: mod.publicHeadersPath ?? null,
+        // The synth wrapper owns the module's public interface: it declares
+        // publicHeadersPath: "include", a symlink to the module's header tree.
+        publicHeadersPath: null,
         sources: userSources,
       },
       origin: 'spmModule',

--- a/packages/react-native/scripts/spm/spm-types.js
+++ b/packages/react-native/scripts/spm/spm-types.js
@@ -168,7 +168,6 @@ export type SpmModuleConfig = {
   name: string,
   path: string,
   exclude?: Array<string>,
-  publicHeadersPath?: ?string,
   // Optional CocoaPods-style glob allowlist (analog of s.source_files).
   // When set, replaces auto source discovery for the module — only files
   // matching one of these patterns are passed to SPM via `sources:`.

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -36,7 +36,6 @@ module.exports = {
       {
         name: 'ReactCommonSamples',
         path: '../react-native/ReactCommon/react/nativemodule/samples/platform/ios',
-        publicHeadersPath: '.',
       },
       {
         name: 'ReactRCTPushNotification',


### PR DESCRIPTION
## Summary:

When using `react-native.config.js` to declare app-side modules using the `spm.modules` field, there is a field for providing the public header files for a module which is not used by the code. This field does not have any meaning either, a local app-side module is registered through module discovery anyway.

This PR removes this field from the SPM config.

## Changelog:

[IOS] [FIXED] - Removed unused field spm.modules.publicHeaderFiles from react-native.config.js's spm section

## Test Plan:

✅ Unit tests/CI