### PR TITLE
Forward declare CDP reporters and ViewTransitionModule in Scheduler.h (#58136)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -13,6 +13,8 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
+#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
@@ -23,6 +25,7 @@
 #include <react/renderer/uimanager/LayoutEventEmitter.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/viewtransition/ViewTransitionModule.h>
 #include <mutex>
 
 namespace facebook::react {
@@ -43,13 +46,15 @@ Scheduler::Scheduler(
 
   if (ReactNativeFeatureFlags::enableBridgelessArchitecture() &&
       ReactNativeFeatureFlags::cdpInteractionMetricsEnabled()) {
-    cdpMetricsReporter_.emplace(CdpMetricsReporter{runtimeExecutor_});
-    performanceEntryReporter_->addEventListener(&*cdpMetricsReporter_);
+    cdpMetricsReporter_ =
+        std::make_unique<CdpMetricsReporter>(runtimeExecutor_);
+    performanceEntryReporter_->addEventListener(cdpMetricsReporter_.get());
   }
 
   if (ReactNativeFeatureFlags::perfIssuesEnabled()) {
-    cdpPerfIssuesReporter_.emplace(CdpPerfIssuesReporter{runtimeExecutor_});
-    performanceEntryReporter_->addEventListener(&*cdpPerfIssuesReporter_);
+    cdpPerfIssuesReporter_ =
+        std::make_unique<CdpPerfIssuesReporter>(runtimeExecutor_);
+    performanceEntryReporter_->addEventListener(cdpPerfIssuesReporter_.get());
   }
 
   eventPerformanceLogger_ =
@@ -206,10 +211,11 @@ Scheduler::~Scheduler() {
   uiManager_->setViewTransitionDelegate(nullptr);
 
   if (cdpMetricsReporter_) {
-    performanceEntryReporter_->removeEventListener(&*cdpMetricsReporter_);
+    performanceEntryReporter_->removeEventListener(cdpMetricsReporter_.get());
   }
   if (cdpPerfIssuesReporter_) {
-    performanceEntryReporter_->removeEventListener(&*cdpPerfIssuesReporter_);
+    performanceEntryReporter_->removeEventListener(
+        cdpPerfIssuesReporter_.get());
   }
 
   // Then, let's verify that the requirement was satisfied.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -11,11 +11,11 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
+#include <shared_mutex>
 #include <vector>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
-#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -31,10 +31,13 @@
 #include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/UIManagerDelegate.h>
-#include <react/renderer/viewtransition/ViewTransitionModule.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class CdpMetricsReporter;
+class CdpPerfIssuesReporter;
+class ViewTransitionModule;
 
 /*
  * Scheduler coordinates Shadow Tree updates and event flows.
@@ -142,8 +145,8 @@ class Scheduler final : public UIManagerDelegate {
   std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   std::shared_ptr<PerformanceEntryReporter> performanceEntryReporter_;
-  std::optional<CdpMetricsReporter> cdpMetricsReporter_;
-  std::optional<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
+  std::unique_ptr<CdpMetricsReporter> cdpMetricsReporter_;
+  std::unique_ptr<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
   std::shared_ptr<EventPerformanceLogger> eventPerformanceLogger_;
 
   /**


### PR DESCRIPTION
Summary:

Under the C++ Stable API RFC, `react/renderer/scheduler:scheduler` is a "for frameworks" module while `react/performance/cdpmetrics:cdpmetrics` and `react/renderer/viewtransition:viewtransition` are private. `Scheduler.h` is an exported header of the scheduler target and included all three private headers, so it transitively exposed them to consumers. `ViewTransitionModule.h` already carries the private-tier guard, so this was an active violation and not just a latent one.

`Scheduler.h` only needs these types for data members. `viewTransitionModule_` was already a `std::shared_ptr`, so a forward declaration is sufficient. The two CDP reporters were held as `std::optional`, which requires a complete type, so they become `std::unique_ptr`. They are constructed conditionally behind feature flags and only ever handed to `PerformanceEntryReporter` as raw pointers, so ownership and lifetime are unchanged. `~Scheduler()` is already out of line, so the incomplete types are fine.

`<optional>` and `<shared_mutex>` are now included explicitly, since they were previously pulled in transitively through the cdpmetrics headers.

`Scheduler.h` is the only header in ReactCommon that reached either module, so both are now cleanly private. No build config change is needed: `cdpmetrics` and `viewtransition` are already non-exported deps of the scheduler target.

Changelog: [Internal]

Differential Revision: D116909092


