### PR TITLE
Remove remaining private includes from scheduler headers (#58137)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -13,6 +13,8 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
+#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
@@ -23,6 +25,7 @@
 #include <react/renderer/uimanager/LayoutEventEmitter.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/viewtransition/ViewTransitionModule.h>
 #include <mutex>
 
 namespace facebook::react {
@@ -43,13 +46,15 @@ Scheduler::Scheduler(
 
   if (ReactNativeFeatureFlags::enableBridgelessArchitecture() &&
       ReactNativeFeatureFlags::cdpInteractionMetricsEnabled()) {
-    cdpMetricsReporter_.emplace(CdpMetricsReporter{runtimeExecutor_});
-    performanceEntryReporter_->addEventListener(&*cdpMetricsReporter_);
+    cdpMetricsReporter_ =
+        std::make_unique<CdpMetricsReporter>(runtimeExecutor_);
+    performanceEntryReporter_->addEventListener(cdpMetricsReporter_.get());
   }
 
   if (ReactNativeFeatureFlags::perfIssuesEnabled()) {
-    cdpPerfIssuesReporter_.emplace(CdpPerfIssuesReporter{runtimeExecutor_});
-    performanceEntryReporter_->addEventListener(&*cdpPerfIssuesReporter_);
+    cdpPerfIssuesReporter_ =
+        std::make_unique<CdpPerfIssuesReporter>(runtimeExecutor_);
+    performanceEntryReporter_->addEventListener(cdpPerfIssuesReporter_.get());
   }
 
   eventPerformanceLogger_ =
@@ -206,10 +211,11 @@ Scheduler::~Scheduler() {
   uiManager_->setViewTransitionDelegate(nullptr);
 
   if (cdpMetricsReporter_) {
-    performanceEntryReporter_->removeEventListener(&*cdpMetricsReporter_);
+    performanceEntryReporter_->removeEventListener(cdpMetricsReporter_.get());
   }
   if (cdpPerfIssuesReporter_) {
-    performanceEntryReporter_->removeEventListener(&*cdpPerfIssuesReporter_);
+    performanceEntryReporter_->removeEventListener(
+        cdpPerfIssuesReporter_.get());
   }
 
   // Then, let's verify that the requirement was satisfied.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -15,12 +15,14 @@
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/performance/cdpmetrics/CdpMetricsReporter.h>
 #include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/LayoutEventEmitter.h>
 #include <react/renderer/uimanager/UIManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -11,11 +11,11 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
+#include <shared_mutex>
 #include <vector>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
-#include <react/performance/cdpmetrics/CdpPerfIssuesReporter.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -31,10 +31,13 @@
 #include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/UIManagerDelegate.h>
-#include <react/renderer/viewtransition/ViewTransitionModule.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class CdpMetricsReporter;
+class CdpPerfIssuesReporter;
+class ViewTransitionModule;
 
 /*
  * Scheduler coordinates Shadow Tree updates and event flows.
@@ -142,8 +145,8 @@ class Scheduler final : public UIManagerDelegate {
   std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   std::shared_ptr<PerformanceEntryReporter> performanceEntryReporter_;
-  std::optional<CdpMetricsReporter> cdpMetricsReporter_;
-  std::optional<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
+  std::unique_ptr<CdpMetricsReporter> cdpMetricsReporter_;
+  std::unique_ptr<CdpPerfIssuesReporter> cdpPerfIssuesReporter_;
   std::shared_ptr<EventPerformanceLogger> eventPerformanceLogger_;
 
   /**

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -16,14 +16,12 @@
 #include <vector>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/EventListener.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
-#include <react/renderer/observers/events/EventPerformanceLogger.h>
 #include <react/renderer/scheduler/InspectorData.h>
 #include <react/renderer/scheduler/SchedulerDelegate.h>
 #include <react/renderer/scheduler/SchedulerToolbox.h>
@@ -37,6 +35,8 @@ namespace facebook::react {
 
 class CdpMetricsReporter;
 class CdpPerfIssuesReporter;
+class EventPerformanceLogger;
+class PerformanceEntryReporter;
 class ViewTransitionModule;
 
 /*

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -15,7 +15,6 @@
 #include <react/renderer/animationbackend/AnimationChoreographer.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/EventBeat.h>
-#include <react/renderer/leakchecker/LeakChecker.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/renderer/uimanager/primitives.h>
 #include <react/utils/ContextContainer.h>


### PR DESCRIPTION
Summary:

Under the C++ Stable API RFC, `react/renderer/scheduler:scheduler` is a "for frameworks" module, but its exported headers still reached two private modules:

- `Scheduler.h` included `react/performance/timeline/PerformanceEntryReporter.h` and `react/renderer/observers/events/EventPerformanceLogger.h`. Both are only used as `std::shared_ptr` data members, so forward declarations are sufficient and the includes move to `Scheduler.cpp`.
- `SchedulerToolbox.h` included `react/renderer/leakchecker/LeakChecker.h` but never named anything from it. `leakchecker` is not even a dependency of the scheduler target, so the include is dead and is simply removed.

`react/renderer/observers/events:events` had no other header-level consumer in ReactCommon, so it is now cleanly private. `react/performance/timeline:timeline` is still reached from `RuntimeScheduler.h` and `NativePerformance.h`, which are handled separately.

After this, no scheduler header includes a private module directly.

Changelog: [Internal]

Differential Revision: D116909093


