### PR TITLE
Cover `react/nativemodule/webperformance` with Stable API guards (#58123)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(react_nativemodule_webperformance
         react_performance_timeline
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
 )
 target_compile_reactnative_options(react_nativemodule_webperformance PRIVATE)
 target_compile_options(react_nativemodule_webperformance PRIVATE -Wpedantic -Wno-deprecated-declarations)

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("rncoreJSI.h") // Cmake headers on Android
 #include "rncoreJSI.h"
 #elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
@@ -53,6 +53,7 @@ Pod::Spec.new do |s|
 
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-bridging"
+  s.dependency "React-cxxstableapi"
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-performancetimeline")


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/webperformance:webperformance` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`NativePerformance.h`), and wires the guard dependency into BUCK, CMake, and the podspec.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Differential Revision: D117322371


