### PR TITLE
Cover `react/renderer/observers/intersection:intersection` with Stable API guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_renderer_observers_intersection PUBLIC ${REACT_
 target_link_libraries(react_renderer_observers_intersection
       react_cxxreact
       react_bridging
+      react_cxxstableapi
       react_debug
       react_renderer_core
       react_renderer_graphics

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 #include <optional>
 


### PR DESCRIPTION
Summary:
Classifies `react/renderer/observers/intersection:intersection` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to all three headers in the module and declares the guard dependency in BUCK and CMake. The module is a `React-Fabric` subspec, so the CocoaPods dependency is already on the parent spec.

Changelog: [Internal]

Differential Revision: D117315061


