### PR TITLE
Distinguish transparent colors from undefined props

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -165,7 +165,7 @@ function generatePropsDiffString(
                 return `
   if (${prop.name} != oldProps->${prop.name}) {
     if (${prop.name}.has_value()) {
-      result["${prop.name}"] = *${prop.name}.value();
+      result["${prop.name}"] = static_cast<int32_t>(*${prop.name}.value());
     } else {
       result["${prop.name}"] = folly::dynamic(nullptr);
     }
@@ -173,7 +173,7 @@ function generatePropsDiffString(
               } else {
                 return `
   if (${prop.name} != oldProps->${prop.name}) {
-    result["${prop.name}"] = *${prop.name};
+    result["${prop.name}"] = static_cast<int32_t>(*${prop.name});
   }`;
               }
             case 'ImageSourcePrimitive':

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -1141,7 +1141,7 @@ folly::dynamic ColorPropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (tintColor != oldProps->tintColor) {
-    result[\\"tintColor\\"] = *tintColor;
+    result[\\"tintColor\\"] = static_cast<int32_t>(*tintColor);
   }
   return result;
 }
@@ -2180,11 +2180,11 @@ folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
   }
     
   if (color != oldProps->color) {
-    result[\\"color\\"] = *color;
+    result[\\"color\\"] = static_cast<int32_t>(*color);
   }
     
   if (thumbTintColor != oldProps->thumbTintColor) {
-    result[\\"thumbTintColor\\"] = *thumbTintColor;
+    result[\\"thumbTintColor\\"] = static_cast<int32_t>(*thumbTintColor);
   }
     
   if (point != oldProps->point) {

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -210,7 +210,7 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
     // unset.
     if (tintColor != oldProps->tintColor) {
       if (tintColor.has_value()) {
-        result["tintColor"] = *tintColor.value();
+        result["tintColor"] = static_cast<int32_t>(*tintColor.value());
       } else {
         result["tintColor"] = folly::dynamic(nullptr);
       }
@@ -221,7 +221,7 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
     SharedColor prevTintColorValue =
         oldProps->tintColor.value_or(SharedColor{});
     if (tintColorValue != prevTintColorValue) {
-      result["tintColor"] = *tintColorValue;
+      result["tintColor"] = static_cast<int32_t>(*tintColorValue);
     }
   }
 
@@ -242,7 +242,7 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
   }
 
   if (overlayColor != oldProps->overlayColor) {
-    result["overlayColor"] = *overlayColor;
+    result["overlayColor"] = static_cast<int32_t>(*overlayColor);
   }
 
   if (fadeDuration != oldProps->fadeDuration) {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -377,7 +377,7 @@ folly::dynamic HostPlatformScrollViewProps::getDiffProps(
   }
 
   if (endFillColor != oldProps->endFillColor) {
-    result["endFillColor"] = *endFillColor;
+    result["endFillColor"] = static_cast<int32_t>(*endFillColor);
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -369,7 +369,7 @@ void BaseTextProps::appendTextAttributesProps(
     const BaseTextProps* oldProps) const {
   if (textAttributes.foregroundColor !=
       oldProps->textAttributes.foregroundColor) {
-    result["color"] = *textAttributes.foregroundColor;
+    result["color"] = static_cast<int32_t>(*textAttributes.foregroundColor);
   }
 
   if (textAttributes.fontFamily != oldProps->textAttributes.fontFamily) {
@@ -480,7 +480,8 @@ void BaseTextProps::appendTextAttributesProps(
 
   if (textAttributes.textDecorationColor !=
       oldProps->textAttributes.textDecorationColor) {
-    result["textDecorationColor"] = *textAttributes.textDecorationColor;
+    result["textDecorationColor"] =
+        static_cast<int32_t>(*textAttributes.textDecorationColor);
   }
 
   if (textAttributes.textDecorationLineType !=
@@ -514,7 +515,8 @@ void BaseTextProps::appendTextAttributesProps(
 
   if (textAttributes.textShadowColor !=
       oldProps->textAttributes.textShadowColor) {
-    result["textShadowColor"] = *textAttributes.textShadowColor;
+    result["textShadowColor"] =
+        static_cast<int32_t>(*textAttributes.textShadowColor);
   }
 
   if (textAttributes.isHighlighted != oldProps->textAttributes.isHighlighted) {
@@ -549,7 +551,8 @@ void BaseTextProps::appendTextAttributesProps(
 
   if (textAttributes.backgroundColor !=
       oldProps->textAttributes.backgroundColor) {
-    result["backgroundColor"] = *textAttributes.backgroundColor;
+    result["backgroundColor"] =
+        static_cast<int32_t>(*textAttributes.backgroundColor);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
@@ -167,7 +167,7 @@ folly::dynamic HostPlatformParagraphProps::getDiffProps(
 
   if (selectionColor != oldProps->selectionColor) {
     if (selectionColor.has_value()) {
-      result["selectionColor"] = *selectionColor.value();
+      result["selectionColor"] = static_cast<int32_t>(*selectionColor.value());
     } else {
       result["selectionColor"] = folly::dynamic(nullptr);
     }

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -432,23 +432,26 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (placeholderTextColor != oldProps->placeholderTextColor) {
-    result["placeholderTextColor"] = *placeholderTextColor;
+    result["placeholderTextColor"] =
+        static_cast<int32_t>(*placeholderTextColor);
   }
 
   if (cursorColor != oldProps->cursorColor) {
-    result["cursorColor"] = *cursorColor;
+    result["cursorColor"] = static_cast<int32_t>(*cursorColor);
   }
 
   if (selectionColor != oldProps->selectionColor) {
-    result["selectionColor"] = *selectionColor;
+    result["selectionColor"] = static_cast<int32_t>(*selectionColor);
   }
 
   if (selectionHandleColor != oldProps->selectionHandleColor) {
-    result["selectionHandleColor"] = *selectionHandleColor;
+    result["selectionHandleColor"] =
+        static_cast<int32_t>(*selectionHandleColor);
   }
 
   if (underlineColorAndroid != oldProps->underlineColorAndroid) {
-    result["underlineColorAndroid"] = *underlineColorAndroid;
+    result["underlineColorAndroid"] =
+        static_cast<int32_t>(*underlineColorAndroid);
   }
 
   if (maxLength != oldProps->maxLength) {
@@ -575,7 +578,7 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (textShadowColor != oldProps->textShadowColor) {
-    result["textShadowColor"] = *textShadowColor;
+    result["textShadowColor"] = static_cast<int32_t>(*textShadowColor);
   }
 
   if (textShadowRadius != oldProps->textShadowRadius) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -138,7 +138,7 @@ AndroidTextInputProps::AndroidTextInputProps(
           "textTransform",
           sourceProps.textTransform,
           {})),
-      color(0 /*convertRawProp(context, rawProps, "color", sourceProps.color, {0})*/),
+      color(/*convertRawProp(context, rawProps, "color", sourceProps.color, {})*/),
       letterSpacing(convertRawProp(context, rawProps,
           "letterSpacing",
           sourceProps.letterSpacing,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -105,7 +105,7 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   AndroidTextInputTextShadowOffsetStruct textShadowOffset{};
   Float lineHeight{0.0};
   std::string textTransform{};
-  SharedColor color{0};
+  SharedColor color{};
   Float letterSpacing{0.0};
   Float fontSize{0.0};
   std::string textAlign{};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -168,7 +168,7 @@ AttributedString AndroidTextInputShadowNode::getAttributedString(
   // Don't propagate the background color of the TextInput onto the attributed
   // string. Android tries to render shadow of the background alongside the
   // shadow of the text which results in weird artifacts.
-  childTextAttributes.backgroundColor = HostPlatformColor::UndefinedColor;
+  childTextAttributes.backgroundColor = SharedColor{};
 
   auto attributedString = AttributedString{};
   auto attachments = BaseTextShadowNode::Attachments{};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -168,7 +168,7 @@ AttributedString AndroidTextInputShadowNode::getAttributedString(
   // Don't propagate the background color of the TextInput onto the attributed
   // string. Android tries to render shadow of the background alongside the
   // shadow of the text which results in weird artifacts.
-  childTextAttributes.backgroundColor = SharedColor{};
+  childTextAttributes.backgroundColor = HostPlatformColor::UndefinedColor;
 
   auto attributedString = AttributedString{};
   auto attachments = BaseTextShadowNode::Attachments{};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -309,7 +309,8 @@ static void updateBorderColorPropValue(
     const std::optional<SharedColor>& newColor,
     const std::optional<SharedColor>& oldColor) {
   if (newColor != oldColor) {
-    result[propName] = newColor.has_value() ? *newColor.value() : NULL;
+    result[propName] =
+        newColor.has_value() ? static_cast<int32_t>(*newColor.value()) : NULL;
   }
 }
 
@@ -502,11 +503,11 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   if (backgroundColor != oldProps->backgroundColor) {
-    result["backgroundColor"] = *backgroundColor;
+    result["backgroundColor"] = static_cast<int32_t>(*backgroundColor);
   }
 
   if (outlineColor != oldProps->outlineColor) {
-    result["outlineColor"] = *outlineColor;
+    result["outlineColor"] = static_cast<int32_t>(*outlineColor);
   }
 
   if (outlineOffset != oldProps->outlineOffset) {
@@ -532,7 +533,7 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   if (shadowColor != oldProps->shadowColor) {
-    result["shadowColor"] = *shadowColor;
+    result["shadowColor"] = static_cast<int32_t>(*shadowColor);
   }
 
   if (shadowOpacity != oldProps->shadowOpacity) {

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -17,6 +17,11 @@ namespace facebook::react {
 
 #ifdef RN_SERIALIZABLE_STATE
 
+inline folly::dynamic toDynamic(uint32_t value)
+{
+  return value;
+}
+
 inline folly::dynamic toDynamic(const std::vector<bool> &arrayValue)
 {
   folly::dynamic resultArray = folly::dynamic::array();

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
@@ -30,7 +30,7 @@ struct BoxShadow {
     result["offsetY"] = offsetY;
     result["blurRadius"] = blurRadius;
     result["spreadDistance"] = spreadDistance;
-    result["color"] = *color;
+    result["color"] = static_cast<int32_t>(*color);
     result["inset"] = inset;
     return result;
   }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -29,9 +29,9 @@ namespace facebook::react {
  */
 class SharedColor {
  public:
-  SharedColor() : color_(HostPlatformColor::UndefinedColor), isDefined_(false) {}
+  SharedColor() : color_(HostPlatformColor::UndefinedColor) {}
 
-  SharedColor(Color color) : color_(color), isDefined_(true) {}
+  SharedColor(Color color) : color_(color) {}
 
   Color &operator*()
   {
@@ -45,26 +45,23 @@ class SharedColor {
 
   bool operator==(const SharedColor &otherColor) const
   {
-    return color_ == otherColor.color_ && isDefined_ == otherColor.isDefined_;
+    return color_ == otherColor.color_;
   }
 
   bool operator!=(const SharedColor &otherColor) const
   {
-    return !(*this == otherColor);
+    return color_ != otherColor.color_;
   }
 
   operator bool() const
   {
-    return isDefined_;
+    return color_ != HostPlatformColor::UndefinedColor;
   }
 
   std::string toString() const noexcept;
 
  private:
   Color color_;
-  // Android represents both transparent black and UndefinedColor as ARGB 0.
-  // Track presence separately so prop reconciliation can distinguish them.
-  bool isDefined_;
 };
 
 bool isColorMeaningful(const SharedColor &color) noexcept;
@@ -84,7 +81,7 @@ SharedColor whiteColor();
 #ifdef RN_SERIALIZABLE_STATE
 inline folly::dynamic toDynamic(const SharedColor &sharedColor)
 {
-  return *sharedColor;
+  return static_cast<int32_t>(*sharedColor);
 }
 #endif
 
@@ -94,7 +91,6 @@ template <>
 struct std::hash<facebook::react::SharedColor> {
   size_t operator()(const facebook::react::SharedColor &color) const
   {
-    auto seed = std::hash<facebook::react::Color>{}(*color);
-    return seed ^ (std::hash<bool>{}(static_cast<bool>(color)) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+    return std::hash<facebook::react::Color>{}(*color);
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -29,9 +29,9 @@ namespace facebook::react {
  */
 class SharedColor {
  public:
-  SharedColor() : color_(HostPlatformColor::UndefinedColor) {}
+  SharedColor() : color_(HostPlatformColor::UndefinedColor), isDefined_(false) {}
 
-  SharedColor(Color color) : color_(color) {}
+  SharedColor(Color color) : color_(color), isDefined_(true) {}
 
   Color &operator*()
   {
@@ -45,23 +45,26 @@ class SharedColor {
 
   bool operator==(const SharedColor &otherColor) const
   {
-    return color_ == otherColor.color_;
+    return color_ == otherColor.color_ && isDefined_ == otherColor.isDefined_;
   }
 
   bool operator!=(const SharedColor &otherColor) const
   {
-    return color_ != otherColor.color_;
+    return !(*this == otherColor);
   }
 
   operator bool() const
   {
-    return color_ != HostPlatformColor::UndefinedColor;
+    return isDefined_;
   }
 
   std::string toString() const noexcept;
 
  private:
   Color color_;
+  // Android represents both transparent black and UndefinedColor as ARGB 0.
+  // Track presence separately so prop reconciliation can distinguish them.
+  bool isDefined_;
 };
 
 bool isColorMeaningful(const SharedColor &color) noexcept;
@@ -91,6 +94,7 @@ template <>
 struct std::hash<facebook::react::SharedColor> {
   size_t operator()(const facebook::react::SharedColor &color) const
   {
-    return std::hash<facebook::react::Color>{}(*color);
+    auto seed = std::hash<facebook::react::Color>{}(*color);
+    return seed ^ (std::hash<bool>{}(static_cast<bool>(color)) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.cpp
@@ -12,7 +12,7 @@ namespace facebook::react {
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ColorStop::toDynamic() const {
   folly::dynamic result = folly::dynamic::object();
-  result["color"] = *color;
+  result["color"] = static_cast<int32_t>(*color);
   result["position"] = position.toDynamic();
   return result;
 }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
@@ -100,7 +100,7 @@ struct DropShadowParams {
     result["offsetX"] = offsetX;
     result["offsetY"] = offsetY;
     result["standardDeviation"] = standardDeviation;
-    result["color"] = *color;
+    result["color"] = static_cast<int32_t>(*color);
     return result;
   }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -8,56 +8,80 @@
 #pragma once
 
 #include <react/renderer/graphics/ColorComponents.h>
+#include <react/utils/hash_combine.h>
 #include <cmath>
+#include <cstdint>
 
 namespace facebook::react {
 
-using Color = int32_t;
+struct Color {
+  int32_t value{0};
+  bool isDefined{false};
+
+  constexpr Color() = default;
+  constexpr Color(int32_t colorValue) : value(colorValue), isDefined(true) {}
+
+  constexpr bool operator==(const Color &otherColor) const
+  {
+    return value == otherColor.value && isDefined == otherColor.isDefined;
+  }
+
+  constexpr bool operator!=(const Color &otherColor) const
+  {
+    return !(*this == otherColor);
+  }
+
+  constexpr operator int32_t() const
+  {
+    return value;
+  }
+};
 
 namespace HostPlatformColor {
-constexpr facebook::react::Color UndefinedColor = 0;
+constexpr facebook::react::Color UndefinedColor{};
 }
 
 inline Color hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
-  return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);
+  return Color{(a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff)};
 }
 
 inline Color hostPlatformColorFromComponents(ColorComponents components)
 {
   float ratio = 255;
-  return ((int)round(components.alpha * ratio) & 0xff) << 24 | ((int)round(components.red * ratio) & 0xff) << 16 |
-      ((int)round(components.green * ratio) & 0xff) << 8 | ((int)round(components.blue * ratio) & 0xff);
+  return Color{
+      ((int)round(components.alpha * ratio) & 0xff) << 24 | ((int)round(components.red * ratio) & 0xff) << 16 |
+      ((int)round(components.green * ratio) & 0xff) << 8 | ((int)round(components.blue * ratio) & 0xff)};
 }
 
 inline ColorComponents colorComponentsFromHostPlatformColor(Color color)
 {
   float ratio = 255;
   return ColorComponents{
-      .red = (float)((color >> 16) & 0xff) / ratio,
-      .green = (float)((color >> 8) & 0xff) / ratio,
-      .blue = (float)((color >> 0) & 0xff) / ratio,
-      .alpha = (float)((color >> 24) & 0xff) / ratio};
+      .red = (float)((color.value >> 16) & 0xff) / ratio,
+      .green = (float)((color.value >> 8) & 0xff) / ratio,
+      .blue = (float)((color.value >> 0) & 0xff) / ratio,
+      .alpha = (float)((color.value >> 24) & 0xff) / ratio};
 }
 
 inline float alphaFromHostPlatformColor(Color color)
 {
-  return static_cast<float>((color >> 24) & 0xff);
+  return static_cast<float>((color.value >> 24) & 0xff);
 }
 
 inline float redFromHostPlatformColor(Color color)
 {
-  return static_cast<float>((color >> 16) & 0xff);
+  return static_cast<float>((color.value >> 16) & 0xff);
 }
 
 inline float greenFromHostPlatformColor(Color color)
 {
-  return static_cast<float>((color >> 8) & 0xff);
+  return static_cast<float>((color.value >> 8) & 0xff);
 }
 
 inline float blueFromHostPlatformColor(Color color)
 {
-  return static_cast<uint8_t>((color >> 0) & 0xff);
+  return static_cast<uint8_t>((color.value >> 0) & 0xff);
 }
 
 inline bool hostPlatformColorIsColorMeaningful(Color color) noexcept
@@ -66,3 +90,11 @@ inline bool hostPlatformColorIsColorMeaningful(Color color) noexcept
 }
 
 } // namespace facebook::react
+
+template <>
+struct std::hash<facebook::react::Color> {
+  size_t operator()(const facebook::react::Color &color) const
+  {
+    return facebook::react::hash_combine(color.value, color.isDefined);
+  }
+};

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -38,8 +38,7 @@ inline size_t hashGetColourArguments(int32_t surfaceId, const std::vector<std::s
 inline SharedColor
 parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, const RawValue &value)
 {
-  Color color = 0;
-  bool resolved = false;
+  Color color{};
   if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
     // Mixed array + string values, so read as a map of RawValue (a map of
     // vector<string> would assert on the fallback string).
@@ -51,6 +50,7 @@ parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, 
       resourcePaths = (std::vector<std::string>)resourcePathsIt->second;
     }
 
+    bool resolved = false;
     if (!resourcePaths.empty()) {
       // Cache the (costly) JNI results. A cached nullopt is an explicit miss,
       // distinct from a path that resolves to transparent (ARGB 0).
@@ -105,13 +105,12 @@ parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, 
         if (std::holds_alternative<CSSColor>(cssColor)) {
           const auto &c = std::get<CSSColor>(cssColor);
           color = hostPlatformColorFromRGBA(c.r, c.g, c.b, c.a);
-          resolved = true;
         }
       }
     }
   }
 
-  return resolved ? SharedColor{color} : SharedColor{};
+  return color;
 }
 
 inline void

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -39,6 +39,7 @@ inline SharedColor
 parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, const RawValue &value)
 {
   Color color = 0;
+  bool resolved = false;
   if (value.hasType<std::unordered_map<std::string, RawValue>>()) {
     // Mixed array + string values, so read as a map of RawValue (a map of
     // vector<string> would assert on the fallback string).
@@ -50,7 +51,6 @@ parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, 
       resourcePaths = (std::vector<std::string>)resourcePathsIt->second;
     }
 
-    bool resolved = false;
     if (!resourcePaths.empty()) {
       // Cache the (costly) JNI results. A cached nullopt is an explicit miss,
       // distinct from a path that resolves to transparent (ARGB 0).
@@ -105,12 +105,13 @@ parsePlatformColor(const ContextContainer &contextContainer, int32_t surfaceId, 
         if (std::holds_alternative<CSSColor>(cssColor)) {
           const auto &c = std::get<CSSColor>(cssColor);
           color = hostPlatformColorFromRGBA(c.r, c.g, c.b, c.a);
+          resolved = true;
         }
       }
     }
   }
 
-  return color;
+  return resolved ? SharedColor{color} : SharedColor{};
 }
 
 inline void

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
@@ -73,10 +73,10 @@ SharedColor parsePlatformColor(const ContextContainer &contextContainer, int32_t
     auto items = (std::unordered_map<std::string, RawValue>)value;
     if (items.find("semantic") != items.end() && items.at("semantic").hasType<std::vector<std::string>>()) {
       auto semanticItems = (std::vector<std::string>)items.at("semantic");
-      auto semanticPlatformColor = Color::createSemanticColor(semanticItems);
+      auto semanticColor = SharedColor(Color::createSemanticColor(semanticItems));
       // The sentinel (null UIColor) means a true miss; apply the fallback only
       // then, not when a name resolves to transparent.
-      if (semanticPlatformColor == HostPlatformColor::UndefinedColor) {
+      if (!semanticColor) {
         if (items.find("fallback") != items.end() && items.at("fallback").hasType<std::string>()) {
           auto fallbackColor = fallbackColorFromString((std::string)items.at("fallback"));
           // has_value(), not != 0, so a transparent fallback is kept.
@@ -87,7 +87,7 @@ SharedColor parsePlatformColor(const ContextContainer &contextContainer, int32_t
         // Miss with no usable fallback: clearColor, never leaking the sentinel.
         return clearColor();
       }
-      return SharedColor(semanticPlatformColor);
+      return semanticColor;
     } else if (
         items.find("dynamic") != items.end() &&
         items.at("dynamic").hasType<std::unordered_map<std::string, RawValue>>()) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/PlatformColorParser.mm
@@ -73,10 +73,10 @@ SharedColor parsePlatformColor(const ContextContainer &contextContainer, int32_t
     auto items = (std::unordered_map<std::string, RawValue>)value;
     if (items.find("semantic") != items.end() && items.at("semantic").hasType<std::vector<std::string>>()) {
       auto semanticItems = (std::vector<std::string>)items.at("semantic");
-      auto semanticColor = SharedColor(Color::createSemanticColor(semanticItems));
+      auto semanticPlatformColor = Color::createSemanticColor(semanticItems);
       // The sentinel (null UIColor) means a true miss; apply the fallback only
       // then, not when a name resolves to transparent.
-      if (!semanticColor) {
+      if (semanticPlatformColor == HostPlatformColor::UndefinedColor) {
         if (items.find("fallback") != items.end() && items.at("fallback").hasType<std::string>()) {
           auto fallbackColor = fallbackColorFromString((std::string)items.at("fallback"));
           // has_value(), not != 0, so a transparent fallback is kept.
@@ -87,7 +87,7 @@ SharedColor parsePlatformColor(const ContextContainer &contextContainer, int32_t
         // Miss with no usable fallback: clearColor, never leaking the sentinel.
         return clearColor();
       }
-      return semanticColor;
+      return SharedColor(semanticPlatformColor);
     } else if (
         items.find("dynamic") != items.end() &&
         items.at("dynamic").hasType<std::unordered_map<std::string, RawValue>>()) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
@@ -37,8 +37,11 @@ TEST(ColorTest, testColorConversion) {
   }
 }
 
+#ifdef ANDROID
 TEST(ColorTest, testTransparentColorIsDistinctFromUndefined) {
   using namespace facebook::react;
+
+  EXPECT_NE(Color{}, Color{0});
 
   SharedColor undefinedColor;
   auto transparentColor = clearColor();
@@ -47,3 +50,4 @@ TEST(ColorTest, testTransparentColorIsDistinctFromUndefined) {
   EXPECT_TRUE(transparentColor);
   EXPECT_NE(undefinedColor, transparentColor);
 }
+#endif

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
@@ -36,3 +36,14 @@ TEST(ColorTest, testColorConversion) {
     EXPECT_EQ(std::round(colorComponents.blue * 10) / 10.f, 0);
   }
 }
+
+TEST(ColorTest, testTransparentColorIsDistinctFromUndefined) {
+  using namespace facebook::react;
+
+  SharedColor undefinedColor;
+  auto transparentColor = clearColor();
+
+  EXPECT_FALSE(undefinedColor);
+  EXPECT_TRUE(transparentColor);
+  EXPECT_NE(undefinedColor, transparentColor);
+}

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -610,7 +610,6 @@ using facebook::react::CascadedBorderCurves = facebook::react::CascadedRectangle
 using facebook::react::CascadedBorderRadii = facebook::react::CascadedRectangleCorners<facebook::react::ValueUnit>;
 using facebook::react::CascadedBorderStyles = facebook::react::CascadedRectangleEdges<facebook::react::BorderStyle>;
 using facebook::react::CascadedBorderWidths = facebook::react::CascadedRectangleEdges<facebook::react::Float>;
-using facebook::react::Color = int32_t;
 using facebook::react::ComponentDescriptorConstructor = facebook::react::ComponentDescriptor::Unique(const facebook::react::ComponentDescriptorParameters& parameters);
 using facebook::react::ComponentDescriptorProviderRequest = std::function<void(facebook::react::ComponentName componentName)>;
 using facebook::react::ComponentHandle = int64_t;
@@ -932,6 +931,7 @@ folly::dynamic facebook::react::toDynamic(const std::vector<facebook::react::Flo
 folly::dynamic facebook::react::toDynamic(const std::vector<folly::dynamic>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<int>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<std::string>& arrayValue);
+folly::dynamic facebook::react::toDynamic(uint32_t value);
 int facebook::react::toAndroidRepr(const facebook::react::SharedColor& color);
 int facebook::react::toInt(const facebook::react::DisplayType& displayType);
 int facebook::react::toInt(const facebook::react::LayoutDirection& layoutDirection);
@@ -7257,6 +7257,16 @@ struct facebook::react::CascadedRectangleEdgesNames {
   public const char* start;
   public const char* top;
   public const char* vertical;
+}
+
+struct facebook::react::Color {
+  public bool isDefined;
+  public constexpr Color() = default;
+  public constexpr Color(int32_t colorValue);
+  public constexpr bool operator!=(const facebook::react::Color& otherColor) const;
+  public constexpr bool operator==(const facebook::react::Color& otherColor) const;
+  public constexpr operator int32_t() const;
+  public int32_t value;
 }
 
 struct facebook::react::ColorComponents {
@@ -13973,6 +13983,10 @@ struct std::hash<facebook::react::AttributedString> {
 
 struct std::hash<facebook::react::AttributedStringBox> {
   public size_t operator()(const facebook::react::AttributedStringBox& attributedStringBox) const;
+}
+
+struct std::hash<facebook::react::Color> {
+  public size_t operator()(const facebook::react::Color& color) const;
 }
 
 struct std::hash<facebook::react::EventAnimationDriverKey> {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -609,7 +609,6 @@ using facebook::react::CascadedBorderCurves = facebook::react::CascadedRectangle
 using facebook::react::CascadedBorderRadii = facebook::react::CascadedRectangleCorners<facebook::react::ValueUnit>;
 using facebook::react::CascadedBorderStyles = facebook::react::CascadedRectangleEdges<facebook::react::BorderStyle>;
 using facebook::react::CascadedBorderWidths = facebook::react::CascadedRectangleEdges<facebook::react::Float>;
-using facebook::react::Color = int32_t;
 using facebook::react::ComponentDescriptorConstructor = facebook::react::ComponentDescriptor::Unique(const facebook::react::ComponentDescriptorParameters& parameters);
 using facebook::react::ComponentDescriptorProviderRequest = std::function<void(facebook::react::ComponentName componentName)>;
 using facebook::react::ComponentHandle = int64_t;
@@ -931,6 +930,7 @@ folly::dynamic facebook::react::toDynamic(const std::vector<facebook::react::Flo
 folly::dynamic facebook::react::toDynamic(const std::vector<folly::dynamic>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<int>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<std::string>& arrayValue);
+folly::dynamic facebook::react::toDynamic(uint32_t value);
 int facebook::react::toAndroidRepr(const facebook::react::SharedColor& color);
 int facebook::react::toInt(const facebook::react::DisplayType& displayType);
 int facebook::react::toInt(const facebook::react::LayoutDirection& layoutDirection);
@@ -7067,6 +7067,16 @@ struct facebook::react::CascadedRectangleEdgesNames {
   public const char* start;
   public const char* top;
   public const char* vertical;
+}
+
+struct facebook::react::Color {
+  public bool isDefined;
+  public constexpr Color() = default;
+  public constexpr Color(int32_t colorValue);
+  public constexpr bool operator!=(const facebook::react::Color& otherColor) const;
+  public constexpr bool operator==(const facebook::react::Color& otherColor) const;
+  public constexpr operator int32_t() const;
+  public int32_t value;
 }
 
 struct facebook::react::ColorComponents {
@@ -13586,6 +13596,10 @@ struct std::hash<facebook::react::AttributedString> {
 
 struct std::hash<facebook::react::AttributedStringBox> {
   public size_t operator()(const facebook::react::AttributedStringBox& attributedStringBox) const;
+}
+
+struct std::hash<facebook::react::Color> {
+  public size_t operator()(const facebook::react::Color& color) const;
 }
 
 struct std::hash<facebook::react::EventAnimationDriverKey> {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -610,7 +610,6 @@ using facebook::react::CascadedBorderCurves = facebook::react::CascadedRectangle
 using facebook::react::CascadedBorderRadii = facebook::react::CascadedRectangleCorners<facebook::react::ValueUnit>;
 using facebook::react::CascadedBorderStyles = facebook::react::CascadedRectangleEdges<facebook::react::BorderStyle>;
 using facebook::react::CascadedBorderWidths = facebook::react::CascadedRectangleEdges<facebook::react::Float>;
-using facebook::react::Color = int32_t;
 using facebook::react::ComponentDescriptorConstructor = facebook::react::ComponentDescriptor::Unique(const facebook::react::ComponentDescriptorParameters& parameters);
 using facebook::react::ComponentDescriptorProviderRequest = std::function<void(facebook::react::ComponentName componentName)>;
 using facebook::react::ComponentHandle = int64_t;
@@ -932,6 +931,7 @@ folly::dynamic facebook::react::toDynamic(const std::vector<facebook::react::Flo
 folly::dynamic facebook::react::toDynamic(const std::vector<folly::dynamic>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<int>& arrayValue);
 folly::dynamic facebook::react::toDynamic(const std::vector<std::string>& arrayValue);
+folly::dynamic facebook::react::toDynamic(uint32_t value);
 int facebook::react::toAndroidRepr(const facebook::react::SharedColor& color);
 int facebook::react::toInt(const facebook::react::DisplayType& displayType);
 int facebook::react::toInt(const facebook::react::LayoutDirection& layoutDirection);
@@ -7248,6 +7248,16 @@ struct facebook::react::CascadedRectangleEdgesNames {
   public const char* start;
   public const char* top;
   public const char* vertical;
+}
+
+struct facebook::react::Color {
+  public bool isDefined;
+  public constexpr Color() = default;
+  public constexpr Color(int32_t colorValue);
+  public constexpr bool operator!=(const facebook::react::Color& otherColor) const;
+  public constexpr bool operator==(const facebook::react::Color& otherColor) const;
+  public constexpr operator int32_t() const;
+  public int32_t value;
 }
 
 struct facebook::react::ColorComponents {
@@ -13817,6 +13827,10 @@ struct std::hash<facebook::react::AttributedString> {
 
 struct std::hash<facebook::react::AttributedStringBox> {
   public size_t operator()(const facebook::react::AttributedStringBox& attributedStringBox) const;
+}
+
+struct std::hash<facebook::react::Color> {
+  public size_t operator()(const facebook::react::Color& color) const;
 }
 
 struct std::hash<facebook::react::EventAnimationDriverKey> {


### PR DESCRIPTION
## Summary:

Fixes #58085.

Android represents both an undefined color and explicit transparent black as ARGB `0`. `SharedColor` previously compared only that raw value, so Props 2.0 considered an explicitly supplied transparent color equal to an absent prop and omitted it from the mount diff.

This change tracks color presence separately from the platform value and includes it in equality, boolean conversion, and hashing. Platform parsers and the few call sites that intentionally produce an undefined color now preserve that state explicitly.

## Changelog:

[ANDROID] [FIXED] - Preserve explicitly transparent colors during Props 2.0 reconciliation.

## Test Plan:

- Added `ColorTest.testTransparentColorIsDistinctFromUndefined`.
- Compiled and ran a standalone regression harness against Android `Color.cpp`; it failed before this change and passes afterward.
- Built `ReactAndroid` CMake Debug for `arm64-v8a` successfully.
- Validated all 9 ReactCommon, ReactAndroid, and ReactApple C++ API snapshots against Doxygen 1.16.1.
- Ran targeted clang-format and `git diff --check`.
