### PR TITLE
Add pnpm-lock.yaml to default lock files in autolinkLibrariesFromCommand

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -51,7 +51,13 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
       lockFiles: FileCollection =
           settings.layout.rootDirectory
               .dir("../")
-              .files("yarn.lock", "package-lock.json", "package.json", "react-native.config.js"),
+              .files(
+                "yarn.lock",
+                "package-lock.json",
+                "package.json",
+                "react-native.config.js",
+                "pnpm-lock.yaml"
+              ),
   ) {
     outputFile.parentFile.mkdirs()
 


### PR DESCRIPTION
## Summary:

Android autolinking caches the output of `npx @react-native-community/cli config` so Gradle does not rerun it on every build. The cache is considered stale when certain files change, [currently only](https://github.com/react/react-native/blob/5b680c5f9fe5eae0f257939bd4a1fdbc543af419/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt#L51-L54) `yarn.lock`, `package-lock.json`, `package.json`, and `react-native.config.js` by default.

Notably, `pnpm-lock.yaml` is absent from that list, so a `pnpm install` that only touched the pnpm lockfile would keep using the old cache. Native libraries could be missing or stale until something else forced a refresh.

This PR adds `pnpm-lock.yaml` to the default list in `autolinkLibrariesFromCommand`:

```kotlin
.files(
  "yarn.lock",
  "package-lock.json",
  "package.json",
  "react-native.config.js",
  "pnpm-lock.yaml"
)
```

If a project already passes its own `lockFiles`, that override still wins, this only changes the default.

It appears that SwiftPM iOS is already checking `pnpm-lock.yaml` to determine staleness [here](https://github.com/react/react-native/blob/5b680c5f9fe5eae0f257939bd4a1fdbc543af419/packages/react-native/scripts/spm/generate-spm-xcodeproj.js#L707-L732), so this change just brings Android in line with that.

## Changelog:

[ANDROID] [FIXED] - Invalidate the Android autolinking cache when `pnpm-lock.yaml` changes

## Test Plan:

I didn't run `./gradlew test` as suggested [here](https://reactnative.dev/contributing/how-to-run-and-write-tests) because `settings.gradle.kts` in repo root [overrides](https://github.com/react/react-native/blob/5b680c5f9fe5eae0f257939bd4a1fdbc543af419/settings.gradle.kts#L41-L46) `lockFiles`,  so RNTester would not hit the new default anyway.

Ran the gradle-plugin unit tests:

```
yarn --cwd packages/gradle-plugin test
```

Output:

```
$ ./gradlew check

BUILD SUCCESSFUL in 2m 11s
22 actionable tasks: 7 executed, 15 up-to-date
Consider enabling configuration cache to speed up this build: https://docs.gradle.org/9.4.1/userguide/configuration_cache_enabling.html
✨  Done in 131.90s.
```