### PR TITLE
Cover `react/renderer/observers/events:events` with Stable API guards (#58121)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(react_renderer_observers_events OBJECT ${react_renderer_observers_ev
 
 target_include_directories(react_renderer_observers_events PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_observers_events
+        react_cxxstableapi
         react_debug
         react_performance_timeline
         react_timing

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/core/EventLogger.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/observers/events:events` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's only exported header (`EventPerformanceLogger.h`), and wires the guard dependency into BUCK and CMake. On iOS the module ships as the `React-Fabric/observers/events` subspec, and the parent `React-Fabric` spec already depends on `React-cxxstableapi` from an earlier migration, so no podspec change is needed.

`Scheduler.h` is a "for frameworks" header that still includes `EventPerformanceLogger.h`, so the module is not cleanly private until that include is replaced with a forward declaration. That change is in review separately (D116909093) and can land in either order relative to this one, since the guards are inert on their own.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D117320589


