### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/e2e-android-templateapp.yml
+++ b/.github/workflows/e2e-android-templateapp.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run yarn
         uses: ./.github/actions/yarn-install
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: '17'
           distribution: 'zulu'


### PR DESCRIPTION
## Summary:

Upgrade the Android template app workflow from actions/setup-java v5 to v6.0.0.

## Changelog:

[INTERNAL] [CHANGED] - Upgrade the Android CI setup-java action to v6.0.0.

## Test Plan:

Reviewed the workflow-only diff and verified no setup-java reference older than v6 remains in active workflow YAML.