### PR TITLE
Cover `react/renderer/bridging` with Stable API guards

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -127,6 +127,7 @@ val preparePrefab by
                       ),
                       // react_renderer_bridging
                       Pair("../ReactCommon/react/renderer/bridging/", "react/renderer/bridging/"),
+                      Pair("../ReactCommon/react/renderer/bridging/React/", "React/"),
                       // react_renderer_componentregistry
                       Pair(
                           "../ReactCommon/react/renderer/componentregistry/",

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -84,8 +84,14 @@ Pod::Spec.new do |s|
 
   s.subspec "bridging" do |ss|
     ss.source_files         = podspec_sources("react/renderer/bridging/**/*.{m,mm,cpp,h}", "react/renderer/bridging/**/*.{h}")
-    ss.exclude_files        = "react/renderer/bridging/tests"
+    ss.exclude_files        = ["react/renderer/bridging/tests", "react/renderer/bridging/React"]
     ss.header_dir           = "react/renderer/bridging"
+  end
+
+  s.subspec "bridgingUmbrella" do |ss|
+    ss.source_files         = "react/renderer/bridging/React/*.h"
+    ss.header_dir           = "React"
+    ss.header_mappings_dir  = "react/renderer/bridging/React"
   end
 
   s.subspec "core" do |ss|

--- a/packages/react-native/ReactCommon/react/renderer/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/bridging/CMakeLists.txt
@@ -11,5 +11,7 @@ include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 add_library(react_renderer_bridging INTERFACE)
 
 target_include_directories(react_renderer_bridging INTERFACE ${REACT_COMMON_DIR})
+
+target_link_libraries(react_renderer_bridging INTERFACE react_cxxstableapi)
 target_compile_reactnative_options(react_renderer_bridging INTERFACE)
 target_compile_options(react_renderer_bridging INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/bridging/React/RendererBridging.h
+++ b/packages/react-native/ReactCommon/react/renderer/bridging/React/RendererBridging.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/bridging` module - public entry
+// point.
+//
+//   #include <React/RendererBridging.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/bridging/...>` includes;
+// only outside consumers use this umbrella.
+//
+// Named `RendererBridging` rather than `Bridging` because all umbrellas share a
+// single `React/` include namespace, and `React/Bridging.h` belongs to the
+// separate `react/bridging` module.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
+// this block so later *direct* includes in the same translation unit are still
+// caught.
+#define RN_UMBRELLA_CONTEXT
+
+#include <react/renderer/bridging/bridging.h>
+
+#undef RN_UMBRELLA_CONTEXT

--- a/packages/react-native/ReactCommon/react/renderer/bridging/bridging.h
+++ b/packages/react-native/ReactCommon/react/renderer/bridging/bridging.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/bridging/Base.h>
 #include <react/renderer/core/ShadowNode.h>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -70,8 +70,17 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       {
         name: 'bridging',
         headerPatterns: ['react/renderer/bridging/**/*.h'],
-        excludePatterns: ['react/renderer/bridging/tests'],
+        excludePatterns: [
+          'react/renderer/bridging/tests',
+          'react/renderer/bridging/React',
+        ],
         headerDir: 'react/renderer/bridging',
+      },
+
+      {
+        name: 'bridgingUmbrella',
+        headerPatterns: ['react/renderer/bridging/React/*.h'],
+        headerDir: 'React',
       },
 
       {


### PR DESCRIPTION
Summary:
Classifies `react/renderer/bridging:bridging` as a public target under the C++ stable API three-tier visibility model and introduces the module umbrella `React/RendererBridging.h` as its public entry point.

The umbrella is named `RendererBridging` rather than `Bridging` because all umbrellas share a single `React/` include namespace, and `React/Bridging.h` belongs to the separate `react/bridging` module.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog:
[General][Added] - Add `<React/RendererBridging.h>` umbrella header as the public entry point for `react/renderer/bridging`

Differential Revision: D117179017


