### PR TITLE
Cover 'react/performance' subtree with C++ stable API guards (#58116)

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(react_performance_cdpmetrics PUBLIC ${REACT_COMMON_DI
 target_link_libraries(react_performance_cdpmetrics
         folly_runtime
         jsi
+        react_cxxstableapi
         react_performance_timeline
         react_timing
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string_view>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancecdpmetrics")
 
+  s.dependency "React-cxxstableapi"
+
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-jsi"
   s.dependency "React-performancetimeline"

--- a/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(react_performance_timeline
         jsinspector
         jsinspector_tracing
         reactperflogger
+        react_cxxstableapi
         react_featureflags
         react_timing
         folly_runtime)

--- a/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <vector>
 #include "PerformanceEntry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "CircularBuffer.h"
 #include "PerformanceEntryBuffer.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <optional>
 #include <unordered_map>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryCircularBuffer.h"
 #include "PerformanceEntryKeyedBuffer.h"
 #include "PerformanceEntryReporterListeners.h"

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntry.h"
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryBuffer.h"
 #include "PerformanceObserverRegistry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <set>

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancetimeline")
 
+  s.dependency "React-cxxstableapi"
+
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')


### PR DESCRIPTION
Summary:


Adds private guards to `react/performance/timeline:timeline` and
`react/performance/cdpmetrics:cdpmetrics` headers preventing from inclusions when `RN_STABLE_API`  is turned on.

Changelog:
[Internal]

Reviewed By: cipolleschi

Differential Revision: D109558177
