### PR TITLE
Forward declare JSExecutorFactory in RCTAppSetupUtils (#58134)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -14,14 +14,14 @@
 #import <memory>
 
 #import <ReactCommon/RCTTurboModuleManager.h>
-#import <jsireact/JSIExecutor.h>
 
 @protocol RCTDependencyProvider;
 
 // Forward declaration to decrease compilation coupling
 namespace facebook::react {
+class JSExecutorFactory;
 class RuntimeScheduler;
-}
+} // namespace facebook::react
 RCT_EXTERN NSArray<NSString *> *RCTAppSetupUnstableModulesRequiringMainQueueSetup(
     id<RCTDependencyProvider> dependencyProvider);
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -7,6 +7,7 @@
 
 #import "RCTAppSetupUtils.h"
 
+#import <cxxreact/JSExecutor.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 


### PR DESCRIPTION
Summary:

`RCTAppSetupUtils.h` is a public header - every app's AppDelegate imports it as `<React/RCTAppSetupUtils.h>` - but it imported `<jsireact/JSIExecutor.h>` while naming nothing from it. The only symbol it needs out of that include chain is `JSExecutorFactory`, the return type of `RCTAppSetupDefaultJsExecutorFactory`, which is declared in `<cxxreact/JSExecutor.h>`.

Both `jsiexecutor:jsiexecutor` and `cxxreact:bridge` are private targets under the three-tier C++ stable API visibility model. The type is forward declared alongside the existing `RuntimeScheduler` forward declaration - `std::unique_ptr<T>` needs only an incomplete type in a declaration - and `<cxxreact/JSExecutor.h>` moves to the implementation file.

Code that relied on reaching `JSIExecutor` or `JSExecutorFactory` through this header should import `<jsireact/JSIExecutor.h>` or `<cxxreact/JSExecutor.h>` directly.

Changelog:
[iOS][Changed] - `RCTAppSetupUtils.h` no longer transitively imports `JSIExecutor.h` or `JSExecutor.h`

Differential Revision: D117330792


