### PR TITLE
Cover the mutation observer modules with Stable API guards (#58126)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_nativemodule_mutationobserver PUBLIC ${REACT_CO
 
 target_link_libraries(react_nativemodule_mutationobserver
         react_codegen_rncore
+        react_cxxstableapi
         react_renderer_bridging
         react_renderer_core
         react_renderer_uimanager

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/React-mutationobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/React-mutationobservernativemodule.podspec
@@ -61,6 +61,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Fabric/bridging"
   s.dependency "React-Fabric/observers/mutation"
   s.dependency "React-featureflags"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_renderer_observers_mutation PUBLIC ${REACT_COMM
 
 target_link_libraries(react_renderer_observers_mutation
       react_cxxreact
+      react_cxxstableapi
       react_renderer_core
       react_renderer_uimanager
       react_renderer_mounting

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ShadowNodeFamily.h>

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/uimanager/UIManager.h>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/observers/mutation:mutation` and `react/nativemodule/mutationobserver:mutationobserver` as private targets under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include their headers directly; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D117326015


