### PR TITLE
Prevent DeviceInfo crash when WindowMetrics API is missing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -43,7 +43,19 @@ internal class DeviceInfoModule(reactContext: ReactApplicationContext) :
     windowDisplayMetrics.setTo(reactApplicationContext.resources.displayMetrics)
 
     val activity = reactApplicationContext.currentActivity ?: return windowDisplayMetrics
-    val bounds = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity).bounds
+    val bounds =
+        try {
+          WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(activity).bounds
+        } catch (error: NoSuchMethodError) {
+          ReactSoftExceptionLogger.logSoftException(
+              NAME,
+              ReactNoCrashSoftException(
+                  "WindowMetrics API is unavailable; falling back to resource display metrics.",
+                  error,
+              ),
+          )
+          return windowDisplayMetrics
+        }
 
     if (isEdgeToEdgeFeatureFlagOn) {
       windowDisplayMetrics.widthPixels = bounds.width()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/deviceinfo/DeviceInfoModuleTest.kt
@@ -208,6 +208,26 @@ class DeviceInfoModuleTest : TestCase() {
     }
   }
 
+  @Test
+  fun getWindowDisplayMetrics_fallsBackWhenWindowMetricsApiIsMissing() {
+    val activity = mock<Activity>()
+    doReturn(activity).whenever(reactContext).currentActivity
+
+    val calculator = mock<WindowMetricsCalculator>()
+    whenever(calculator.computeCurrentWindowMetrics(activity))
+        .thenThrow(NoSuchMethodError("WindowMetrics.getDensity()"))
+
+    withWindowMetricsCalculator(calculator) {
+      val resourceMetrics = reactContext.resources.displayMetrics
+      val metrics = deviceInfoModule.getWindowDisplayMetrics()
+
+      assertThat(metrics.widthPixels).isEqualTo(resourceMetrics.widthPixels)
+      assertThat(metrics.heightPixels).isEqualTo(resourceMetrics.heightPixels)
+      assertThat(metrics.density).isEqualTo(resourceMetrics.density)
+      assertThat(metrics.densityDpi).isEqualTo(resourceMetrics.densityDpi)
+    }
+  }
+
   private fun givenDisplayMetricsHolderContains(fakeDisplayMetrics: WritableMap?) {
     doReturn(fakeDisplayMetrics).whenever(deviceInfoModule).getDisplayMetricsWritableMap()
   }


### PR DESCRIPTION
## Summary:

Fixes #57785.

Some modified Android runtimes report API 34 or later while shipping a `WindowMetrics` implementation without `getDensity()`. `WindowMetricsCalculator` then throws `NoSuchMethodError` while `NativeDeviceInfo` exports its constants, crashing the app before the JavaScript runtime is ready.

This change catches only that missing-method failure around the window metrics lookup, reports it as a soft exception, and returns the resource display metrics that were already copied as the fallback. Normal Android runtimes continue to use the current window bounds path unchanged.

The regression test injects a `WindowMetricsCalculator` that throws the same `NoSuchMethodError` and verifies that resource width, height, density, and density DPI are returned. Before the production change, this test failed at `DeviceInfoModule.kt:46` with the uncaught error.

## Changelog:

[ANDROID] [FIXED] - Prevent a startup crash when the WindowMetrics API is missing on an inconsistent Android runtime

## Test Plan:

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.modules.deviceinfo.DeviceInfoModuleTest -Preact.internal.useHermesStable=true --no-daemon` — BUILD SUCCESSFUL (8 tests)
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :packages:react-native:ReactAndroid:ktfmtCheck -Preact.internal.useHermesStable=true --no-daemon --rerun-tasks` — BUILD SUCCESSFUL
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :packages:react-native:ReactAndroid:lintDebug -Preact.internal.useHermesStable=true --no-daemon` — BUILD SUCCESSFUL
