### PR TITLE
Cover the intersection observer modules with Stable API guards (#58125)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_nativemodule_intersectionobserver PUBLIC ${REAC
 target_link_libraries(react_nativemodule_intersectionobserver
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
         react_renderer_bridging
         react_renderer_core
         react_renderer_graphics

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Fabric"
   s.dependency "React-Fabric/bridging"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_renderer_observers_intersection PUBLIC ${REACT_
 target_link_libraries(react_renderer_observers_intersection
       react_cxxreact
       react_bridging
+      react_cxxstableapi
       react_debug
       react_renderer_core
       react_renderer_graphics

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 #include <optional>
 


### PR DESCRIPTION
Summary:

Classifies `react/renderer/observers/intersection:intersection` and `react/nativemodule/intersectionobserver:intersectionobserver` as private targets under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include their headers directly; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D117324071


