### PR TITLE
Drop RCT_EXPORT_METHOD from RCTTestModule TurboModule

### DIFF
--- a/packages/rn-tester/RCTTest/RCTTestModule.mm
+++ b/packages/rn-tester/RCTTest/RCTTestModule.mm
@@ -105,7 +105,7 @@ RCT_EXPORT_MODULE()
   // noop
 }
 
-RCT_EXPORT_METHOD(verifySnapshot : (RCTResponseSenderBlock)callback)
+- (void)verifySnapshot:(RCTResponseSenderBlock)callback
 {
   RCTAssert(_controller != nil, @"No snapshot controller configured.");
 
@@ -156,12 +156,12 @@ RCT_REMAP_METHOD(
   reject(nil, nil, nil);
 }
 
-RCT_EXPORT_METHOD(markTestCompleted)
+- (void)markTestCompleted
 {
   [self markTestPassed:YES];
 }
 
-RCT_EXPORT_METHOD(markTestPassed : (BOOL)success)
+- (void)markTestPassed:(BOOL)success
 {
   [_bridge.uiManager
       addUIBlock:^(__unused RCTUIManager *uiManager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {


### PR DESCRIPTION
Summary:
`RCTTestModule` is a TurboModule: it conforms to `NativeTestModuleSpec` and returns
`NativeTestModuleSpecJSI` from `getTurboModule:`, so JS->ObjC dispatch is driven by
codegen, not by `RCT_EXPORT_METHOD`'s `__rct_export__` metadata. The macro is dead weight.
Convert the three spec-declared methods to plain ObjC declarations; conformance to
`NativeTestModuleSpec` keeps their signatures compiler-enforced.

```
- (void)markTestCompleted;
- (void)markTestPassed:(BOOL)success;
- (void)verifySnapshot:(RCTResponseSenderBlock)callback;
```

`sendAppEvent:body:` keeps its macro because it is not declared in the spec protocol, and
the two `RCT_REMAP_METHOD` exports keep theirs because they define custom JS names.

Changelog: [Internal]

Differential Revision: D117201272


