### PR TITLE
Use legacy JNI packaging for ARM64 Android E2E APKs

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -51,12 +51,17 @@ runs:
     - name: Build and publish all the Android Artifacts to /tmp/maven-local
       shell: bash
       run: |
+        GRADLE_ARGS=()
         if [[ "${{ inputs.release-type }}" == "dry-run" ]]; then
           # dry-run: we only build ARM64 to save time/resources. Android E2E
           # runs this APK on an x86_64 API 35 image using NDK translation.
           # For release/nightlies the default is to build all architectures.
           export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
           export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesNightly=true"
+          GRADLE_ARGS=(
+            --init-script
+            "$GITHUB_WORKSPACE/.github/workflow-scripts/legacy-jni-packaging.gradle"
+          )
           TASKS="publishAllToMavenTempLocal build"
         elif [[ "${{ inputs.release-type }}" == "nightly" ]]; then
           # nightly: we set isSnapshot to true so artifacts are sent to the right repository on Maven Central.
@@ -69,7 +74,7 @@ runs:
           export HERMES_PREBUILT_FLAG="ORG_GRADLE_PROJECT_react.internal.useHermesStable=true"
           TASKS="publishAllToMavenTempLocal publishAndroidToSonatype closeSonatypeStagingRepository build"
         fi
-        env "$HERMES_PREBUILT_FLAG" ./gradlew $TASKS -PenableWarningsAsErrors=true
+        env "$HERMES_PREBUILT_FLAG" ./gradlew "${GRADLE_ARGS[@]}" $TASKS -PenableWarningsAsErrors=true
     - name: Save Android ccache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
       uses: actions/cache/save@v5

--- a/.github/workflow-scripts/legacy-jni-packaging.gradle
+++ b/.github/workflow-scripts/legacy-jni-packaging.gradle
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Extract native libraries when installing ARM64-only APKs on x86_64 emulators. This lets Android's
+// native bridge select the translated ABI without relying on SoLoader's direct-from-APK ABI lookup.
+allprojects { project ->
+  project.pluginManager.withPlugin("com.android.application") {
+    project.extensions.getByName("android").packaging.jniLibs.useLegacyPackaging = true
+  }
+}

--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -74,7 +74,10 @@ jobs:
           # Build
           cd android
           CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
-          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=arm64-v8a
+          ./gradlew --no-daemon \
+            --init-script "$GITHUB_WORKSPACE/.github/workflow-scripts/legacy-jni-packaging.gradle" \
+            assemble$CAPITALIZED_FLAVOR \
+            -PreactNativeArchitectures=arm64-v8a
 
       - name: Download previous per-flow test state
         if: ${{ inputs.retry-attempt > 0 }}


### PR DESCRIPTION
## Summary:

Follow-up to #58092.

Android API 35 x86_64 emulator images expose both `x86_64` and `arm64-v8a` through `libndk_translation.so`. SoLoader 0.12.1 only searches the first ABI when loading uncompressed native libraries directly from the APK, causing ARM64-only RNTester and template apps to crash while loading `libreactnative.so`.

Enable legacy JNI packaging through a CI-only Gradle init script so Android extracts the ARM64 libraries and the existing SoLoader `ApplicationSoSource` can load them. This applies only to dry-run RNTester builds and Android template E2E builds. Nightly and release packaging is unchanged.

Failure evidence: https://github.com/react/react-native/actions/runs/32741094253

## Changelog:

[INTERNAL] [FIXED] - Extract native libraries for ARM64 Android E2E APKs running through NDK translation.

## Test Plan:

- `./node_modules/.bin/prettier --check .github/actions/build-android/action.yml .github/workflows/e2e-android-templateapp.yml` — passed.
- Parsed both modified YAML files with the `yaml` Node package — passed.
- Parsed the embedded workflow shell scripts with `bash -n` — passed.
- Compiled `.github/workflow-scripts/legacy-jni-packaging.gradle` with the Groovy compiler bundled with Gradle 9.4.1 — passed.
- Full Android E2E validation is delegated to this draft PR because the local Gradle daemon could not establish its localhost connection.
