### PR TITLE
Cover `react/renderer/leakchecker` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(react_renderer_leakchecker STATIC ${react_renderer_leakchecker_SRC})
 target_include_directories(react_renderer_leakchecker PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_leakchecker
         glog
+        react_cxxstableapi
         react_renderer_core
         runtimeexecutor)
 target_compile_reactnative_options(react_renderer_leakchecker PRIVATE)

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/LeakChecker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNodeFamily.h>

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/WeakFamilyRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNodeFamily.h>
 #include <unordered_map>


### PR DESCRIPTION
Summary:
Classifies `react/renderer/leakchecker:leakchecker` as a private target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its headers; without that flag the guards are inert, so no existing build changes behaviour. The pod that ships the module, `React-Fabric`, already depends on `React-cxxstableapi` and is already marked as a React Native build, so no podspec change is needed.

Changelog: [Internal]

Differential Revision: D117188751


