### PR TITLE
Forward declare LeakChecker in UIManager.h (#58091)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -14,6 +14,7 @@
 #include <react/renderer/core/DynamicPropsUtilities.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
+#include <react/renderer/leakchecker/LeakChecker.h>
 #include <react/renderer/uimanager/AppRegistryBinding.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -21,7 +21,6 @@
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/StateData.h>
-#include <react/renderer/leakchecker/LeakChecker.h>
 #include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/mounting/ShadowTreeDelegate.h>
 #include <react/renderer/mounting/ShadowTreeRegistry.h>
@@ -37,6 +36,7 @@
 
 namespace facebook::react {
 
+class LeakChecker;
 class UIManagerBinding;
 class UIManagerCommitHook;
 class UIManagerMountHook;


### PR DESCRIPTION
Summary:

Under the C++ Stable API RFC, `react/renderer/uimanager:uimanager` is a public target while `react/renderer/leakchecker:leakchecker` is private. `UIManager.h` is an exported header of the uimanager target and is re-exported from the module umbrella `React/UIManager.h`, so it transitively exposed the private module through the blessed public entry point. The private guard is suppressed only by `RN_BUILDING`, not by `RN_UMBRELLA_CONTEXT`, so a consumer including `<React/UIManager.h>` under `RN_STRICT_API` would get a hard error from a header they never named and cannot acknowledge.

`UIManager.h` only needs the type for the `std::unique_ptr<LeakChecker> leakChecker_` data member. `~UIManager()` is already out of line, so a forward declaration is sufficient and the include moves to `UIManager.cpp`, which already constructs the object. No build config change is needed: `leakchecker` is already a non-exported dep of the uimanager target in both BUCK and CMake.

`UIManager.h` is the only public or for-frameworks header in ReactCommon that still reached `leakchecker`, so the module is now cleanly private.

Changelog: [Internal]

Differential Revision: D117188750


