### PR TITLE
Cover `react/nativemodule/dom` with Stable API guards (#58127)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(react_nativemodule_dom
 target_include_directories(react_nativemodule_dom PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_dom
+        react_cxxstableapi
         rrc_root
         react_codegen_rncore
         react_cxxreact

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string>
 
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -55,6 +55,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Fabric"
   s.dependency "React-Fabric/bridging"
   s.dependency "React-FabricComponents"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
   add_dependency(s, "React-RCTFBReactNativeSpec")


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/dom:dom` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`NativeDOM.h`), and wires the guard dependency into BUCK, CMake, and the podspec.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117326651


