### PR TITLE
Fix zIndex being ignored on Android ScrollView/FlatList with a RefreshControl

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-refreshControl-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-refreshControl-test.js
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+
+const flattenStyle = require('../../../StyleSheet/flattenStyle').default;
+const RefreshControl = require('../../RefreshControl/RefreshControl').default;
+const ScrollView = require('../ScrollView').default;
+const ReactTestRenderer = require('react-test-renderer');
+
+// This test is about the element tree `ScrollView.render()` builds, so the
+// default component mocks have to be turned off.
+jest.unmock('react-native/Libraries/Components/ScrollView/ScrollView');
+jest.unmock('react-native/Libraries/Components/RefreshControl/RefreshControl');
+// On Android a `ScrollView` with a `RefreshControl` is wrapped in an
+// `AndroidSwipeRefreshLayout`, and `style` is split across the two nodes.
+jest.mock('../../../Utilities/Platform', () =>
+  // $FlowFixMe[missing-platform-support]
+  require('../../../Utilities/Platform.android'),
+);
+
+async function renderScrollView(style: $FlowFixMe): Promise<$FlowFixMe> {
+  let testRenderer: $FlowFixMe = null;
+  await ReactTestRenderer.act(() => {
+    testRenderer = ReactTestRenderer.create(
+      <ScrollView
+        style={style}
+        refreshControl={
+          <RefreshControl refreshing={false} onRefresh={() => {}} />
+        }
+      />,
+    );
+  });
+  return testRenderer.toJSON();
+}
+
+describe('ScrollView with a RefreshControl on Android', () => {
+  it('applies zIndex to the wrapper, not to the inner ScrollView', async () => {
+    const wrapper = await renderScrollView({zIndex: 7});
+
+    // `zIndex` has to reach the wrapper: that is the node parented by the
+    // user's view, and on Android z-ordering is applied by the parent.
+    expect(wrapper.type).toBe('AndroidSwipeRefreshLayout');
+    expect(flattenStyle(wrapper.props.style)?.zIndex).toBe(7);
+
+    // The inner scroll view is an only child, so a `zIndex` left here could
+    // never affect stacking.
+    const scrollView = wrapper.children[0];
+    expect(scrollView.type).toBe('RCTScrollView');
+    expect(flattenStyle(scrollView.props.style)?.zIndex).toBeUndefined();
+  });
+
+  it('keeps non-layout style on the inner ScrollView', async () => {
+    const wrapper = await renderScrollView({backgroundColor: 'red'});
+
+    expect(flattenStyle(wrapper.props.style)?.backgroundColor).toBeUndefined();
+    expect(flattenStyle(wrapper.children[0].props.style)?.backgroundColor).toBe(
+      'red',
+    );
+  });
+});

--- a/packages/react-native/Libraries/StyleSheet/__tests__/splitLayoutProps-itest.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/splitLayoutProps-itest.js
@@ -47,6 +47,18 @@ test('does not copy values to both returned objects', () => {
   `);
 });
 
+test('splits zIndex into the outer style', () => {
+  // On Android a ScrollView with a RefreshControl is wrapped in an
+  // AndroidSwipeRefreshLayout, and the outer style is applied to that wrapper.
+  // `zIndex` has to travel outwards along with the other positioning props,
+  // because the wrapper is the node that participates in the parent's
+  // stacking context.
+  const style = {zIndex: 1, top: 0, backgroundColor: 'red', padding: 8};
+  const {outer, inner} = splitLayoutProps(style);
+  expect(outer).toEqual({zIndex: 1, top: 0});
+  expect(inner).toEqual({backgroundColor: 'red', padding: 8});
+});
+
 test('returns null values if argument is null', () => {
   const {outer, inner} = splitLayoutProps(null);
   expect(outer).toBe(null);

--- a/packages/react-native/Libraries/StyleSheet/splitLayoutProps.js
+++ b/packages/react-native/Libraries/StyleSheet/splitLayoutProps.js
@@ -44,6 +44,7 @@ export default function splitLayoutProps(props: ?____ViewStyle_Internal): {
         case 'minWidth':
         case 'maxWidth':
         case 'position':
+        case 'zIndex':
         case 'left':
         case 'right':
         case 'bottom':


### PR DESCRIPTION
## Summary:

Fixes #31083.

On Android, a `ScrollView` that has a `RefreshControl` is not one view. `ScrollView.render()` wraps it
in an `AndroidSwipeRefreshLayout` and splits the user's `style` across the two nodes with
`splitLayoutProps()` — layout props to the wrapper, painting props to the scroll view
(`Libraries/Components/ScrollView/ScrollView.js:1939-1948`).

`splitLayoutProps` routes `position`, `top`, `left`, `right`, `bottom` and `transform` to the **outer**
node, but never listed `zIndex`. So `zIndex` fell through to the **inner** `NativeScrollView` — which
is an only child of the wrapper, and therefore can never be reordered against anything. The user's
`zIndex` silently stops working the moment `onRefresh` is added, because `onRefresh` is exactly what
makes `VirtualizedList` synthesize a `RefreshControl`
(`packages/virtualized-lists/Lists/VirtualizedList.js:1308-1317`).

That is why removing a single `onRefresh` prop fixes the stacking, and why the workaround in the issue
thread — wrapping the list in `<View style={{zIndex: 1}}>` — works: it reintroduces a node that the
parent can order.

On Android z-order is not a view property. `BaseViewManager.setZIndex` is an explicit no-op
("Z-order is managed at the C++ layer in Fabric"); `ConcreteViewShadowNode` copies `zIndex` into
`orderIndex_`, and `sliceChildShadowNodeViewPairs` stable-sorts a parent's children by it to assign
mount indices. The parent does the ordering, reading each child's own `zIndex` — so the prop has to
be on the wrapper. Correspondingly, `sliceChildShadowNodeViewPairs` returns early for a single child,
which is why the current placement is inert rather than merely wrong.

This is a regression, not a long-standing gap: the wrapper split and this omission both arrived in
d9a8ac5071d2 (#24411), first shipping in 0.60.0.

Prior art for this exact shape of fix: #26611 added `transform` to this same outer list for the same
reason, and #24411 itself created the list. Both landed.

Both consumers already apply the split correctly and need no change — `ScrollView.js:1939` and
`Libraries/Animated/components/AnimatedScrollView.js:94`. `splitLayoutProps` is internal (not exported
from `index.js`, absent from `ReactNativeApi.d.ts`) and the diff adds only a `case` label, so no
generated artifact changes and no `yarn build-types` run is needed.

Scoped deliberately to `zIndex`. `elevation` is routed to `inner` too and has related symptoms, but
moving it is not equivalent — it would put the elevation on a background-less wrapper and change the
drop shadow — so it belongs in a separate change.

Note that because Android z-order is implemented by reordering mount indices, this also affects touch
and accessibility order, not just paint order — which is the correct, consistent behaviour, and
matches what a list without `onRefresh` already does.

## Changelog:

[ANDROID] [FIXED] - Fix `zIndex` being ignored on a `ScrollView`/`FlatList` that has a `RefreshControl` (e.g. when `onRefresh` is set)

## Test Plan:

Added `Libraries/Components/ScrollView/__tests__/ScrollView-refreshControl-test.js`, which renders a
real `ScrollView` with a `RefreshControl` on Android and asserts where the style lands — this pins the
actual reported behaviour, not just the helper:

```
PASS packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-refreshControl-test.js
  ScrollView with a RefreshControl on Android
    ✓ applies zIndex to the wrapper, not to the inner ScrollView
    ✓ keeps non-layout style on the inner ScrollView
```

Verified it is a real regression guard — with the one-line fix reverted, it fails:

```
● applies zIndex to the wrapper, not to the inner ScrollView
    Expected: 7
    Received: undefined
```

The rendered trees, before and after:

```
BEFORE                                    AFTER
AndroidSwipeRefreshLayout                 AndroidSwipeRefreshLayout
  style: [..., {flexGrow, flexShrink}]      style: [..., {flexGrow, flexShrink, zIndex: 7}]
  └─ RCTScrollView                          └─ RCTScrollView
       style: [..., {zIndex: 7}]                 style: [...]              <- no zIndex
```

Also extended `Libraries/StyleSheet/__tests__/splitLayoutProps-itest.js` with a unit case covering the
routing directly.

Static checks, against `main` @ ab2ea64:

```
$ eslint --max-warnings 0 <the three files>
(clean, exit 0)

$ prettier --check <the three files>
All matched files use Prettier code style!

$ flow focus-check <the three files>
Found 0 errors

$ flow full-check
Found 0 errors
```

Flow 0.329.0 matching the `.flowconfig` pin; ESLint 8.57.0 and Prettier 3.9.4, both the versions
declared in `package.json`.

**Not run locally:** the Fantom itest (`splitLayoutProps-itest.js`) — the Fantom tester needs a JDK
plus cmake/ninja, which I don't have set up. Its assertions were verified by exercising the
transpiled module directly, and `toEqual` is used widely in existing itests. Also no on-device run;
the before/after above is from the rendered element tree, not a device.