### PR TITLE
Cover `jsiexecutor` with Stable API guards (#58133)

### DIFF
--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(jsireact PUBLIC .)
 
 target_link_libraries(jsireact
         react_cxxreact
+        react_cxxstableapi
         reactperflogger
         folly_runtime
         glog

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-jsitooling"
   s.dependency "React-perflogger"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <cxxreact/JSBigString.h>
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/RAMBundleRegistry.h>

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <memory>


### PR DESCRIPTION
Summary:

Classifies `jsiexecutor:jsiexecutor` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to both exported headers (`JSIExecutor.h` and `JSINativeModules.h`), and wires the guard dependency into BUCK, CMake and the podspec.

The podspec needs no `USE_FRAMEWORKS` header search path edit: it already sets `HEADER_SEARCH_PATHS` to `"$(PODS_TARGET_SRCROOT)/.."` unconditionally, and that resolves to `ReactCommon`.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D117330790


