### PR TITLE
Cover `react/featureflags` with Stable API guards (#58083)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -115,6 +115,7 @@ val preparePrefab by
                       Pair("../ReactCommon/cxxreact/", "cxxreact/"),
                       // react_featureflags
                       Pair("../ReactCommon/react/featureflags/", "react/featureflags/"),
+                      Pair("../ReactCommon/react/featureflags/React/", "React/"),
                       // react_devtoolsruntimesettings
                       Pair(
                           "../ReactCommon/react/devtoolsruntimesettings/",

--- a/packages/react-native/ReactCommon/react/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/featureflags/CMakeLists.txt
@@ -12,7 +12,8 @@ file(GLOB react_featureflags_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_featureflags OBJECT ${react_featureflags_SRC})
 
 target_include_directories(react_featureflags PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_featureflags INTERFACE ${REACT_COMMON_DIR}/react/featureflags)
 
-target_link_libraries(react_featureflags folly_runtime)
+target_link_libraries(react_featureflags folly_runtime react_cxxstableapi)
 target_compile_reactnative_options(react_featureflags PRIVATE)
 target_compile_options(react_featureflags PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -39,8 +39,15 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_featureflags")
 
+  s.dependency "React-cxxstableapi"
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+
+  s.subspec "featureflagsUmbrella" do |ss|
+    ss.source_files        = "React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "."
+  end
 
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/react/featureflags/React/FeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/React/FeatureFlags.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/featureflags` module - public entry point.
+//
+//   #include <React/FeatureFlags.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/featureflags/...>` includes; only
+// outside consumers use this umbrella.
+//
+// The headers below are generated from
+// `scripts/featureflags/ReactNativeFeatureFlags.config.js`, but this file is
+// not - keep it in sync by hand when the set of generated headers in
+// `scripts/featureflags/generateCommonCxxModules.js` changes.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/featureflags/ReactNativeFeatureFlagsAccessor.h>
+#include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
+#include <react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h>
+#include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h>
+#include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h>
+#include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>
+#include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2d59cf5ea42847d6174fc433ba5a6fe4>>
+ * @generated SignedSource<<414b7a90eeecd2abe9849955131fb122>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlagsAccessor.h>
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<55f19e7a0d7fbbda3aa131a74909ec07>>
+ * @generated SignedSource<<c1b8add7c4f70f65e71ff2742a7f5427>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
 #include <array>

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8e00ed57e2faa8e13ae2eb58afd64962>>
+ * @generated SignedSource<<9e798b7ae2a2f26097359ca37fa99d04>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9c0b6df9433a5696f5eacf47713b9040>>
+ * @generated SignedSource<<3429660cde44d793af0e86ff425b1094>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <folly/dynamic.h>
 #include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<70297dc6230d386e556c82860cbf9985>>
+ * @generated SignedSource<<650cb266846c66577dde6d7c7a703af1>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h>
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dc6298e569276bf047951a8e4105aa96>>
+ * @generated SignedSource<<5c7271fe5fcdd90f61a5a07772b820e5>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h>
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<51d2bd8d3e88e7848039f845c1709a39>>
+ * @generated SignedSource<<281f4bad9056734eec71185a3fdd6483>>
  */
 
 /**
@@ -18,6 +18,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlags.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlags.h-template.js
@@ -27,6 +27,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlagsAccessor.h>
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
 #include <memory>

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsAccessor.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsAccessor.h-template.js
@@ -27,6 +27,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
 #include <array>
 #include <atomic>

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
@@ -31,6 +31,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlagsProvider.h>
 
 namespace facebook::react {

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -31,6 +31,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/featureflags/ReactNativeFeatureFlagsDefaults.h>
 

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
@@ -54,6 +54,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/featureflags/${getParentClassName(ossReleaseStage)}.h>
 
 namespace facebook::react {

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsProvider.h-template.js
@@ -27,6 +27,8 @@ ${DO_NOT_MODIFY_COMMENT}
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 class ReactNativeFeatureFlagsProvider {

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -312,6 +312,23 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
     headerPatterns: ['*.h'],
     headerDir: 'jsinspector-modern/tracing',
   },
+  'ReactCommon/react/featureflags/React-featureflags.podspec': {
+    name: 'React-featureflags',
+    headerPatterns: [],
+    headerDir: '',
+    subSpecs: [
+      {
+        name: 'featureflags',
+        headerPatterns: ['*.h'],
+        headerDir: 'react/featureflags',
+      },
+      {
+        name: 'featureflagsUmbrella',
+        headerPatterns: ['React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'React/React-RCTFabric.podspec': {
     name: 'React-RCTFabric',
     headerPatterns: ['Fabric/**/*.h'],


### PR DESCRIPTION
Summary:

Classifies `react/featureflags:featureflags` as a public target under the C++ stable API three-tier visibility model and introduces the module umbrella `React/FeatureFlags.h` as its public entry point.

This module's headers are generated, so the `UmbrellaGuard.h` include is added to the templates in `scripts/featureflags/templates/common-cxx/` rather than to the headers themselves. `ReactNativeFeatureFlagsOverridesOSSStable.h` is the module's one hand-written header and is edited directly. The umbrella is not generated, and re-exports all eight of the module's headers.

The sibling `react/nativemodule/featureflags:featureflags` target is private under the same model.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog:
[General][Added] - Add `<React/FeatureFlags.h>` umbrella header as the public entry point for `react/featureflags`

Reviewed By: cortinico

Differential Revision: D117172757


