### PR TITLE
Cover `devtoolsruntimesettings` with Stable API guards (#58131)

### DIFF
--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
@@ -13,5 +13,5 @@ add_library(devtoolsruntimesettings OBJECT ${devtoolsruntimesettings_SRCS})
 
 target_include_directories(devtoolsruntimesettings PUBLIC .)
 
-target_link_libraries(devtoolsruntimesettings jsi react_codegen_rncore)
+target_link_libraries(devtoolsruntimesettings jsi react_codegen_rncore react_cxxstableapi)
 target_compile_reactnative_options(devtoolsruntimesettings PRIVATE)

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.h
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:

Classifies `devtoolsruntimesettings:devtoolsruntimesettings` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`DevToolsRuntimeSettings.h`), and wires the guard dependency into BUCK and CMake.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117328566


