### PR TITLE
Animate filter without forcing a Fabric commit every frame

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
@@ -48,6 +48,7 @@ inline const std::unordered_set<std::string> &getDirectManipulationAllowlist()
       "borderStartStartRadius",
       "elevation",
       "opacity",
+      "filter",
       "transform",
       "zIndex",
       /* ios styles */

--- a/packages/react-native/ReactCommon/react/renderer/animated/tests/AnimatedNodeTests.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/tests/AnimatedNodeTests.cpp
@@ -7,6 +7,7 @@
 
 #include "AnimationTestsBase.h"
 
+#include <react/renderer/animated/internal/NativeAnimatedAllowlist.h>
 #include <react/renderer/animated/nodes/ColorAnimatedNode.h>
 #include <react/renderer/animated/nodes/ObjectAnimatedNode.h>
 #include <react/renderer/core/ReactRootViewTagGenerator.h>
@@ -330,6 +331,63 @@ TEST_F(AnimatedNodeTests, ObjectAnimatedNode) {
   EXPECT_EQ(collectedProps["test"][1]["rotate3d"]["y"], 0);
   EXPECT_EQ(collectedProps["test"][1]["rotate3d"]["angle"], "180deg");
   EXPECT_EQ(collectedProps["test"][2]["scale3d"], 4);
+}
+
+// Styles that Animated supports and that do not participate in layout must be
+// direct-manipulation eligible; anything absent from this set is treated as a
+// layout update by StyleAnimatedNode and forced through a Fabric commit.
+// Keep in sync with SUPPORTED_STYLES in
+// packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js.
+TEST_F(AnimatedNodeTests, directManipulationAllowlistCoversNonLayoutStyles) {
+  const auto& allowlist = getDirectManipulationAllowlist();
+
+  for (const auto& style :
+       {"backgroundColor",
+        "borderBottomColor",
+        "borderColor",
+        "borderEndColor",
+        "borderLeftColor",
+        "borderRightColor",
+        "borderStartColor",
+        "borderTopColor",
+        "color",
+        "tintColor",
+        "borderBottomEndRadius",
+        "borderBottomLeftRadius",
+        "borderBottomRightRadius",
+        "borderBottomStartRadius",
+        "borderEndEndRadius",
+        "borderEndStartRadius",
+        "borderRadius",
+        "borderTopEndRadius",
+        "borderTopLeftRadius",
+        "borderTopRightRadius",
+        "borderTopStartRadius",
+        "borderStartEndRadius",
+        "borderStartStartRadius",
+        "elevation",
+        "opacity",
+        "filter",
+        "transform",
+        "zIndex",
+        "shadowOpacity",
+        "shadowRadius",
+        "scaleX",
+        "scaleY",
+        "translateX",
+        "translateY"}) {
+    EXPECT_EQ(allowlist.count(style), 1u)
+        << style
+        << " is animatable and does not affect layout, so it must be "
+           "direct-manipulation eligible";
+  }
+
+  // Layout styles must stay out, so they keep going through Fabric.
+  for (const auto& style :
+       {"width", "height", "margin", "padding", "flex", "top", "gap"}) {
+    EXPECT_EQ(allowlist.count(style), 0u)
+        << style << " affects layout and must not be direct-manipulated";
+  }
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

`NativeAnimatedAllowlist.h` carries this instruction:

```c++
/**
 * Direct manipulation eligible styles allowed by the NativeAnimated JS
 * implementation. Keep in sync with
 * packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
 */
```

It has drifted by one entry. `SUPPORTED_STYLES` in the JS file lists `filter` between `opacity` and `transform`; the C++ set goes straight from `"opacity"` to `"transform"`. Every other member of the JS list's non-layout half is present, so this is a missed sync rather than a deliberate exclusion.

The set is not advisory — it is what separates layout props from paint props:

```c++
// StyleAnimatedNode.cpp
bool isLayoutPropsUpdated(const folly::dynamic& props) {
  for (const auto& styleNodeProp : props.items()) {
    if (getDirectManipulationAllowlist().count(styleNodeProp.first.asString()) == 0u) {
      return true;   // absent => treated as a layout prop
    }
  }
  return false;
}
```

and that verdict picks the transport:

```c++
// NativeAnimatedNodesManager.cpp
auto& current = layoutStyleUpdated
    ? updateViewPropsForBackend_[viewTag]        // Fabric commit
    : updateViewPropsDirectForBackend_[viewTag]; // direct manipulation
```

So animating `filter` runs a shadow-tree commit on every frame instead of taking the direct-manipulation path, for a property that cannot affect layout — `filter` lives in `BaseViewProps` (`std::vector<FilterFunction> filter{}`), not in `YogaStylableProps`, and nothing in `react/renderer/animated/` treats it specially.

Note the C++ set is deliberately *not* a mirror of the whole JS `SUPPORTED_STYLES`: the entries the JS file adds under `useSharedAnimatedBackend()` (`width`, `height`, `margin`, `padding`, `flex`, `gap`, …) are genuine layout props and must stay out so they keep going through Fabric. Only the non-layout half has to match, and `filter` belongs to it.

## Changelog:

[GENERAL] [FIXED] - Animating `filter` no longer forces a Fabric commit on every frame

## Test Plan:

Added `directManipulationAllowlistCoversNonLayoutStyles` to `AnimatedNodeTests`. It asserts the allowlist contains every non-layout style the JS file supports, and — so the test cannot be satisfied by simply widening the set — that the layout styles are still absent.

The allowlist header is dependency-free, so the invariant can also be checked directly:

```
$ c++ -std=c++20 -Wall -Wextra -I packages/react-native/ReactCommon allowcheck.cpp -o allowcheck

# before
MISSING from C++ allowlist: filter
checked 34 JS non-layout styles, missing=1     (exit 1)

# after
checked 34 JS non-layout styles, missing=0     (exit 0)
```

```
$ yarn jest packages/react-native/Libraries/Animated
Test Suites: 3 passed, 3 total
Tests:       66 passed, 66 total

$ node ./scripts/clang-format.js <both changed files>
(no changes)
```

`getDirectManipulationAllowlist` appears in the C++ API snapshots, but only by signature — this changes the contents of the static set, not the declaration, so `scripts/cxx-api` is unaffected.

### Running the new gtest

`react/renderer/animated/tests` is built by neither public CI lane: it is excluded from the iOS build
(`React-Fabric.podspec`: `ss.exclude_files = "react/renderer/animated/tests"`) and is not in the Android CMake glob
(`react/renderer/animated/CMakeLists.txt` globs `*.cpp drivers/*.cpp event_drivers/*.cpp internal/*.cpp nodes/*.cpp`),
so it compiles only in the internal build reached at import time.

To avoid landing an unexercised test, I ran it locally against googletest 1.18.0. The `TEST_F` body was taken verbatim
from `AnimatedNodeTests.cpp` into a standalone translation unit, with the fixture base swapped from `AnimationTestsBase`
to `testing::Test`. That substitution is faithful for this test: `AnimationTestsBase` declares no `SetUp()`
(`initNodesManager()` is called explicitly by the tests that need it) and this test touches none of its members.
`NativeAnimatedAllowlist.h` is header-only and pulls in just `<string>` and `<unordered_set>`, so the real header is
used as-is.

```
$ clang++ -std=c++20 -Wall -Wextra -I packages/react-native/ReactCommon \
    probe.cpp -lgtest -lgtest_main -o probe     # 0 errors, 0 warnings

# against this branch's header
[  PASSED  ] 1 test.

# against the same test compiled with main's NativeAnimatedAllowlist.h
[  FAILED  ] AnimatedNodeTests.directManipulationAllowlistCoversNonLayoutStyles
  Expected equality of these values:
    allowlist.count(style)  Which is: 0
    1u                      Which is: 1
  filter is animatable and does not affect layout, so it must be direct-manipulation eligible
```

So the test compiles warning-free, passes with the fix, and fails without it with the intended diagnostic.


