### PR TITLE
Remove enableRuntimeSchedulerQueueClearingOnError feature flag (#58132)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d5bab65a116d6f6d3415c5c8a2f08db9>>
+ * @generated SignedSource<<59766885e05931a728d63cec89fd6103>>
  */
 
 /**
@@ -287,12 +287,6 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableResizeObserverByDefault(): Boolean = accessor.enableResizeObserverByDefault()
-
-  /**
-   * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
-   */
-  @JvmStatic
-  public fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = accessor.enableRuntimeSchedulerQueueClearingOnError()
 
   /**
    * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<331c699ee09143bbb98a81857cb2659c>>
+ * @generated SignedSource<<f663e0e2ea5f17d06c68b306c039dda6>>
  */
 
 /**
@@ -63,7 +63,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
   private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
@@ -491,15 +490,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableResizeObserverByDefault()
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean {
-    var cached = enableRuntimeSchedulerQueueClearingOnErrorCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.enableRuntimeSchedulerQueueClearingOnError()
-      enableRuntimeSchedulerQueueClearingOnErrorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9cf60776cac41ff2ebb6a5e267343ca>>
+ * @generated SignedSource<<f1f3adfc52674ed54b41a95ada50664e>>
  */
 
 /**
@@ -113,8 +113,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip @JvmStatic public external fun enableRuntimeSchedulerQueueClearingOnError(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableSchedulerDelegateInvalidation(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74896623764d3d01d2925fdcf30948f1>>
+ * @generated SignedSource<<c7480fceb75a5f614abf28813c501a54>>
  */
 
 /**
@@ -109,7 +109,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableResizeObserverByDefault(): Boolean = false
 
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = false
+  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c7480fceb75a5f614abf28813c501a54>>
+ * @generated SignedSource<<e625acde9241c0577165b2248c5a35fe>>
  */
 
 /**
@@ -108,8 +108,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
 
   override fun enableResizeObserverByDefault(): Boolean = false
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e05552bb01ea7e80fde1c19b5199caa>>
+ * @generated SignedSource<<2365c1d552f84ca44c789ced558679f5>>
  */
 
 /**
@@ -67,7 +67,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
   private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
@@ -538,16 +537,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.enableResizeObserverByDefault()
       accessedFeatureFlags.add("enableResizeObserverByDefault")
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean {
-    var cached = enableRuntimeSchedulerQueueClearingOnErrorCache
-    if (cached == null) {
-      cached = currentProvider.enableRuntimeSchedulerQueueClearingOnError()
-      accessedFeatureFlags.add("enableRuntimeSchedulerQueueClearingOnError")
-      enableRuntimeSchedulerQueueClearingOnErrorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7103d9c2fa3e2f152ce60b5dff12c0e4>>
+ * @generated SignedSource<<29904c9a4e11c71f7657c49f3f45a32f>>
  */
 
 /**
@@ -24,8 +24,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // but that is more expensive than just duplicating the defaults here.
 
   override fun enableFlexboxAutoMinSizeInStrictMode(): Boolean = true
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<998a99e804cf713c8ce8adafa1b1b83b>>
+ * @generated SignedSource<<54381ab2e0b0d3c32451a00ee0a8be96>>
  */
 
 /**
@@ -108,8 +108,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip public fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip public fun enableRuntimeSchedulerQueueClearingOnError(): Boolean
 
   @DoNotStrip public fun enableSchedulerDelegateInvalidation(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7513432f85b9832654814f381b13fe97>>
+ * @generated SignedSource<<7216125910d143e4f0ae9af350687336>>
  */
 
 /**
@@ -294,12 +294,6 @@ class ReactNativeFeatureFlagsJavaProvider
   bool enableResizeObserverByDefault() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableResizeObserverByDefault");
-    return method(javaProvider_);
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableRuntimeSchedulerQueueClearingOnError");
     return method(javaProvider_);
   }
 
@@ -780,11 +774,6 @@ bool JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault(
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
 }
 
-bool JReactNativeFeatureFlagsCxxInterop::enableRuntimeSchedulerQueueClearingOnError(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError();
-}
-
 bool JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
@@ -1160,9 +1149,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableResizeObserverByDefault",
         JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault),
-      makeNativeMethod(
-        "enableRuntimeSchedulerQueueClearingOnError",
-        JReactNativeFeatureFlagsCxxInterop::enableRuntimeSchedulerQueueClearingOnError),
       makeNativeMethod(
         "enableSchedulerDelegateInvalidation",
         JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9689c541fa98ffbaf9f5d83077ab1208>>
+ * @generated SignedSource<<357799e6db7d4644f73a79845104b3d4>>
  */
 
 /**
@@ -157,9 +157,6 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableResizeObserverByDefault(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
-  static bool enableRuntimeSchedulerQueueClearingOnError(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableSchedulerDelegateInvalidation(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<acec83211036df307dd8711e96fcb80c>>
+ * @generated SignedSource<<1e69bcd6066ac1a47c1b4a20eb4eedd4>>
  */
 
 /**
@@ -196,10 +196,6 @@ bool ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid() {
 
 bool ReactNativeFeatureFlags::enableResizeObserverByDefault() {
   return getAccessor().enableResizeObserverByDefault();
-}
-
-bool ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError() {
-  return getAccessor().enableRuntimeSchedulerQueueClearingOnError();
 }
 
 bool ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e437a03ac130e2f24a857a64b3677490>>
+ * @generated SignedSource<<7c7d9b2eb64ecf6b5bd61ff0cc2bb70e>>
  */
 
 /**
@@ -253,11 +253,6 @@ class ReactNativeFeatureFlags {
    * Enables the ResizeObserver Web API in React Native.
    */
   RN_EXPORT static bool enableResizeObserverByDefault();
-
-  /**
-   * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
-   */
-  RN_EXPORT static bool enableRuntimeSchedulerQueueClearingOnError();
 
   /**
    * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c1a9ad1347a455ab5973df3231ac8cb4>>
+ * @generated SignedSource<<a0ff32dbae9b1ad79011b1c638637b8f>>
  */
 
 /**
@@ -803,24 +803,6 @@ bool ReactNativeFeatureFlagsAccessor::enableResizeObserverByDefault() {
   return flagValue.value();
 }
 
-bool ReactNativeFeatureFlagsAccessor::enableRuntimeSchedulerQueueClearingOnError() {
-  auto flagValue = enableRuntimeSchedulerQueueClearingOnError_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(43, "enableRuntimeSchedulerQueueClearingOnError");
-
-    flagValue = currentProvider_->enableRuntimeSchedulerQueueClearingOnError();
-    enableRuntimeSchedulerQueueClearingOnError_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
 bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
   auto flagValue = enableSchedulerDelegateInvalidation_.load();
 
@@ -830,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(44, "enableSchedulerDelegateInvalidation");
+    markFlagAsAccessed(43, "enableSchedulerDelegateInvalidation");
 
     flagValue = currentProvider_->enableSchedulerDelegateInvalidation();
     enableSchedulerDelegateInvalidation_ = flagValue;
@@ -848,7 +830,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSwiftUIBasedFilters() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(45, "enableSwiftUIBasedFilters");
+    markFlagAsAccessed(44, "enableSwiftUIBasedFilters");
 
     flagValue = currentProvider_->enableSwiftUIBasedFilters();
     enableSwiftUIBasedFilters_ = flagValue;
@@ -866,7 +848,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(46, "enableViewCulling");
+    markFlagAsAccessed(45, "enableViewCulling");
 
     flagValue = currentProvider_->enableViewCulling();
     enableViewCulling_ = flagValue;
@@ -884,7 +866,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(47, "enableViewRecycling");
+    markFlagAsAccessed(46, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -902,7 +884,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForImage() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(48, "enableViewRecyclingForImage");
+    markFlagAsAccessed(47, "enableViewRecyclingForImage");
 
     flagValue = currentProvider_->enableViewRecyclingForImage();
     enableViewRecyclingForImage_ = flagValue;
@@ -920,7 +902,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForScrollView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(49, "enableViewRecyclingForScrollView");
+    markFlagAsAccessed(48, "enableViewRecyclingForScrollView");
 
     flagValue = currentProvider_->enableViewRecyclingForScrollView();
     enableViewRecyclingForScrollView_ = flagValue;
@@ -938,7 +920,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(50, "enableViewRecyclingForText");
+    markFlagAsAccessed(49, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -956,7 +938,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(51, "enableViewRecyclingForView");
+    markFlagAsAccessed(50, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -974,7 +956,7 @@ bool ReactNativeFeatureFlagsAccessor::enableVirtualViewContainerStateExperimenta
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(52, "enableVirtualViewContainerStateExperimental");
+    markFlagAsAccessed(51, "enableVirtualViewContainerStateExperimental");
 
     flagValue = currentProvider_->enableVirtualViewContainerStateExperimental();
     enableVirtualViewContainerStateExperimental_ = flagValue;
@@ -992,7 +974,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorParentTagForUnflattenCase
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(53, "fixDifferentiatorParentTagForUnflattenCase");
+    markFlagAsAccessed(52, "fixDifferentiatorParentTagForUnflattenCase");
 
     flagValue = currentProvider_->fixDifferentiatorParentTagForUnflattenCase();
     fixDifferentiatorParentTagForUnflattenCase_ = flagValue;
@@ -1010,7 +992,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(54, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(53, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -1028,7 +1010,7 @@ bool ReactNativeFeatureFlagsAccessor::fixYogaFlexBasisFitContentInMainAxis() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(55, "fixYogaFlexBasisFitContentInMainAxis");
+    markFlagAsAccessed(54, "fixYogaFlexBasisFitContentInMainAxis");
 
     flagValue = currentProvider_->fixYogaFlexBasisFitContentInMainAxis();
     fixYogaFlexBasisFitContentInMainAxis_ = flagValue;
@@ -1046,7 +1028,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxAssertSingleHostState() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(56, "fuseboxAssertSingleHostState");
+    markFlagAsAccessed(55, "fuseboxAssertSingleHostState");
 
     flagValue = currentProvider_->fuseboxAssertSingleHostState();
     fuseboxAssertSingleHostState_ = flagValue;
@@ -1064,7 +1046,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(57, "fuseboxEnabledRelease");
+    markFlagAsAccessed(56, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -1082,7 +1064,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxFrameRecordingEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(58, "fuseboxFrameRecordingEnabled");
+    markFlagAsAccessed(57, "fuseboxFrameRecordingEnabled");
 
     flagValue = currentProvider_->fuseboxFrameRecordingEnabled();
     fuseboxFrameRecordingEnabled_ = flagValue;
@@ -1100,7 +1082,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(59, "fuseboxScreenshotCaptureEnabled");
+    markFlagAsAccessed(58, "fuseboxScreenshotCaptureEnabled");
 
     flagValue = currentProvider_->fuseboxScreenshotCaptureEnabled();
     fuseboxScreenshotCaptureEnabled_ = flagValue;
@@ -1118,7 +1100,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxWebSocketEventsEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(60, "fuseboxWebSocketEventsEnabled");
+    markFlagAsAccessed(59, "fuseboxWebSocketEventsEnabled");
 
     flagValue = currentProvider_->fuseboxWebSocketEventsEnabled();
     fuseboxWebSocketEventsEnabled_ = flagValue;
@@ -1136,7 +1118,7 @@ bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "optimizedAnimatedPropUpdates");
+    markFlagAsAccessed(60, "optimizedAnimatedPropUpdates");
 
     flagValue = currentProvider_->optimizedAnimatedPropUpdates();
     optimizedAnimatedPropUpdates_ = flagValue;
@@ -1154,7 +1136,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(61, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1172,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "perfIssuesEnabled");
+    markFlagAsAccessed(62, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1190,7 +1172,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "perfMonitorV2Enabled");
+    markFlagAsAccessed(63, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1208,7 +1190,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "preparedTextCacheSize");
+    markFlagAsAccessed(64, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1226,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(65, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1244,7 +1226,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "redBoxV2Android");
+    markFlagAsAccessed(66, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1262,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "redBoxV2IOS");
+    markFlagAsAccessed(67, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1280,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(68, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1298,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(69, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1316,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(70, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1334,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(71, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1352,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(72, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1370,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1388,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1406,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(75, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1424,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useFabricInterop");
+    markFlagAsAccessed(76, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1442,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(77, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1460,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(78, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1478,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useSharedAnimatedBackend");
+    markFlagAsAccessed(79, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1496,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(80, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1514,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useTurboModuleInterop");
+    markFlagAsAccessed(81, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1532,7 +1514,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewCullingOutsetRatio");
+    markFlagAsAccessed(82, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1550,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewTransitionEnabled");
+    markFlagAsAccessed(83, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1568,7 +1550,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(84, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1586,7 +1568,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(85, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c08fb696ba1dc5b90155163ca690f218>>
+ * @generated SignedSource<<6bfe194529e322fc98e43f6fe87cebeb>>
  */
 
 /**
@@ -75,7 +75,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool enablePreparedTextLayout();
   bool enablePropsUpdateReconciliationAndroid();
   bool enableResizeObserverByDefault();
-  bool enableRuntimeSchedulerQueueClearingOnError();
   bool enableSchedulerDelegateInvalidation();
   bool enableSwiftUIBasedFilters();
   bool enableViewCulling();
@@ -130,7 +129,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 86> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -175,7 +174,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enablePreparedTextLayout_;
   std::atomic<std::optional<bool>> enablePropsUpdateReconciliationAndroid_;
   std::atomic<std::optional<bool>> enableResizeObserverByDefault_;
-  std::atomic<std::optional<bool>> enableRuntimeSchedulerQueueClearingOnError_;
   std::atomic<std::optional<bool>> enableSchedulerDelegateInvalidation_;
   std::atomic<std::optional<bool>> enableSwiftUIBasedFilters_;
   std::atomic<std::optional<bool>> enableViewCulling_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcc09eb60ab85de9bc72410e93c2a1c>>
+ * @generated SignedSource<<374da5049c71e475cb3e5c2bfed87c9c>>
  */
 
 /**
@@ -200,7 +200,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return false;
+    return true;
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<374da5049c71e475cb3e5c2bfed87c9c>>
+ * @generated SignedSource<<bfdd2dff4688bcde04ece735f9635253>>
  */
 
 /**
@@ -197,10 +197,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool enableResizeObserverByDefault() override {
     return false;
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return true;
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<340aadae79b8e4f77daa915e9ab397a1>>
+ * @generated SignedSource<<30b0399ab09d2d273c465bfa950a5a15>>
  */
 
 /**
@@ -430,15 +430,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::enableResizeObserverByDefault();
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    auto value = values_["enableRuntimeSchedulerQueueClearingOnError"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::enableRuntimeSchedulerQueueClearingOnError();
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7341b28bb77aeeec670051149faeae04>>
+ * @generated SignedSource<<764568389a1ae8675638104ab3d96d4d>>
  */
 
 /**
@@ -28,10 +28,6 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
   bool enableFlexboxAutoMinSizeInStrictMode() override {
-    return true;
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<988feef999c2b900926fe5ba47fc313b>>
+ * @generated SignedSource<<7ebf2d5220215a3d02ce496257c7d3e0>>
  */
 
 /**
@@ -68,7 +68,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enablePreparedTextLayout() = 0;
   virtual bool enablePropsUpdateReconciliationAndroid() = 0;
   virtual bool enableResizeObserverByDefault() = 0;
-  virtual bool enableRuntimeSchedulerQueueClearingOnError() = 0;
   virtual bool enableSchedulerDelegateInvalidation() = 0;
   virtual bool enableSwiftUIBasedFilters() = 0;
   virtual bool enableViewCulling() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b67c8966cce4fef1d3478cd9f1afdbc0>>
+ * @generated SignedSource<<8bef73ce7833191807c05d34586612dd>>
  */
 
 /**
@@ -257,11 +257,6 @@ bool NativeReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid(
 bool NativeReactNativeFeatureFlags::enableResizeObserverByDefault(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
-}
-
-bool NativeReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError();
 }
 
 bool NativeReactNativeFeatureFlags::enableSchedulerDelegateInvalidation(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<40d25fafea07a23f9d4e146973c65cb5>>
+ * @generated SignedSource<<9e8d3d0a144ac859479d5ef5b1b12f2f>>
  */
 
 /**
@@ -123,8 +123,6 @@ class NativeReactNativeFeatureFlags
   bool enablePropsUpdateReconciliationAndroid(jsi::Runtime& runtime);
 
   bool enableResizeObserverByDefault(jsi::Runtime& runtime);
-
-  bool enableRuntimeSchedulerQueueClearingOnError(jsi::Runtime& runtime);
 
   bool enableSchedulerDelegateInvalidation(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -10,7 +10,6 @@
 #include <ReactCommon/RuntimeExecutorSyncUIThreadUtils.h>
 #include <cxxreact/TraceSection.h>
 #include <jsinspector-modern/tracing/EventLoopReporter.h>
-#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
 #include <react/utils/OnScopeExit.h>
@@ -498,9 +497,7 @@ void RuntimeScheduler_Modern::reportLongTasks(
 void RuntimeScheduler_Modern::handleTaskError(
     jsi::Runtime& runtime,
     jsi::JSError& error) {
-  if (ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError()) {
-    clearQueues();
-  }
+  clearQueues();
 
   onTaskError_(runtime, error);
 }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -370,16 +370,19 @@ void RuntimeScheduler_Modern::updateRendering(
   // internally; this call site stays a single invocation per tick.
   if (resizeObserverDelegate_ != nullptr) {
     // This delivers the observations to JS synchronously, so it is outside the
-    // error boundary of `executeTask`. Handle errors the same way here, so a
-    // throwing observer callback can't abort the remaining steps below.
+    // error boundary of `executeTask`. Report the error without going through
+    // `handleTaskError`: we are already inside the "update the rendering" step,
+    // so clearing the queues here would drop the pending rendering updates this
+    // step is about to drain, and a throwing observer callback would abort the
+    // remaining steps below.
     try {
       resizeObserverDelegate_->runResizeObservations(runtime);
     } catch (jsi::JSError& error) {
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     } catch (std::exception& ex) {
       jsi::JSError error(
           runtime, std::string("Non-JS exception: ") + ex.what());
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -34,24 +34,15 @@ using namespace std::chrono_literals;
 class RuntimeSchedulerTestFeatureFlags
     : public ReactNativeFeatureFlagsDefaults {
  public:
-  explicit RuntimeSchedulerTestFeatureFlags(
-      bool enableEventLoop,
-      bool enableRuntimeSchedulerQueueClearingOnError = false)
-      : enableEventLoop_(enableEventLoop),
-        enableRuntimeSchedulerQueueClearingOnError_(
-            enableRuntimeSchedulerQueueClearingOnError) {}
+  explicit RuntimeSchedulerTestFeatureFlags(bool enableEventLoop)
+      : enableEventLoop_(enableEventLoop) {}
 
   bool enableBridgelessArchitecture() override {
     return enableEventLoop_;
   }
 
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return enableRuntimeSchedulerQueueClearingOnError_;
-  }
-
  private:
   bool enableEventLoop_;
-  bool enableRuntimeSchedulerQueueClearingOnError_;
 };
 
 class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
@@ -97,12 +88,10 @@ class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
     ReactNativeFeatureFlags::dangerouslyReset();
   }
 
-  void setUpFeatureFlags(
-      bool enableRuntimeSchedulerQueueClearingOnError = false) {
+  void setUpFeatureFlags() {
     ReactNativeFeatureFlags::dangerouslyReset();
     ReactNativeFeatureFlags::override(
-        std::make_unique<RuntimeSchedulerTestFeatureFlags>(
-            GetParam(), enableRuntimeSchedulerQueueClearingOnError));
+        std::make_unique<RuntimeSchedulerTestFeatureFlags>(GetParam()));
   }
 
   jsi::Function createHostFunctionFromLambda(
@@ -924,8 +913,6 @@ TEST_P(RuntimeSchedulerTest, clearsQueuesOnError) {
   if (!GetParam()) {
     return;
   }
-
-  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
 
   bool didRunThrowingTask = false;
   bool didRunQueuedTask = false;
@@ -1825,8 +1812,6 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
   if (!GetParam()) {
     return;
   }
-
-  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
 
   StubResizeObserverDelegate resizeObserverDelegate;
   resizeObserverDelegate.onRunResizeObservations = [](jsi::Runtime& runtime) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -1826,6 +1826,8 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
     return;
   }
 
+  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
+
   StubResizeObserverDelegate resizeObserverDelegate;
   resizeObserverDelegate.onRunResizeObservations = [](jsi::Runtime& runtime) {
     throw jsi::JSError(runtime, "Test error");
@@ -1848,6 +1850,9 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
 
   // Delivering observations to JS synchronously happens outside the error
   // boundary of the task, so the step handles the error itself and carries on.
+  // In particular the error must not be routed through `handleTaskError`:
+  // that clears the pending rendering updates this same step is about to
+  // drain, and `didRunRenderingUpdate` below would be false.
   EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
   EXPECT_EQ(resizeObserverDelegate.callCount, 1);
   EXPECT_EQ(intersectionObserverDelegate.callCount, 1);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
@@ -198,9 +198,6 @@ class TestExecutorQueue {
 
 // Feature flags relevant to this test:
 //   - enableSchedulerDelegateInvalidation: the token guard under test.
-//   - enableRuntimeSchedulerQueueClearingOnError: a RuntimeScheduler_Modern
-//     fallback that drops queued work before host error handling tears down the
-//     delegate.
 //   - enableBridgelessArchitecture: forced ON so the Scheduler picks
 //     RuntimeScheduler_Modern. Modern queues rendering updates in
 //     pendingRenderingUpdates_ and drains them at end-of-tick, which is the
@@ -208,17 +205,10 @@ class TestExecutorQueue {
 //     scheduleRenderingUpdate inline, collapsing the window we want to test.
 class TestFeatureFlags : public ReactNativeFeatureFlagsDefaults {
  public:
-  explicit TestFeatureFlags(
-      bool guardEnabled,
-      bool queueClearingOnErrorEnabled = false)
-      : guardEnabled_(guardEnabled),
-        queueClearingOnErrorEnabled_(queueClearingOnErrorEnabled) {}
+  explicit TestFeatureFlags(bool guardEnabled) : guardEnabled_(guardEnabled) {}
 
   bool enableBridgelessArchitecture() override {
     return true;
-  }
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return queueClearingOnErrorEnabled_;
   }
   bool enableSchedulerDelegateInvalidation() override {
     return guardEnabled_;
@@ -226,7 +216,6 @@ class TestFeatureFlags : public ReactNativeFeatureFlagsDefaults {
 
  private:
   bool guardEnabled_;
-  bool queueClearingOnErrorEnabled_;
 };
 
 // Builds a ComponentRegistryFactory with just the descriptors needed for the
@@ -253,10 +242,9 @@ ComponentRegistryFactory makeComponentRegistryFactory() {
 // a real Scheduler and drive uiManagerDidFinishTransaction end-to-end.
 class SchedulerDelegateInvalidationTest : public ::testing::Test {
  protected:
-  void setUp(bool guardEnabled, bool queueClearingOnErrorEnabled = false) {
+  void setUp(bool guardEnabled) {
     ReactNativeFeatureFlags::override(
-        std::make_unique<TestFeatureFlags>(
-            guardEnabled, queueClearingOnErrorEnabled));
+        std::make_unique<TestFeatureFlags>(guardEnabled));
 
     runtime_ = facebook::hermes::makeHermesRuntime(
         ::hermes::vm::RuntimeConfig::Builder()
@@ -502,19 +490,17 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 3 — JS-throw-initiated teardown, guard DISABLED but runtime-scheduler
-// queue clearing ENABLED.
+// Test 3 — JS-throw-initiated teardown, guard DISABLED.
 //
 // Same cascade as Test 2 but with the scheduler invalidation guard OFF. The
 // runtime scheduler clears pendingRenderingUpdates_ before onTaskError tears
-// down the delegate, so the later tick has no stale delegate lambda to drain.
+// down the delegate, so the later tick has no stale delegate lambda to drain
+// even without the guard.
 // ---------------------------------------------------------------------------
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardDisabled_QueueClearingOnError_JSThrowInitiatedTeardownIsSafe) {
-  setUp(
-      /*guardEnabled=*/false,
-      /*queueClearingOnErrorEnabled=*/true);
+    GuardDisabled_JSThrowInitiatedTeardownIsSafe) {
+  setUp(/*guardEnabled=*/false);
 
   scheduler_->uiManagerDidFinishTransaction(
       coordinator_, /*mountSynchronously=*/false);
@@ -533,39 +519,35 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 4 — JS-throw-initiated teardown, guard DISABLED.
+// Test 4 — The window the guard still closes: a delegate dropped and
+// destroyed with no error involved.
 //
-// Same cascade as Test 2 but with the guard OFF. The previously-enqueued
-// lambda has no working token check, so when the rendering-update drain
-// runs after teardown it dereferences the destroyed delegate.
-//
-// EXPECT_DEATH catches the abort: either RecordingDelegate's magic-sentinel
-// ASSERT_EQ inside schedulerShouldRenderTransactions trips, or ASan reports
-// heap-use-after-free on the vptr load before our assertion runs.
+// Retargeted from a JS-throw trigger, which can no longer reach this race:
+// handleTaskError clears pendingRenderingUpdates_ before the host error
+// handler runs, so the queue is already empty by the time the delegate goes
+// away (Test 3). A plain setDelegate swap never reaches handleTaskError, so
+// with the guard OFF the lambda enqueued in (a) still holds a raw pointer to
+// freed memory when the queue drains in (c).
 // ---------------------------------------------------------------------------
 #if GTEST_HAS_DEATH_TEST
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardDisabled_JSThrowInitiatedTeardownIsUAF) {
+    GuardDisabled_DelegateDestroyedWithoutError_IsUAF) {
   EXPECT_DEATH(
       {
         setUp(/*guardEnabled=*/false);
 
-        // (a) Pre-throw transaction: lambda lands in
-        // pendingRenderingUpdates_.
+        // (a) Enqueue a rendering-update lambda capturing delegate_ raw.
         scheduler_->uiManagerDidFinishTransaction(
             coordinator_, /*mountSynchronously=*/false);
 
-        // (b) Uncaught JS throw → onTaskError → teardown drops the delegate.
-        // (c) Note: with guard DISABLED, setDelegate(nullptr) does NOT flip
-        // the invalidation token — Scheduler::setDelegate gates that branch
-        // on the feature flag — so the pending lambda has no signal that
-        // the delegate is going away.
-        scheduleJSThrowingTask();
-        executorQueue_->flush();
+        // (b) Host swaps the delegate out and destroys it. No JS throw, so
+        // nothing clears the rendering-update queue. With the guard ON,
+        // setDelegate would flip the invalidation token here.
+        scheduler_->setDelegate(nullptr);
+        delegate_.reset();
 
-        // (d) Drain the pending rendering update. The lambda dereferences
-        // the destroyed delegate → UAF.
+        // (c) Drain — the lambda dereferences the destroyed delegate.
         runOneEventLoopTick();
       },
       "");
@@ -605,34 +587,7 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 6 — Same race as Test 3, but enqueued via
-// Scheduler::uiManagerDidDispatchCommand. Guard OFF → lambda dereferences
-// the destroyed delegate → UAF caught by the magic sentinel inside
-// schedulerDidDispatchCommand or by ASan on the vptr load.
-// ---------------------------------------------------------------------------
-#if GTEST_HAS_DEATH_TEST
-TEST_F(
-    SchedulerDelegateInvalidationTest,
-    GuardDisabled_DispatchCommandLambda_JSThrowInitiatedTeardownIsUAF) {
-  EXPECT_DEATH(
-      {
-        setUp(/*guardEnabled=*/false);
-        ASSERT_NE(rootShadowNode_, nullptr);
-
-        scheduler_->uiManagerDidDispatchCommand(
-            rootShadowNode_, "scrollTo", folly::dynamic::array());
-
-        scheduleJSThrowingTask();
-        executorQueue_->flush();
-
-        runOneEventLoopTick();
-      },
-      "");
-}
-#endif
-
-// ---------------------------------------------------------------------------
-// Test 7 — Architectural assertion: surface-shutdown alone does NOT drain
+// Test 6 — Architectural assertion: surface-shutdown alone does NOT drain
 // pendingRenderingUpdates_ in RuntimeScheduler_Modern.
 //
 // This is the explicit refutation of the implicit reading "if the host just

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -506,7 +506,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableRuntimeSchedulerQueueClearingOnError: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-05-19',
         description:
@@ -514,7 +514,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'experimental',
+      ossReleaseStage: 'none',
     },
     enableSchedulerDelegateInvalidation: {
       defaultValue: false,

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -505,17 +505,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    enableRuntimeSchedulerQueueClearingOnError: {
-      defaultValue: true,
-      metadata: {
-        dateAdded: '2026-05-19',
-        description:
-          'When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     enableSchedulerDelegateInvalidation: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2adcae106ae1e758061a91ee20f902fd>>
+ * @generated SignedSource<<9bdc0e5397839b38c408db16dd2fffdc>>
  * @flow strict
  * @noformat
  */
@@ -92,7 +92,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   enablePreparedTextLayout: Getter<boolean>,
   enablePropsUpdateReconciliationAndroid: Getter<boolean>,
   enableResizeObserverByDefault: Getter<boolean>,
-  enableRuntimeSchedulerQueueClearingOnError: Getter<boolean>,
   enableSchedulerDelegateInvalidation: Getter<boolean>,
   enableSwiftUIBasedFilters: Getter<boolean>,
   enableViewCulling: Getter<boolean>,
@@ -384,10 +383,6 @@ export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNat
  * Enables the ResizeObserver Web API in React Native.
  */
 export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGetter('enableResizeObserverByDefault', false);
-/**
- * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
- */
-export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', true);
 /**
  * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fbab08ee89a2969b45034a45b6425581>>
+ * @generated SignedSource<<2adcae106ae1e758061a91ee20f902fd>>
  * @flow strict
  * @noformat
  */
@@ -387,7 +387,7 @@ export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGe
 /**
  * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
  */
-export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', false);
+export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', true);
 /**
  * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9b62a9e25b6088e25d9c39be7650a1d2>>
+ * @generated SignedSource<<f777c1ad56b2e5b38ddee06e327319c5>>
  * @flow strict
  * @noformat
  */
@@ -68,7 +68,6 @@ export interface Spec extends TurboModule {
   readonly enablePreparedTextLayout?: () => boolean;
   readonly enablePropsUpdateReconciliationAndroid?: () => boolean;
   readonly enableResizeObserverByDefault?: () => boolean;
-  readonly enableRuntimeSchedulerQueueClearingOnError?: () => boolean;
   readonly enableSchedulerDelegateInvalidation?: () => boolean;
   readonly enableSwiftUIBasedFilters?: () => boolean;
   readonly enableViewCulling?: () => boolean;


### PR DESCRIPTION
Summary:

Clearing the `RuntimeScheduler` queues before handling a task error is now the
default everywhere, so drop the flag and make the behaviour unconditional.

While removing the gate, one call site needed correcting. `updateRendering`
routed a throwing resize-observer callback through `handleTaskError`, which
clears the queues. That is wrong inside the "update the rendering" step: it
drops the pending rendering updates the step is about to drain, so a throwing
observer callback aborts the remaining steps - exactly what the call site's own
comment says must not happen. That path now reports the error without clearing.
Queue clearing stays on the task-execution and microtask-checkpoint paths, which
are the ones that unwind before the rest of the tick runs.

The two death tests in `SchedulerDelegateInvalidationTest` both reached the
use-after-free by way of an uncaught JS throw, which is now the very thing that
empties the queue before the delegate goes away - so they no longer die. Rather
than drop that coverage, one is retargeted to the trigger that still reaches the
race: a plain `setDelegate` swap followed by delegate destruction never runs
`handleTaskError`, so the queued lambda still dereferences freed memory. The
second was the same mechanism through the other lambda site and is dropped as
redundant; both sites keep their safe-path coverage.

Changelog: [Internal]

Differential Revision: D117324787
