### PR TITLE
Enable RuntimeScheduler queue clearing on error by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74896623764d3d01d2925fdcf30948f1>>
+ * @generated SignedSource<<c7480fceb75a5f614abf28813c501a54>>
  */
 
 /**
@@ -109,7 +109,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableResizeObserverByDefault(): Boolean = false
 
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = false
+  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7103d9c2fa3e2f152ce60b5dff12c0e4>>
+ * @generated SignedSource<<29904c9a4e11c71f7657c49f3f45a32f>>
  */
 
 /**
@@ -24,8 +24,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // but that is more expensive than just duplicating the defaults here.
 
   override fun enableFlexboxAutoMinSizeInStrictMode(): Boolean = true
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = true
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcc09eb60ab85de9bc72410e93c2a1c>>
+ * @generated SignedSource<<374da5049c71e475cb3e5c2bfed87c9c>>
  */
 
 /**
@@ -200,7 +200,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return false;
+    return true;
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7341b28bb77aeeec670051149faeae04>>
+ * @generated SignedSource<<764568389a1ae8675638104ab3d96d4d>>
  */
 
 /**
@@ -28,10 +28,6 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
   bool enableFlexboxAutoMinSizeInStrictMode() override {
-    return true;
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -370,16 +370,19 @@ void RuntimeScheduler_Modern::updateRendering(
   // internally; this call site stays a single invocation per tick.
   if (resizeObserverDelegate_ != nullptr) {
     // This delivers the observations to JS synchronously, so it is outside the
-    // error boundary of `executeTask`. Handle errors the same way here, so a
-    // throwing observer callback can't abort the remaining steps below.
+    // error boundary of `executeTask`. Report the error without going through
+    // `handleTaskError`: we are already inside the "update the rendering" step,
+    // so clearing the queues here would drop the pending rendering updates this
+    // step is about to drain, and a throwing observer callback would abort the
+    // remaining steps below.
     try {
       resizeObserverDelegate_->runResizeObservations(runtime);
     } catch (jsi::JSError& error) {
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     } catch (std::exception& ex) {
       jsi::JSError error(
           runtime, std::string("Non-JS exception: ") + ex.what());
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -1826,6 +1826,8 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
     return;
   }
 
+  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
+
   StubResizeObserverDelegate resizeObserverDelegate;
   resizeObserverDelegate.onRunResizeObservations = [](jsi::Runtime& runtime) {
     throw jsi::JSError(runtime, "Test error");
@@ -1848,6 +1850,9 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
 
   // Delivering observations to JS synchronously happens outside the error
   // boundary of the task, so the step handles the error itself and carries on.
+  // In particular the error must not be routed through `handleTaskError`:
+  // that clears the pending rendering updates this same step is about to
+  // drain, and `didRunRenderingUpdate` below would be false.
   EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
   EXPECT_EQ(resizeObserverDelegate.callCount, 1);
   EXPECT_EQ(intersectionObserverDelegate.callCount, 1);

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -506,7 +506,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableRuntimeSchedulerQueueClearingOnError: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-05-19',
         description:
@@ -514,7 +514,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'experimental',
+      ossReleaseStage: 'none',
     },
     enableSchedulerDelegateInvalidation: {
       defaultValue: false,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fbab08ee89a2969b45034a45b6425581>>
+ * @generated SignedSource<<2adcae106ae1e758061a91ee20f902fd>>
  * @flow strict
  * @noformat
  */
@@ -387,7 +387,7 @@ export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGe
 /**
  * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
  */
-export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', false);
+export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', true);
 /**
  * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
  */


### PR DESCRIPTION
Summary:
The experiment for clearing the `RuntimeScheduler` queues before handling a task
error has run its course, so make the behaviour the default for everyone.

When a task throws, `RuntimeScheduler_Modern` now drops the pending task queue
and any pending rendering updates before invoking the host error handler. That
stops queued work from being executed against state the error handler is about
to tear down.

Turning this on for everyone exposed a bug in one of the call sites. A throwing
resize-observer callback was routed through `handleTaskError`, which clears the
queues - wrong inside the "update the rendering" step, because it drops the
pending rendering updates that same step is about to drain, so a throwing
observer callback aborts the remaining steps. That is exactly what the call
site's own comment says must not happen. That path now reports the error without
clearing. Queue clearing stays on the task-execution and microtask-checkpoint
paths, which are the ones that unwind before the rest of the tick runs.

The flag default flips to `true`, and the per-app runtime gates are removed so
every consumer picks up the default rather than an override.

Changelog:
[General][Changed] - `RuntimeScheduler` now clears pending tasks and rendering updates when a task throws

Differential Revision: D117322680


