### PR TITLE
Support 'react-native/react-private-interface' in build-types

### DIFF
--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -26,9 +26,10 @@ export type Getter<T> = () => T;
 
 // This defines the types for the overrides object, whose methods can return
 // null or undefined to fallback to the default value.
-export type OverridesFor<T> = Partial<{
-  [key in keyof T]: Getter<?ReturnType<T[key]>>,
-}>;
+export type OverridesFor<T extends {readonly [string]: () => unknown}> =
+  Partial<{
+    [key in keyof T]: Getter<?ReturnType<T[key]>>,
+  }>;
 
 function createGetter<T extends boolean | number | string>(
   configName: string,

--- a/scripts/js-api/build-types/resolution/simpleResolve.js
+++ b/scripts/js-api/build-types/resolution/simpleResolve.js
@@ -8,7 +8,10 @@
  * @format
  */
 
-const {PACKAGES_DIR} = require('../../../shared/consts');
+const {
+  PACKAGES_DIR,
+  REACT_NATIVE_PACKAGE_DIR,
+} = require('../../../shared/consts');
 const {getPackages} = require('../../../shared/monorepoUtils');
 const {existsSync} = require('node:fs');
 const path = require('node:path');
@@ -36,6 +39,14 @@ async function simpleResolve(
       includeReactNative: true,
       includePrivate: false,
     });
+  }
+
+  // Resolve the 'react-native/react-private-interface' subpath export
+  if (importPath === 'react-native/react-private-interface') {
+    return path.join(
+      REACT_NATIVE_PACKAGE_DIR,
+      'src/react-private-interface.js',
+    );
   }
 
   // Resolve exact '@react-native/<package>' import


### PR DESCRIPTION
## Summary

**Motivation**

Minimum infra fix to enable subsequently landing https://github.com/react/react-native/pull/57940.

Referencing `ReactNativeFeatureFlags` on the existing `react-native/react-private-interface` boundary is blocked by a gap in the `build-types` pipeline and a type translation error, addressed here.

**Changes**

- `simpleResolve.js`: Explicitly support `react-native/react-private-interface` as a special case, fixing resolution.
- `ReactNativeFeatureFlagsBase.js`: Tweak the `OverridesFor` type here to fix TypeScript translation compatibility, where the unconstrained `T` type param is now narrowed.

**Impact**

No change to the API snapshot (the `ReactNativeFeatureFlags` import is ultimately tree-shaken!), and no effect on generated types until #57940 lands.

Changelog: [Internal]

## Test Plan

- `yarn build-types`
- Applied #57940 patch on top; both stayed green, no `types_generated/**/featureflags/**`