### PR TITLE
Cover `react/nativemodule/devtoolsruntimesettings` with Stable API guards (#58122)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_nativemodule_devtoolsruntimesettings PUBLIC ${R
 
 target_link_libraries(react_nativemodule_devtoolsruntimesettings
         devtoolsruntimesettings
+        react_cxxstableapi
 )
 target_compile_reactnative_options(react_nativemodule_devtoolsruntimesettings PRIVATE)
 target_compile_options(react_nativemodule_devtoolsruntimesettings PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <devtoolsruntimesettings/DevToolsRuntimeSettings.h>
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/devtoolsruntimesettings:devtoolsruntimesettings` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`DevToolsRuntimeSettingsModule.h`), and wires the guard dependency into BUCK and CMake.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117320628


