### PR TITLE
Clear NetworkReporter timing data for failed requests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp
@@ -13,6 +13,7 @@
 #include <oscompat/OSCompat.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/networking/NetworkReporter.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 
 using namespace ::testing;
 
@@ -280,6 +281,38 @@ TEST_P(NetworkReporterTest, testLoadingFailedError) {
                                   "id": 2,
                                   "method": "Network.disable"
                                 })");
+}
+
+TEST_P(NetworkReporterTest, testFailedRequestDiscardsResourceTimingData) {
+  auto& networkReporter = NetworkReporter::getInstance();
+  auto performanceEntryReporter = PerformanceEntryReporter::getInstance();
+  const std::string requestId = "failed-request-resource-timing";
+  const std::string retryUrl = "https://example.com/retry";
+
+  performanceEntryReporter->clearEntries(PerformanceEntryType::RESOURCE);
+
+  networkReporter.reportRequestStart(
+      requestId,
+      {.url = "https://example.com/failed", .httpMethod = "GET"},
+      0,
+      std::nullopt);
+  networkReporter.reportRequestFailed(requestId, false);
+
+  // Reusing the ID makes retained timing data observable without exposing
+  // NetworkReporter internals.
+  networkReporter.reportRequestStart(
+      requestId, {.url = retryUrl, .httpMethod = "GET"}, 0, std::nullopt);
+  networkReporter.reportResponseStart(
+      requestId, {.url = retryUrl, .statusCode = 200}, 0);
+  networkReporter.reportResponseEnd(requestId, 0);
+
+  const auto entries =
+      performanceEntryReporter->getEntries(PerformanceEntryType::RESOURCE);
+  ASSERT_EQ(1, entries.size());
+  EXPECT_EQ(
+      retryUrl, std::get<PerformanceResourceTiming>(entries.front()).name);
+
+  performanceEntryReporter->clearEntries(PerformanceEntryType::RESOURCE);
 }
 
 TEST_P(NetworkReporterTest, testCompleteNetworkFlow) {

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.cpp
@@ -234,6 +234,12 @@ void NetworkReporter::reportResponseEnd(
 void NetworkReporter::reportRequestFailed(
     const std::string& requestId,
     bool cancelled) const {
+  // All builds: Discard incomplete PerformanceResourceTiming metadata
+  {
+    std::lock_guard<std::mutex> lock(perfTimingsMutex_);
+    perfTimingsBuffer_.erase(requestId);
+  }
+
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
   // Debugger enabled: CDP event handling
   jsinspector_modern::NetworkHandler::getInstance().onLoadingFailed(

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -200,8 +200,8 @@ class NetworkReporter {
   NetworkReporter &operator=(const NetworkReporter &) = delete;
   ~NetworkReporter() = default;
 
-  std::unordered_map<std::string, ResourceTimingData> perfTimingsBuffer_{};
-  std::mutex perfTimingsMutex_;
+  mutable std::unordered_map<std::string, ResourceTimingData> perfTimingsBuffer_{};
+  mutable std::mutex perfTimingsMutex_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

`NetworkReporter` stores `PerformanceResourceTiming` metadata when a request starts and removes it when the response completes. Failed or cancelled requests did not remove that metadata, so each failure left an entry in the process-wide timing buffer. If a request ID was reused, the retained entry could also be reported for the later request.

This clears incomplete resource timing metadata from `reportRequestFailed` in all builds while preserving the existing CDP failure event. The public C++ method signature remains unchanged.

A regression test reuses a failed request ID and verifies that the completed retry reports its own URL.

## Changelog:

[GENERAL] [FIXED] - Clear retained resource timing metadata when network requests fail.

## Test Plan:

- `yarn clang-format packages/react-native/ReactCommon/react/networking/NetworkReporter.cpp packages/react-native/ReactCommon/react/networking/NetworkReporter.h packages/react-native/ReactCommon/jsinspector-modern/tests/NetworkReporterTest.cpp`
- `./gradlew ':packages:react-native:ReactAndroid:buildCMakeDebug[arm64-v8a][hermestooling,jsi,etc]' --no-daemon --max-workers=2 --console=plain`
  - Passed: `BUILD SUCCESSFUL`
- Added `testFailedRequestDiscardsResourceTimingData` to cover failure cleanup and request ID reuse.
- The OSS Gradle/CMake setup does not expose the `NetworkReporterTest` C++ test target locally; that test was not executed locally.
