### PR TITLE
Stop framework headers from exposing private performance APIs (#58011)

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(react_performance_cdpmetrics PUBLIC ${REACT_COMMON_DI
 target_link_libraries(react_performance_cdpmetrics
         folly_runtime
         jsi
+        react_cxxstableapi
         react_performance_timeline
         react_timing
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string_view>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpPerfIssuesReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/jsi.h>
 #include <react/performance/timeline/PerformanceEntry.h>

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancecdpmetrics")
 
+  s.dependency "React-cxxstableapi"
+
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-jsi"
   s.dependency "React-performancetimeline"

--- a/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(react_performance_timeline
         jsinspector
         jsinspector_tracing
         reactperflogger
+        react_cxxstableapi
         react_featureflags
         react_timing
         folly_runtime)

--- a/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/timing/primitives.h>
 
 #include <optional>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <vector>
 #include "PerformanceEntry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "CircularBuffer.h"
 #include "PerformanceEntryBuffer.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <optional>
 #include <unordered_map>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryCircularBuffer.h"
 #include "PerformanceEntryKeyedBuffer.h"
 #include "PerformanceEntryReporterListeners.h"

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntry.h"
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "PerformanceEntryBuffer.h"
 #include "PerformanceObserverRegistry.h"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserverRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <set>

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancetimeline")
 
+  s.dependency "React-cxxstableapi"
+
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -9,7 +9,6 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/hermes-interfaces.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/SchedulerPriorityUtils.h>
 #include <react/renderer/runtimescheduler/Task.h>
@@ -19,6 +18,8 @@
 #include "RuntimeSchedulerResizeObserverDelegate.h"
 
 namespace facebook::react {
+
+class PerformanceEntryReporter;
 
 using RuntimeSchedulerRenderingUpdate = std::function<void()>;
 using SurfaceId = int32_t;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -11,6 +11,7 @@
 #include <cxxreact/TraceSection.h>
 #include <jsinspector-modern/tracing/EventLoopReporter.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
 #include <react/utils/OnScopeExit.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -13,12 +13,16 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
+#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/LayoutEventEmitter.h>
 #include <react/renderer/uimanager/UIManager.h>
@@ -44,12 +48,14 @@ Scheduler::Scheduler(
 
   if (ReactNativeFeatureFlags::enableBridgelessArchitecture() &&
       ReactNativeFeatureFlags::cdpInteractionMetricsEnabled()) {
-    cdpMetricsReporter_.emplace(CdpMetricsReporter{runtimeExecutor_});
+    cdpMetricsReporter_ =
+        std::make_unique<CdpMetricsReporter>(runtimeExecutor_);
     performanceEntryReporter_->addEventListener(&*cdpMetricsReporter_);
   }
 
   if (ReactNativeFeatureFlags::perfIssuesEnabled()) {
-    cdpPerfIssuesReporter_.emplace(CdpPerfIssuesReporter{runtimeExecutor_});
+    cdpPerfIssuesReporter_ =
+        std::make_unique<CdpPerfIssuesReporter>(runtimeExecutor_);
     performanceEntryReporter_->addEventListener(&*cdpPerfIssuesReporter_);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -12,16 +12,12 @@
 #include <vector>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
-#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
-#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/scheduler/InspectorData.h>
 #include <react/renderer/scheduler/SchedulerDelegate.h>
 #include <react/renderer/scheduler/SchedulerToolbox.h>
@@ -33,6 +29,11 @@
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class CdpMetricsReporter;
+class CdpPerfIssuesReporter;
+class EventPerformanceLogger;
+class PerformanceEntryReporter;
 
 /*
  * Scheduler coordinates Shadow Tree updates and event flows.
@@ -145,8 +146,8 @@ class Scheduler final : public UIManagerDelegate {
   std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   std::shared_ptr<PerformanceEntryReporter> performanceEntryReporter_;
-  std::optional<CdpMetricsReporter> cdpMetricsReporter_;
-  std::optional<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
+  std::unique_ptr<CdpMetricsReporter> cdpMetricsReporter_;
+  std::unique_ptr<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
   std::shared_ptr<EventPerformanceLogger> eventPerformanceLogger_;
 
   /**

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -18,6 +18,7 @@
 #include <jsi/instrumentation.h>
 #include <jsinspector-modern/HostTarget.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/runtime/JSRuntimeBindings.h>
 #include <react/timing/primitives.h>


### PR DESCRIPTION
Summary:

Move private performance includes out of framework-facing scheduler headers and into their implementation files. Store the conditional CDP reporters behind unique pointers so their declarations can remain private implementation details.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D116621742


