### PR TITLE
Cover `react/nativemodule/defaults:defaults` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_nativemodule_defaults PUBLIC ${REACT_COMMON_DIR
 
 target_link_libraries(react_nativemodule_defaults
         react_codegen_rncore
+        react_cxxstableapi
         react_nativemodule_core
         react_nativemodule_dom
         react_nativemodule_devtoolsruntimesettings

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <ReactCommon/TurboModule.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -58,6 +58,7 @@ Pod::Spec.new do |s|
   s.dependency "React-viewtransitionnativemodule"
   s.dependency "React-webperformancenativemodule"
   s.dependency "React-Fabric/animated"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-featureflagsnativemodule")


### PR DESCRIPTION
Summary:
Classifies `react/nativemodule/defaults` as a private target under the three-tier C++ stable API visibility model. `DefaultTurboModules.h` now includes `<react/cxxstableapi/PrivateGuard.h>`, and the module picks up a dependency on the guard target so the include resolves for every build.

Changelog: [Internal]

Differential Revision: D116287984


