### PR TITLE
Remove enableSchedulerDelegateInvalidation feature flag and guard

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<59766885e05931a728d63cec89fd6103>>
+ * @generated SignedSource<<ffaf7abad8f9b217cc16e28ee9270b40>>
  */
 
 /**
@@ -287,12 +287,6 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableResizeObserverByDefault(): Boolean = accessor.enableResizeObserverByDefault()
-
-  /**
-   * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
-   */
-  @JvmStatic
-  public fun enableSchedulerDelegateInvalidation(): Boolean = accessor.enableSchedulerDelegateInvalidation()
 
   /**
    * When enabled, it will use SwiftUI for filter effects like blur on iOS.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d5bab65a116d6f6d3415c5c8a2f08db9>>
+ * @generated SignedSource<<59766885e05931a728d63cec89fd6103>>
  */
 
 /**
@@ -287,12 +287,6 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableResizeObserverByDefault(): Boolean = accessor.enableResizeObserverByDefault()
-
-  /**
-   * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
-   */
-  @JvmStatic
-  public fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = accessor.enableRuntimeSchedulerQueueClearingOnError()
 
   /**
    * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f663e0e2ea5f17d06c68b306c039dda6>>
+ * @generated SignedSource<<0bfeba3d07af6fade47b24974a80a592>>
  */
 
 /**
@@ -63,7 +63,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
   private var enableViewRecyclingCache: Boolean? = null
@@ -490,15 +489,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableResizeObserverByDefault()
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableSchedulerDelegateInvalidation(): Boolean {
-    var cached = enableSchedulerDelegateInvalidationCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.enableSchedulerDelegateInvalidation()
-      enableSchedulerDelegateInvalidationCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<331c699ee09143bbb98a81857cb2659c>>
+ * @generated SignedSource<<f663e0e2ea5f17d06c68b306c039dda6>>
  */
 
 /**
@@ -63,7 +63,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
   private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
@@ -491,15 +490,6 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableResizeObserverByDefault()
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean {
-    var cached = enableRuntimeSchedulerQueueClearingOnErrorCache
-    if (cached == null) {
-      cached = ReactNativeFeatureFlagsCxxInterop.enableRuntimeSchedulerQueueClearingOnError()
-      enableRuntimeSchedulerQueueClearingOnErrorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a9cf60776cac41ff2ebb6a5e267343ca>>
+ * @generated SignedSource<<f1f3adfc52674ed54b41a95ada50664e>>
  */
 
 /**
@@ -113,8 +113,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip @JvmStatic public external fun enableRuntimeSchedulerQueueClearingOnError(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableSchedulerDelegateInvalidation(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f1f3adfc52674ed54b41a95ada50664e>>
+ * @generated SignedSource<<b79fbf8335bf2b480743c3cd93d4e6bd>>
  */
 
 /**
@@ -113,8 +113,6 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip @JvmStatic public external fun enableSchedulerDelegateInvalidation(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableSwiftUIBasedFilters(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e625acde9241c0577165b2248c5a35fe>>
+ * @generated SignedSource<<bc2a060e5718ae7afd6d22199c8e9d38>>
  */
 
 /**
@@ -108,8 +108,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
 
   override fun enableResizeObserverByDefault(): Boolean = false
-
-  override fun enableSchedulerDelegateInvalidation(): Boolean = false
 
   override fun enableSwiftUIBasedFilters(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<74896623764d3d01d2925fdcf30948f1>>
+ * @generated SignedSource<<c7480fceb75a5f614abf28813c501a54>>
  */
 
 /**
@@ -109,7 +109,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableResizeObserverByDefault(): Boolean = false
 
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = false
+  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c7480fceb75a5f614abf28813c501a54>>
+ * @generated SignedSource<<e625acde9241c0577165b2248c5a35fe>>
  */
 
 /**
@@ -108,8 +108,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
 
   override fun enableResizeObserverByDefault(): Boolean = false
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2365c1d552f84ca44c789ced558679f5>>
+ * @generated SignedSource<<3605df96fad767e3ec3957d7305ef926>>
  */
 
 /**
@@ -67,7 +67,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
   private var enableViewRecyclingCache: Boolean? = null
@@ -537,16 +536,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.enableResizeObserverByDefault()
       accessedFeatureFlags.add("enableResizeObserverByDefault")
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableSchedulerDelegateInvalidation(): Boolean {
-    var cached = enableSchedulerDelegateInvalidationCache
-    if (cached == null) {
-      cached = currentProvider.enableSchedulerDelegateInvalidation()
-      accessedFeatureFlags.add("enableSchedulerDelegateInvalidation")
-      enableSchedulerDelegateInvalidationCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e05552bb01ea7e80fde1c19b5199caa>>
+ * @generated SignedSource<<2365c1d552f84ca44c789ced558679f5>>
  */
 
 /**
@@ -67,7 +67,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enablePreparedTextLayoutCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
   private var enableResizeObserverByDefaultCache: Boolean? = null
-  private var enableRuntimeSchedulerQueueClearingOnErrorCache: Boolean? = null
   private var enableSchedulerDelegateInvalidationCache: Boolean? = null
   private var enableSwiftUIBasedFiltersCache: Boolean? = null
   private var enableViewCullingCache: Boolean? = null
@@ -538,16 +537,6 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.enableResizeObserverByDefault()
       accessedFeatureFlags.add("enableResizeObserverByDefault")
       enableResizeObserverByDefaultCache = cached
-    }
-    return cached
-  }
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean {
-    var cached = enableRuntimeSchedulerQueueClearingOnErrorCache
-    if (cached == null) {
-      cached = currentProvider.enableRuntimeSchedulerQueueClearingOnError()
-      accessedFeatureFlags.add("enableRuntimeSchedulerQueueClearingOnError")
-      enableRuntimeSchedulerQueueClearingOnErrorCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<29904c9a4e11c71f7657c49f3f45a32f>>
+ * @generated SignedSource<<bad3dbaf92a0a869dfb91523ef4904f9>>
  */
 
 /**
@@ -24,8 +24,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // but that is more expensive than just duplicating the defaults here.
 
   override fun enableFlexboxAutoMinSizeInStrictMode(): Boolean = true
-
-  override fun enableSchedulerDelegateInvalidation(): Boolean = true
 
   override fun preventShadowTreeCommitExhaustion(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7103d9c2fa3e2f152ce60b5dff12c0e4>>
+ * @generated SignedSource<<29904c9a4e11c71f7657c49f3f45a32f>>
  */
 
 /**
@@ -24,8 +24,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // but that is more expensive than just duplicating the defaults here.
 
   override fun enableFlexboxAutoMinSizeInStrictMode(): Boolean = true
-
-  override fun enableRuntimeSchedulerQueueClearingOnError(): Boolean = true
 
   override fun enableSchedulerDelegateInvalidation(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<998a99e804cf713c8ce8adafa1b1b83b>>
+ * @generated SignedSource<<54381ab2e0b0d3c32451a00ee0a8be96>>
  */
 
 /**
@@ -108,8 +108,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip public fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip public fun enableRuntimeSchedulerQueueClearingOnError(): Boolean
 
   @DoNotStrip public fun enableSchedulerDelegateInvalidation(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<54381ab2e0b0d3c32451a00ee0a8be96>>
+ * @generated SignedSource<<100e31bd98a30aba4abef10f168638fc>>
  */
 
 /**
@@ -108,8 +108,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enablePropsUpdateReconciliationAndroid(): Boolean
 
   @DoNotStrip public fun enableResizeObserverByDefault(): Boolean
-
-  @DoNotStrip public fun enableSchedulerDelegateInvalidation(): Boolean
 
   @DoNotStrip public fun enableSwiftUIBasedFilters(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7216125910d143e4f0ae9af350687336>>
+ * @generated SignedSource<<ce8ba846a2e567547c4ba7370b9f4e89>>
  */
 
 /**
@@ -294,12 +294,6 @@ class ReactNativeFeatureFlagsJavaProvider
   bool enableResizeObserverByDefault() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableResizeObserverByDefault");
-    return method(javaProvider_);
-  }
-
-  bool enableSchedulerDelegateInvalidation() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableSchedulerDelegateInvalidation");
     return method(javaProvider_);
   }
 
@@ -774,11 +768,6 @@ bool JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault(
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
 }
 
-bool JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
-}
-
 bool JReactNativeFeatureFlagsCxxInterop::enableSwiftUIBasedFilters(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableSwiftUIBasedFilters();
@@ -1149,9 +1138,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableResizeObserverByDefault",
         JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault),
-      makeNativeMethod(
-        "enableSchedulerDelegateInvalidation",
-        JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation),
       makeNativeMethod(
         "enableSwiftUIBasedFilters",
         JReactNativeFeatureFlagsCxxInterop::enableSwiftUIBasedFilters),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7513432f85b9832654814f381b13fe97>>
+ * @generated SignedSource<<7216125910d143e4f0ae9af350687336>>
  */
 
 /**
@@ -294,12 +294,6 @@ class ReactNativeFeatureFlagsJavaProvider
   bool enableResizeObserverByDefault() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableResizeObserverByDefault");
-    return method(javaProvider_);
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableRuntimeSchedulerQueueClearingOnError");
     return method(javaProvider_);
   }
 
@@ -780,11 +774,6 @@ bool JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault(
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
 }
 
-bool JReactNativeFeatureFlagsCxxInterop::enableRuntimeSchedulerQueueClearingOnError(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
-  return ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError();
-}
-
 bool JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
@@ -1160,9 +1149,6 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableResizeObserverByDefault",
         JReactNativeFeatureFlagsCxxInterop::enableResizeObserverByDefault),
-      makeNativeMethod(
-        "enableRuntimeSchedulerQueueClearingOnError",
-        JReactNativeFeatureFlagsCxxInterop::enableRuntimeSchedulerQueueClearingOnError),
       makeNativeMethod(
         "enableSchedulerDelegateInvalidation",
         JReactNativeFeatureFlagsCxxInterop::enableSchedulerDelegateInvalidation),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9689c541fa98ffbaf9f5d83077ab1208>>
+ * @generated SignedSource<<357799e6db7d4644f73a79845104b3d4>>
  */
 
 /**
@@ -157,9 +157,6 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableResizeObserverByDefault(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
-  static bool enableRuntimeSchedulerQueueClearingOnError(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableSchedulerDelegateInvalidation(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<357799e6db7d4644f73a79845104b3d4>>
+ * @generated SignedSource<<145b12c4a208db86c7bfdfed56cf433f>>
  */
 
 /**
@@ -157,9 +157,6 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableResizeObserverByDefault(
-    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
-
-  static bool enableSchedulerDelegateInvalidation(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableSwiftUIBasedFilters(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1e69bcd6066ac1a47c1b4a20eb4eedd4>>
+ * @generated SignedSource<<9c1052fdfafd3f0ef6bcdaa740cf25ec>>
  */
 
 /**
@@ -196,10 +196,6 @@ bool ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid() {
 
 bool ReactNativeFeatureFlags::enableResizeObserverByDefault() {
   return getAccessor().enableResizeObserverByDefault();
-}
-
-bool ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation() {
-  return getAccessor().enableSchedulerDelegateInvalidation();
 }
 
 bool ReactNativeFeatureFlags::enableSwiftUIBasedFilters() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<acec83211036df307dd8711e96fcb80c>>
+ * @generated SignedSource<<1e69bcd6066ac1a47c1b4a20eb4eedd4>>
  */
 
 /**
@@ -196,10 +196,6 @@ bool ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid() {
 
 bool ReactNativeFeatureFlags::enableResizeObserverByDefault() {
   return getAccessor().enableResizeObserverByDefault();
-}
-
-bool ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError() {
-  return getAccessor().enableRuntimeSchedulerQueueClearingOnError();
 }
 
 bool ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e437a03ac130e2f24a857a64b3677490>>
+ * @generated SignedSource<<7c7d9b2eb64ecf6b5bd61ff0cc2bb70e>>
  */
 
 /**
@@ -253,11 +253,6 @@ class ReactNativeFeatureFlags {
    * Enables the ResizeObserver Web API in React Native.
    */
   RN_EXPORT static bool enableResizeObserverByDefault();
-
-  /**
-   * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
-   */
-  RN_EXPORT static bool enableRuntimeSchedulerQueueClearingOnError();
 
   /**
    * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7c7d9b2eb64ecf6b5bd61ff0cc2bb70e>>
+ * @generated SignedSource<<2d59cf5ea42847d6174fc433ba5a6fe4>>
  */
 
 /**
@@ -253,11 +253,6 @@ class ReactNativeFeatureFlags {
    * Enables the ResizeObserver Web API in React Native.
    */
   RN_EXPORT static bool enableResizeObserverByDefault();
-
-  /**
-   * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
-   */
-  RN_EXPORT static bool enableSchedulerDelegateInvalidation();
 
   /**
    * When enabled, it will use SwiftUI for filter effects like blur on iOS.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a0ff32dbae9b1ad79011b1c638637b8f>>
+ * @generated SignedSource<<58600d43eecb5c6593a0edbac4f13ac6>>
  */
 
 /**
@@ -803,24 +803,6 @@ bool ReactNativeFeatureFlagsAccessor::enableResizeObserverByDefault() {
   return flagValue.value();
 }
 
-bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
-  auto flagValue = enableSchedulerDelegateInvalidation_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(43, "enableSchedulerDelegateInvalidation");
-
-    flagValue = currentProvider_->enableSchedulerDelegateInvalidation();
-    enableSchedulerDelegateInvalidation_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
 bool ReactNativeFeatureFlagsAccessor::enableSwiftUIBasedFilters() {
   auto flagValue = enableSwiftUIBasedFilters_.load();
 
@@ -830,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSwiftUIBasedFilters() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(44, "enableSwiftUIBasedFilters");
+    markFlagAsAccessed(43, "enableSwiftUIBasedFilters");
 
     flagValue = currentProvider_->enableSwiftUIBasedFilters();
     enableSwiftUIBasedFilters_ = flagValue;
@@ -848,7 +830,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(45, "enableViewCulling");
+    markFlagAsAccessed(44, "enableViewCulling");
 
     flagValue = currentProvider_->enableViewCulling();
     enableViewCulling_ = flagValue;
@@ -866,7 +848,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(46, "enableViewRecycling");
+    markFlagAsAccessed(45, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -884,7 +866,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForImage() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(47, "enableViewRecyclingForImage");
+    markFlagAsAccessed(46, "enableViewRecyclingForImage");
 
     flagValue = currentProvider_->enableViewRecyclingForImage();
     enableViewRecyclingForImage_ = flagValue;
@@ -902,7 +884,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForScrollView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(48, "enableViewRecyclingForScrollView");
+    markFlagAsAccessed(47, "enableViewRecyclingForScrollView");
 
     flagValue = currentProvider_->enableViewRecyclingForScrollView();
     enableViewRecyclingForScrollView_ = flagValue;
@@ -920,7 +902,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(49, "enableViewRecyclingForText");
+    markFlagAsAccessed(48, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -938,7 +920,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(50, "enableViewRecyclingForView");
+    markFlagAsAccessed(49, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -956,7 +938,7 @@ bool ReactNativeFeatureFlagsAccessor::enableVirtualViewContainerStateExperimenta
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(51, "enableVirtualViewContainerStateExperimental");
+    markFlagAsAccessed(50, "enableVirtualViewContainerStateExperimental");
 
     flagValue = currentProvider_->enableVirtualViewContainerStateExperimental();
     enableVirtualViewContainerStateExperimental_ = flagValue;
@@ -974,7 +956,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorParentTagForUnflattenCase
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(52, "fixDifferentiatorParentTagForUnflattenCase");
+    markFlagAsAccessed(51, "fixDifferentiatorParentTagForUnflattenCase");
 
     flagValue = currentProvider_->fixDifferentiatorParentTagForUnflattenCase();
     fixDifferentiatorParentTagForUnflattenCase_ = flagValue;
@@ -992,7 +974,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(53, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(52, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -1010,7 +992,7 @@ bool ReactNativeFeatureFlagsAccessor::fixYogaFlexBasisFitContentInMainAxis() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(54, "fixYogaFlexBasisFitContentInMainAxis");
+    markFlagAsAccessed(53, "fixYogaFlexBasisFitContentInMainAxis");
 
     flagValue = currentProvider_->fixYogaFlexBasisFitContentInMainAxis();
     fixYogaFlexBasisFitContentInMainAxis_ = flagValue;
@@ -1028,7 +1010,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxAssertSingleHostState() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(55, "fuseboxAssertSingleHostState");
+    markFlagAsAccessed(54, "fuseboxAssertSingleHostState");
 
     flagValue = currentProvider_->fuseboxAssertSingleHostState();
     fuseboxAssertSingleHostState_ = flagValue;
@@ -1046,7 +1028,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(56, "fuseboxEnabledRelease");
+    markFlagAsAccessed(55, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -1064,7 +1046,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxFrameRecordingEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(57, "fuseboxFrameRecordingEnabled");
+    markFlagAsAccessed(56, "fuseboxFrameRecordingEnabled");
 
     flagValue = currentProvider_->fuseboxFrameRecordingEnabled();
     fuseboxFrameRecordingEnabled_ = flagValue;
@@ -1082,7 +1064,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(58, "fuseboxScreenshotCaptureEnabled");
+    markFlagAsAccessed(57, "fuseboxScreenshotCaptureEnabled");
 
     flagValue = currentProvider_->fuseboxScreenshotCaptureEnabled();
     fuseboxScreenshotCaptureEnabled_ = flagValue;
@@ -1100,7 +1082,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxWebSocketEventsEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(59, "fuseboxWebSocketEventsEnabled");
+    markFlagAsAccessed(58, "fuseboxWebSocketEventsEnabled");
 
     flagValue = currentProvider_->fuseboxWebSocketEventsEnabled();
     fuseboxWebSocketEventsEnabled_ = flagValue;
@@ -1118,7 +1100,7 @@ bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(60, "optimizedAnimatedPropUpdates");
+    markFlagAsAccessed(59, "optimizedAnimatedPropUpdates");
 
     flagValue = currentProvider_->optimizedAnimatedPropUpdates();
     optimizedAnimatedPropUpdates_ = flagValue;
@@ -1136,7 +1118,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(60, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1154,7 +1136,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "perfIssuesEnabled");
+    markFlagAsAccessed(61, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1172,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "perfMonitorV2Enabled");
+    markFlagAsAccessed(62, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1190,7 +1172,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "preparedTextCacheSize");
+    markFlagAsAccessed(63, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1208,7 +1190,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(64, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1226,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "redBoxV2Android");
+    markFlagAsAccessed(65, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1244,7 +1226,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "redBoxV2IOS");
+    markFlagAsAccessed(66, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1262,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(67, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1280,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(68, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1298,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(69, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1316,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(70, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1334,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(71, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1352,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(72, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1370,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1388,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(74, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1406,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useFabricInterop");
+    markFlagAsAccessed(75, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1424,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(76, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1442,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(77, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1460,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useSharedAnimatedBackend");
+    markFlagAsAccessed(78, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1478,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(79, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1496,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useTurboModuleInterop");
+    markFlagAsAccessed(80, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1514,7 +1496,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "viewCullingOutsetRatio");
+    markFlagAsAccessed(81, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1532,7 +1514,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewTransitionEnabled");
+    markFlagAsAccessed(82, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1550,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(83, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1568,7 +1550,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(84, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c1a9ad1347a455ab5973df3231ac8cb4>>
+ * @generated SignedSource<<a0ff32dbae9b1ad79011b1c638637b8f>>
  */
 
 /**
@@ -803,24 +803,6 @@ bool ReactNativeFeatureFlagsAccessor::enableResizeObserverByDefault() {
   return flagValue.value();
 }
 
-bool ReactNativeFeatureFlagsAccessor::enableRuntimeSchedulerQueueClearingOnError() {
-  auto flagValue = enableRuntimeSchedulerQueueClearingOnError_.load();
-
-  if (!flagValue.has_value()) {
-    // This block is not exclusive but it is not necessary.
-    // If multiple threads try to initialize the feature flag, we would only
-    // be accessing the provider multiple times but the end state of this
-    // instance and the returned flag value would be the same.
-
-    markFlagAsAccessed(43, "enableRuntimeSchedulerQueueClearingOnError");
-
-    flagValue = currentProvider_->enableRuntimeSchedulerQueueClearingOnError();
-    enableRuntimeSchedulerQueueClearingOnError_ = flagValue;
-  }
-
-  return flagValue.value();
-}
-
 bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
   auto flagValue = enableSchedulerDelegateInvalidation_.load();
 
@@ -830,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSchedulerDelegateInvalidation() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(44, "enableSchedulerDelegateInvalidation");
+    markFlagAsAccessed(43, "enableSchedulerDelegateInvalidation");
 
     flagValue = currentProvider_->enableSchedulerDelegateInvalidation();
     enableSchedulerDelegateInvalidation_ = flagValue;
@@ -848,7 +830,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSwiftUIBasedFilters() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(45, "enableSwiftUIBasedFilters");
+    markFlagAsAccessed(44, "enableSwiftUIBasedFilters");
 
     flagValue = currentProvider_->enableSwiftUIBasedFilters();
     enableSwiftUIBasedFilters_ = flagValue;
@@ -866,7 +848,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(46, "enableViewCulling");
+    markFlagAsAccessed(45, "enableViewCulling");
 
     flagValue = currentProvider_->enableViewCulling();
     enableViewCulling_ = flagValue;
@@ -884,7 +866,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(47, "enableViewRecycling");
+    markFlagAsAccessed(46, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -902,7 +884,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForImage() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(48, "enableViewRecyclingForImage");
+    markFlagAsAccessed(47, "enableViewRecyclingForImage");
 
     flagValue = currentProvider_->enableViewRecyclingForImage();
     enableViewRecyclingForImage_ = flagValue;
@@ -920,7 +902,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForScrollView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(49, "enableViewRecyclingForScrollView");
+    markFlagAsAccessed(48, "enableViewRecyclingForScrollView");
 
     flagValue = currentProvider_->enableViewRecyclingForScrollView();
     enableViewRecyclingForScrollView_ = flagValue;
@@ -938,7 +920,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(50, "enableViewRecyclingForText");
+    markFlagAsAccessed(49, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -956,7 +938,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(51, "enableViewRecyclingForView");
+    markFlagAsAccessed(50, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -974,7 +956,7 @@ bool ReactNativeFeatureFlagsAccessor::enableVirtualViewContainerStateExperimenta
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(52, "enableVirtualViewContainerStateExperimental");
+    markFlagAsAccessed(51, "enableVirtualViewContainerStateExperimental");
 
     flagValue = currentProvider_->enableVirtualViewContainerStateExperimental();
     enableVirtualViewContainerStateExperimental_ = flagValue;
@@ -992,7 +974,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorParentTagForUnflattenCase
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(53, "fixDifferentiatorParentTagForUnflattenCase");
+    markFlagAsAccessed(52, "fixDifferentiatorParentTagForUnflattenCase");
 
     flagValue = currentProvider_->fixDifferentiatorParentTagForUnflattenCase();
     fixDifferentiatorParentTagForUnflattenCase_ = flagValue;
@@ -1010,7 +992,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(54, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(53, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -1028,7 +1010,7 @@ bool ReactNativeFeatureFlagsAccessor::fixYogaFlexBasisFitContentInMainAxis() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(55, "fixYogaFlexBasisFitContentInMainAxis");
+    markFlagAsAccessed(54, "fixYogaFlexBasisFitContentInMainAxis");
 
     flagValue = currentProvider_->fixYogaFlexBasisFitContentInMainAxis();
     fixYogaFlexBasisFitContentInMainAxis_ = flagValue;
@@ -1046,7 +1028,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxAssertSingleHostState() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(56, "fuseboxAssertSingleHostState");
+    markFlagAsAccessed(55, "fuseboxAssertSingleHostState");
 
     flagValue = currentProvider_->fuseboxAssertSingleHostState();
     fuseboxAssertSingleHostState_ = flagValue;
@@ -1064,7 +1046,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(57, "fuseboxEnabledRelease");
+    markFlagAsAccessed(56, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -1082,7 +1064,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxFrameRecordingEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(58, "fuseboxFrameRecordingEnabled");
+    markFlagAsAccessed(57, "fuseboxFrameRecordingEnabled");
 
     flagValue = currentProvider_->fuseboxFrameRecordingEnabled();
     fuseboxFrameRecordingEnabled_ = flagValue;
@@ -1100,7 +1082,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxScreenshotCaptureEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(59, "fuseboxScreenshotCaptureEnabled");
+    markFlagAsAccessed(58, "fuseboxScreenshotCaptureEnabled");
 
     flagValue = currentProvider_->fuseboxScreenshotCaptureEnabled();
     fuseboxScreenshotCaptureEnabled_ = flagValue;
@@ -1118,7 +1100,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxWebSocketEventsEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(60, "fuseboxWebSocketEventsEnabled");
+    markFlagAsAccessed(59, "fuseboxWebSocketEventsEnabled");
 
     flagValue = currentProvider_->fuseboxWebSocketEventsEnabled();
     fuseboxWebSocketEventsEnabled_ = flagValue;
@@ -1136,7 +1118,7 @@ bool ReactNativeFeatureFlagsAccessor::optimizedAnimatedPropUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(61, "optimizedAnimatedPropUpdates");
+    markFlagAsAccessed(60, "optimizedAnimatedPropUpdates");
 
     flagValue = currentProvider_->optimizedAnimatedPropUpdates();
     optimizedAnimatedPropUpdates_ = flagValue;
@@ -1154,7 +1136,7 @@ bool ReactNativeFeatureFlagsAccessor::overrideBySynchronousMountPropsAtMountingA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(62, "overrideBySynchronousMountPropsAtMountingAndroid");
+    markFlagAsAccessed(61, "overrideBySynchronousMountPropsAtMountingAndroid");
 
     flagValue = currentProvider_->overrideBySynchronousMountPropsAtMountingAndroid();
     overrideBySynchronousMountPropsAtMountingAndroid_ = flagValue;
@@ -1172,7 +1154,7 @@ bool ReactNativeFeatureFlagsAccessor::perfIssuesEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(63, "perfIssuesEnabled");
+    markFlagAsAccessed(62, "perfIssuesEnabled");
 
     flagValue = currentProvider_->perfIssuesEnabled();
     perfIssuesEnabled_ = flagValue;
@@ -1190,7 +1172,7 @@ bool ReactNativeFeatureFlagsAccessor::perfMonitorV2Enabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(64, "perfMonitorV2Enabled");
+    markFlagAsAccessed(63, "perfMonitorV2Enabled");
 
     flagValue = currentProvider_->perfMonitorV2Enabled();
     perfMonitorV2Enabled_ = flagValue;
@@ -1208,7 +1190,7 @@ double ReactNativeFeatureFlagsAccessor::preparedTextCacheSize() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(65, "preparedTextCacheSize");
+    markFlagAsAccessed(64, "preparedTextCacheSize");
 
     flagValue = currentProvider_->preparedTextCacheSize();
     preparedTextCacheSize_ = flagValue;
@@ -1226,7 +1208,7 @@ bool ReactNativeFeatureFlagsAccessor::preventShadowTreeCommitExhaustion() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(66, "preventShadowTreeCommitExhaustion");
+    markFlagAsAccessed(65, "preventShadowTreeCommitExhaustion");
 
     flagValue = currentProvider_->preventShadowTreeCommitExhaustion();
     preventShadowTreeCommitExhaustion_ = flagValue;
@@ -1244,7 +1226,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2Android() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(67, "redBoxV2Android");
+    markFlagAsAccessed(66, "redBoxV2Android");
 
     flagValue = currentProvider_->redBoxV2Android();
     redBoxV2Android_ = flagValue;
@@ -1262,7 +1244,7 @@ bool ReactNativeFeatureFlagsAccessor::redBoxV2IOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(68, "redBoxV2IOS");
+    markFlagAsAccessed(67, "redBoxV2IOS");
 
     flagValue = currentProvider_->redBoxV2IOS();
     redBoxV2IOS_ = flagValue;
@@ -1280,7 +1262,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldPressibilityUseW3CPointerEventsForHo
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(69, "shouldPressibilityUseW3CPointerEventsForHover");
+    markFlagAsAccessed(68, "shouldPressibilityUseW3CPointerEventsForHover");
 
     flagValue = currentProvider_->shouldPressibilityUseW3CPointerEventsForHover();
     shouldPressibilityUseW3CPointerEventsForHover_ = flagValue;
@@ -1298,7 +1280,7 @@ bool ReactNativeFeatureFlagsAccessor::shouldTriggerResponderTransferOnScrollAndr
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(70, "shouldTriggerResponderTransferOnScrollAndroid");
+    markFlagAsAccessed(69, "shouldTriggerResponderTransferOnScrollAndroid");
 
     flagValue = currentProvider_->shouldTriggerResponderTransferOnScrollAndroid();
     shouldTriggerResponderTransferOnScrollAndroid_ = flagValue;
@@ -1316,7 +1298,7 @@ bool ReactNativeFeatureFlagsAccessor::skipActivityIdentityAssertionOnHostPause()
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "skipActivityIdentityAssertionOnHostPause");
+    markFlagAsAccessed(70, "skipActivityIdentityAssertionOnHostPause");
 
     flagValue = currentProvider_->skipActivityIdentityAssertionOnHostPause();
     skipActivityIdentityAssertionOnHostPause_ = flagValue;
@@ -1334,7 +1316,7 @@ bool ReactNativeFeatureFlagsAccessor::syncAndroidClipBoundsWithOverflow() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "syncAndroidClipBoundsWithOverflow");
+    markFlagAsAccessed(71, "syncAndroidClipBoundsWithOverflow");
 
     flagValue = currentProvider_->syncAndroidClipBoundsWithOverflow();
     syncAndroidClipBoundsWithOverflow_ = flagValue;
@@ -1352,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(72, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -1370,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(73, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -1388,7 +1370,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommitT
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "updateRuntimeShadowNodeReferencesOnCommitThread");
+    markFlagAsAccessed(74, "updateRuntimeShadowNodeReferencesOnCommitThread");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommitThread();
     updateRuntimeShadowNodeReferencesOnCommitThread_ = flagValue;
@@ -1406,7 +1388,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(76, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(75, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -1424,7 +1406,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(77, "useFabricInterop");
+    markFlagAsAccessed(76, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -1442,7 +1424,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(78, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(77, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -1460,7 +1442,7 @@ bool ReactNativeFeatureFlagsAccessor::useNestedScrollViewAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(79, "useNestedScrollViewAndroid");
+    markFlagAsAccessed(78, "useNestedScrollViewAndroid");
 
     flagValue = currentProvider_->useNestedScrollViewAndroid();
     useNestedScrollViewAndroid_ = flagValue;
@@ -1478,7 +1460,7 @@ bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(80, "useSharedAnimatedBackend");
+    markFlagAsAccessed(79, "useSharedAnimatedBackend");
 
     flagValue = currentProvider_->useSharedAnimatedBackend();
     useSharedAnimatedBackend_ = flagValue;
@@ -1496,7 +1478,7 @@ bool ReactNativeFeatureFlagsAccessor::useTraitHiddenOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(81, "useTraitHiddenOnAndroid");
+    markFlagAsAccessed(80, "useTraitHiddenOnAndroid");
 
     flagValue = currentProvider_->useTraitHiddenOnAndroid();
     useTraitHiddenOnAndroid_ = flagValue;
@@ -1514,7 +1496,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(82, "useTurboModuleInterop");
+    markFlagAsAccessed(81, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1532,7 +1514,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(83, "viewCullingOutsetRatio");
+    markFlagAsAccessed(82, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1550,7 +1532,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(84, "viewTransitionEnabled");
+    markFlagAsAccessed(83, "viewTransitionEnabled");
 
     flagValue = currentProvider_->viewTransitionEnabled();
     viewTransitionEnabled_ = flagValue;
@@ -1568,7 +1550,7 @@ bool ReactNativeFeatureFlagsAccessor::viewTransitionUseHardwareBitmapAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(85, "viewTransitionUseHardwareBitmapAndroid");
+    markFlagAsAccessed(84, "viewTransitionUseHardwareBitmapAndroid");
 
     flagValue = currentProvider_->viewTransitionUseHardwareBitmapAndroid();
     viewTransitionUseHardwareBitmapAndroid_ = flagValue;
@@ -1586,7 +1568,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(86, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(85, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6bfe194529e322fc98e43f6fe87cebeb>>
+ * @generated SignedSource<<55f19e7a0d7fbbda3aa131a74909ec07>>
  */
 
 /**
@@ -75,7 +75,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool enablePreparedTextLayout();
   bool enablePropsUpdateReconciliationAndroid();
   bool enableResizeObserverByDefault();
-  bool enableSchedulerDelegateInvalidation();
   bool enableSwiftUIBasedFilters();
   bool enableViewCulling();
   bool enableViewRecycling();
@@ -129,7 +128,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 86> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 85> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -174,7 +173,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enablePreparedTextLayout_;
   std::atomic<std::optional<bool>> enablePropsUpdateReconciliationAndroid_;
   std::atomic<std::optional<bool>> enableResizeObserverByDefault_;
-  std::atomic<std::optional<bool>> enableSchedulerDelegateInvalidation_;
   std::atomic<std::optional<bool>> enableSwiftUIBasedFilters_;
   std::atomic<std::optional<bool>> enableViewCulling_;
   std::atomic<std::optional<bool>> enableViewRecycling_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c08fb696ba1dc5b90155163ca690f218>>
+ * @generated SignedSource<<6bfe194529e322fc98e43f6fe87cebeb>>
  */
 
 /**
@@ -75,7 +75,6 @@ class ReactNativeFeatureFlagsAccessor {
   bool enablePreparedTextLayout();
   bool enablePropsUpdateReconciliationAndroid();
   bool enableResizeObserverByDefault();
-  bool enableRuntimeSchedulerQueueClearingOnError();
   bool enableSchedulerDelegateInvalidation();
   bool enableSwiftUIBasedFilters();
   bool enableViewCulling();
@@ -130,7 +129,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 87> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 86> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -175,7 +174,6 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enablePreparedTextLayout_;
   std::atomic<std::optional<bool>> enablePropsUpdateReconciliationAndroid_;
   std::atomic<std::optional<bool>> enableResizeObserverByDefault_;
-  std::atomic<std::optional<bool>> enableRuntimeSchedulerQueueClearingOnError_;
   std::atomic<std::optional<bool>> enableSchedulerDelegateInvalidation_;
   std::atomic<std::optional<bool>> enableSwiftUIBasedFilters_;
   std::atomic<std::optional<bool>> enableViewCulling_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bfdd2dff4688bcde04ece735f9635253>>
+ * @generated SignedSource<<8e00ed57e2faa8e13ae2eb58afd64962>>
  */
 
 /**
@@ -196,10 +196,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableResizeObserverByDefault() override {
-    return false;
-  }
-
-  bool enableSchedulerDelegateInvalidation() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0dcc09eb60ab85de9bc72410e93c2a1c>>
+ * @generated SignedSource<<374da5049c71e475cb3e5c2bfed87c9c>>
  */
 
 /**
@@ -200,7 +200,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return false;
+    return true;
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<374da5049c71e475cb3e5c2bfed87c9c>>
+ * @generated SignedSource<<bfdd2dff4688bcde04ece735f9635253>>
  */
 
 /**
@@ -197,10 +197,6 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool enableResizeObserverByDefault() override {
     return false;
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return true;
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<340aadae79b8e4f77daa915e9ab397a1>>
+ * @generated SignedSource<<30b0399ab09d2d273c465bfa950a5a15>>
  */
 
 /**
@@ -430,15 +430,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::enableResizeObserverByDefault();
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    auto value = values_["enableRuntimeSchedulerQueueClearingOnError"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::enableRuntimeSchedulerQueueClearingOnError();
   }
 
   bool enableSchedulerDelegateInvalidation() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<30b0399ab09d2d273c465bfa950a5a15>>
+ * @generated SignedSource<<9c0b6df9433a5696f5eacf47713b9040>>
  */
 
 /**
@@ -430,15 +430,6 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::enableResizeObserverByDefault();
-  }
-
-  bool enableSchedulerDelegateInvalidation() override {
-    auto value = values_["enableSchedulerDelegateInvalidation"];
-    if (!value.isNull()) {
-      return value.getBool();
-    }
-
-    return ReactNativeFeatureFlagsDefaults::enableSchedulerDelegateInvalidation();
   }
 
   bool enableSwiftUIBasedFilters() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7341b28bb77aeeec670051149faeae04>>
+ * @generated SignedSource<<764568389a1ae8675638104ab3d96d4d>>
  */
 
 /**
@@ -28,10 +28,6 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
   bool enableFlexboxAutoMinSizeInStrictMode() override {
-    return true;
-  }
-
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<764568389a1ae8675638104ab3d96d4d>>
+ * @generated SignedSource<<dc6298e569276bf047951a8e4105aa96>>
  */
 
 /**
@@ -28,10 +28,6 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
   bool enableFlexboxAutoMinSizeInStrictMode() override {
-    return true;
-  }
-
-  bool enableSchedulerDelegateInvalidation() override {
     return true;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<988feef999c2b900926fe5ba47fc313b>>
+ * @generated SignedSource<<7ebf2d5220215a3d02ce496257c7d3e0>>
  */
 
 /**
@@ -68,7 +68,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enablePreparedTextLayout() = 0;
   virtual bool enablePropsUpdateReconciliationAndroid() = 0;
   virtual bool enableResizeObserverByDefault() = 0;
-  virtual bool enableRuntimeSchedulerQueueClearingOnError() = 0;
   virtual bool enableSchedulerDelegateInvalidation() = 0;
   virtual bool enableSwiftUIBasedFilters() = 0;
   virtual bool enableViewCulling() = 0;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7ebf2d5220215a3d02ce496257c7d3e0>>
+ * @generated SignedSource<<51d2bd8d3e88e7848039f845c1709a39>>
  */
 
 /**
@@ -68,7 +68,6 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enablePreparedTextLayout() = 0;
   virtual bool enablePropsUpdateReconciliationAndroid() = 0;
   virtual bool enableResizeObserverByDefault() = 0;
-  virtual bool enableSchedulerDelegateInvalidation() = 0;
   virtual bool enableSwiftUIBasedFilters() = 0;
   virtual bool enableViewCulling() = 0;
   virtual bool enableViewRecycling() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b67c8966cce4fef1d3478cd9f1afdbc0>>
+ * @generated SignedSource<<8bef73ce7833191807c05d34586612dd>>
  */
 
 /**
@@ -257,11 +257,6 @@ bool NativeReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid(
 bool NativeReactNativeFeatureFlags::enableResizeObserverByDefault(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
-}
-
-bool NativeReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError();
 }
 
 bool NativeReactNativeFeatureFlags::enableSchedulerDelegateInvalidation(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8bef73ce7833191807c05d34586612dd>>
+ * @generated SignedSource<<54cf6211f3dbfc379c6058cbc9d9af07>>
  */
 
 /**
@@ -257,11 +257,6 @@ bool NativeReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid(
 bool NativeReactNativeFeatureFlags::enableResizeObserverByDefault(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableResizeObserverByDefault();
-}
-
-bool NativeReactNativeFeatureFlags::enableSchedulerDelegateInvalidation(
-    jsi::Runtime& /*runtime*/) {
-  return ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
 }
 
 bool NativeReactNativeFeatureFlags::enableSwiftUIBasedFilters(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9e8d3d0a144ac859479d5ef5b1b12f2f>>
+ * @generated SignedSource<<2c30d3942ab1183a99091db3566c020d>>
  */
 
 /**
@@ -123,8 +123,6 @@ class NativeReactNativeFeatureFlags
   bool enablePropsUpdateReconciliationAndroid(jsi::Runtime& runtime);
 
   bool enableResizeObserverByDefault(jsi::Runtime& runtime);
-
-  bool enableSchedulerDelegateInvalidation(jsi::Runtime& runtime);
 
   bool enableSwiftUIBasedFilters(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<40d25fafea07a23f9d4e146973c65cb5>>
+ * @generated SignedSource<<9e8d3d0a144ac859479d5ef5b1b12f2f>>
  */
 
 /**
@@ -123,8 +123,6 @@ class NativeReactNativeFeatureFlags
   bool enablePropsUpdateReconciliationAndroid(jsi::Runtime& runtime);
 
   bool enableResizeObserverByDefault(jsi::Runtime& runtime);
-
-  bool enableRuntimeSchedulerQueueClearingOnError(jsi::Runtime& runtime);
 
   bool enableSchedulerDelegateInvalidation(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -10,7 +10,6 @@
 #include <ReactCommon/RuntimeExecutorSyncUIThreadUtils.h>
 #include <cxxreact/TraceSection.h>
 #include <jsinspector-modern/tracing/EventLoopReporter.h>
-#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
 #include <react/utils/OnScopeExit.h>
@@ -498,9 +497,7 @@ void RuntimeScheduler_Modern::reportLongTasks(
 void RuntimeScheduler_Modern::handleTaskError(
     jsi::Runtime& runtime,
     jsi::JSError& error) {
-  if (ReactNativeFeatureFlags::enableRuntimeSchedulerQueueClearingOnError()) {
-    clearQueues();
-  }
+  clearQueues();
 
   onTaskError_(runtime, error);
 }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -370,16 +370,19 @@ void RuntimeScheduler_Modern::updateRendering(
   // internally; this call site stays a single invocation per tick.
   if (resizeObserverDelegate_ != nullptr) {
     // This delivers the observations to JS synchronously, so it is outside the
-    // error boundary of `executeTask`. Handle errors the same way here, so a
-    // throwing observer callback can't abort the remaining steps below.
+    // error boundary of `executeTask`. Report the error without going through
+    // `handleTaskError`: we are already inside the "update the rendering" step,
+    // so clearing the queues here would drop the pending rendering updates this
+    // step is about to drain, and a throwing observer callback would abort the
+    // remaining steps below.
     try {
       resizeObserverDelegate_->runResizeObservations(runtime);
     } catch (jsi::JSError& error) {
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     } catch (std::exception& ex) {
       jsi::JSError error(
           runtime, std::string("Non-JS exception: ") + ex.what());
-      handleTaskError(runtime, error);
+      onTaskError_(runtime, error);
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -34,24 +34,15 @@ using namespace std::chrono_literals;
 class RuntimeSchedulerTestFeatureFlags
     : public ReactNativeFeatureFlagsDefaults {
  public:
-  explicit RuntimeSchedulerTestFeatureFlags(
-      bool enableEventLoop,
-      bool enableRuntimeSchedulerQueueClearingOnError = false)
-      : enableEventLoop_(enableEventLoop),
-        enableRuntimeSchedulerQueueClearingOnError_(
-            enableRuntimeSchedulerQueueClearingOnError) {}
+  explicit RuntimeSchedulerTestFeatureFlags(bool enableEventLoop)
+      : enableEventLoop_(enableEventLoop) {}
 
   bool enableBridgelessArchitecture() override {
     return enableEventLoop_;
   }
 
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return enableRuntimeSchedulerQueueClearingOnError_;
-  }
-
  private:
   bool enableEventLoop_;
-  bool enableRuntimeSchedulerQueueClearingOnError_;
 };
 
 class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
@@ -97,12 +88,10 @@ class RuntimeSchedulerTest : public testing::TestWithParam<bool> {
     ReactNativeFeatureFlags::dangerouslyReset();
   }
 
-  void setUpFeatureFlags(
-      bool enableRuntimeSchedulerQueueClearingOnError = false) {
+  void setUpFeatureFlags() {
     ReactNativeFeatureFlags::dangerouslyReset();
     ReactNativeFeatureFlags::override(
-        std::make_unique<RuntimeSchedulerTestFeatureFlags>(
-            GetParam(), enableRuntimeSchedulerQueueClearingOnError));
+        std::make_unique<RuntimeSchedulerTestFeatureFlags>(GetParam()));
   }
 
   jsi::Function createHostFunctionFromLambda(
@@ -924,8 +913,6 @@ TEST_P(RuntimeSchedulerTest, clearsQueuesOnError) {
   if (!GetParam()) {
     return;
   }
-
-  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
 
   bool didRunThrowingTask = false;
   bool didRunQueuedTask = false;
@@ -1825,8 +1812,6 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
   if (!GetParam()) {
     return;
   }
-
-  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
 
   StubResizeObserverDelegate resizeObserverDelegate;
   resizeObserverDelegate.onRunResizeObservations = [](jsi::Runtime& runtime) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -1826,6 +1826,8 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
     return;
   }
 
+  setUpFeatureFlags(/*enableRuntimeSchedulerQueueClearingOnError=*/true);
+
   StubResizeObserverDelegate resizeObserverDelegate;
   resizeObserverDelegate.onRunResizeObservations = [](jsi::Runtime& runtime) {
     throw jsi::JSError(runtime, "Test error");
@@ -1848,6 +1850,9 @@ TEST_P(RuntimeSchedulerTest, errorInResizeObservationsDoesNotStopUpdate) {
 
   // Delivering observations to JS synchronously happens outside the error
   // boundary of the task, so the step handles the error itself and carries on.
+  // In particular the error must not be routed through `handleTaskError`:
+  // that clears the pending rendering updates this same step is about to
+  // drain, and `didRunRenderingUpdate` below would be false.
   EXPECT_EQ(stubErrorUtils_->getReportFatalCallCount(), 1);
   EXPECT_EQ(resizeObserverDelegate.callCount, 1);
   EXPECT_EQ(intersectionObserverDelegate.callCount, 1);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -31,8 +31,7 @@ Scheduler::Scheduler(
     const SchedulerToolbox& schedulerToolbox,
     UIManagerAnimationDelegate* animationDelegate,
     SchedulerDelegate* delegate)
-    : delegateInvalidated_(std::make_shared<std::atomic<bool>>(false)),
-      runtimeExecutor_(schedulerToolbox.runtimeExecutor),
+    : runtimeExecutor_(schedulerToolbox.runtimeExecutor),
       contextContainer_(schedulerToolbox.contextContainer) {
   // Creating a container for future `EventDispatcher` instance.
   eventDispatcher_ = std::make_shared<std::optional<const EventDispatcher>>();
@@ -182,15 +181,6 @@ Scheduler::~Scheduler() {
   LOG(WARNING) << "Scheduler::~Scheduler() was called (address: " << this
                << ").";
 
-  // Invalidate any lambdas already queued via scheduleRenderingUpdate that
-  // captured a raw delegate_ pointer; without this they'd dereference a
-  // dangling SchedulerDelegate after Scheduler teardown. (No replacement
-  // token is allocated here — Scheduler is going away.)
-  // Gated to allow controlled rollout / rollback.
-  if (ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation()) {
-    *delegateInvalidated_ = true;
-  }
-
   auto weakRuntimeScheduler =
       contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
           RuntimeSchedulerKey);
@@ -280,21 +270,6 @@ Scheduler::findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
 #pragma mark - Delegate
 
 void Scheduler::setDelegate(SchedulerDelegate* delegate) {
-  // Gated to allow controlled rollout / rollback.
-  if (ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation() &&
-      delegate_ != delegate) {
-    // Mark the *current* token invalid: any rendering-update lambda already
-    // queued holds a shared_ptr to this atomic and will observe `true` on
-    // its next read, so it no-ops instead of calling into the previous
-    // delegate (which the caller is about to drop).
-    *delegateInvalidated_ = true;
-    // Then install a *fresh* token (a new atomic) so lambdas captured
-    // against the new delegate use their own non-invalidated flag.
-    // Reusing the previous atomic and flipping it back to `false` would
-    // re-arm the in-flight lambdas — exactly the use-after-free we're
-    // trying to prevent — because they share the same shared_ptr.
-    delegateInvalidated_ = std::make_shared<std::atomic<bool>>(false);
-  }
   delegate_ = delegate;
 }
 
@@ -326,21 +301,10 @@ void Scheduler::uiManagerDidFinishTransaction(
     if (!mountSynchronously) {
       auto surfaceId = mountingCoordinator->getSurfaceId();
 
-      // Capture the gating flag at queue time: the lambda's decision to
-      // honor the invalidation guard is fixed when we enqueue, not when it
-      // later runs. Avoids per-invocation feature-flag reads and keeps the
-      // contract for an in-flight lambda stable across flag flips.
-      auto guardEnabled =
-          ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
       runtimeScheduler_->scheduleRenderingUpdate(
           surfaceId,
           [delegate = delegate_,
-           invalidated = delegateInvalidated_,
-           guardEnabled,
            mountingCoordinator = std::move(mountingCoordinator)]() {
-            if (guardEnabled && *invalidated) {
-              return;
-            }
             delegate->schedulerShouldRenderTransactions(mountingCoordinator);
           });
     } else {
@@ -363,20 +327,12 @@ void Scheduler::uiManagerDidDispatchCommand(
       "Scheduler::uiManagerDispatchCommand", "commandName", commandName);
   if (delegate_ != nullptr) {
     auto shadowView = ShadowView(*shadowNode);
-    // See comment in uiManagerDidFinishTransaction above for gating shape.
-    auto guardEnabled =
-        ReactNativeFeatureFlags::enableSchedulerDelegateInvalidation();
     runtimeScheduler_->scheduleRenderingUpdate(
         shadowNode->getSurfaceId(),
         [delegate = delegate_,
-         invalidated = delegateInvalidated_,
-         guardEnabled,
          shadowView = std::move(shadowView),
          commandName,
          args]() {
-          if (guardEnabled && *invalidated) {
-            return;
-          }
           delegate->schedulerDidDispatchCommand(shadowView, commandName, args);
         });
   }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -124,11 +124,6 @@ class Scheduler final : public UIManagerDelegate {
   friend class SurfaceHandler;
 
   SchedulerDelegate *delegate_;
-  // Invalidation token captured by-value into lambdas deferred via
-  // runtimeScheduler_->scheduleRenderingUpdate. Set to true on delegate
-  // change or Scheduler destruction so a lambda that outlives its captured
-  // raw delegate pointer can no-op instead of dereferencing dangling memory.
-  std::shared_ptr<std::atomic<bool>> delegateInvalidated_;
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   RuntimeExecutor runtimeExecutor_;
   std::shared_ptr<UIManager> uiManager_;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
@@ -198,9 +198,6 @@ class TestExecutorQueue {
 
 // Feature flags relevant to this test:
 //   - enableSchedulerDelegateInvalidation: the token guard under test.
-//   - enableRuntimeSchedulerQueueClearingOnError: a RuntimeScheduler_Modern
-//     fallback that drops queued work before host error handling tears down the
-//     delegate.
 //   - enableBridgelessArchitecture: forced ON so the Scheduler picks
 //     RuntimeScheduler_Modern. Modern queues rendering updates in
 //     pendingRenderingUpdates_ and drains them at end-of-tick, which is the
@@ -208,17 +205,10 @@ class TestExecutorQueue {
 //     scheduleRenderingUpdate inline, collapsing the window we want to test.
 class TestFeatureFlags : public ReactNativeFeatureFlagsDefaults {
  public:
-  explicit TestFeatureFlags(
-      bool guardEnabled,
-      bool queueClearingOnErrorEnabled = false)
-      : guardEnabled_(guardEnabled),
-        queueClearingOnErrorEnabled_(queueClearingOnErrorEnabled) {}
+  explicit TestFeatureFlags(bool guardEnabled) : guardEnabled_(guardEnabled) {}
 
   bool enableBridgelessArchitecture() override {
     return true;
-  }
-  bool enableRuntimeSchedulerQueueClearingOnError() override {
-    return queueClearingOnErrorEnabled_;
   }
   bool enableSchedulerDelegateInvalidation() override {
     return guardEnabled_;
@@ -226,7 +216,6 @@ class TestFeatureFlags : public ReactNativeFeatureFlagsDefaults {
 
  private:
   bool guardEnabled_;
-  bool queueClearingOnErrorEnabled_;
 };
 
 // Builds a ComponentRegistryFactory with just the descriptors needed for the
@@ -253,10 +242,9 @@ ComponentRegistryFactory makeComponentRegistryFactory() {
 // a real Scheduler and drive uiManagerDidFinishTransaction end-to-end.
 class SchedulerDelegateInvalidationTest : public ::testing::Test {
  protected:
-  void setUp(bool guardEnabled, bool queueClearingOnErrorEnabled = false) {
+  void setUp(bool guardEnabled) {
     ReactNativeFeatureFlags::override(
-        std::make_unique<TestFeatureFlags>(
-            guardEnabled, queueClearingOnErrorEnabled));
+        std::make_unique<TestFeatureFlags>(guardEnabled));
 
     runtime_ = facebook::hermes::makeHermesRuntime(
         ::hermes::vm::RuntimeConfig::Builder()
@@ -502,19 +490,17 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 3 — JS-throw-initiated teardown, guard DISABLED but runtime-scheduler
-// queue clearing ENABLED.
+// Test 3 — JS-throw-initiated teardown, guard DISABLED.
 //
 // Same cascade as Test 2 but with the scheduler invalidation guard OFF. The
 // runtime scheduler clears pendingRenderingUpdates_ before onTaskError tears
-// down the delegate, so the later tick has no stale delegate lambda to drain.
+// down the delegate, so the later tick has no stale delegate lambda to drain
+// even without the guard.
 // ---------------------------------------------------------------------------
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardDisabled_QueueClearingOnError_JSThrowInitiatedTeardownIsSafe) {
-  setUp(
-      /*guardEnabled=*/false,
-      /*queueClearingOnErrorEnabled=*/true);
+    GuardDisabled_JSThrowInitiatedTeardownIsSafe) {
+  setUp(/*guardEnabled=*/false);
 
   scheduler_->uiManagerDidFinishTransaction(
       coordinator_, /*mountSynchronously=*/false);
@@ -533,39 +519,35 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 4 — JS-throw-initiated teardown, guard DISABLED.
+// Test 4 — The window the guard still closes: a delegate dropped and
+// destroyed with no error involved.
 //
-// Same cascade as Test 2 but with the guard OFF. The previously-enqueued
-// lambda has no working token check, so when the rendering-update drain
-// runs after teardown it dereferences the destroyed delegate.
-//
-// EXPECT_DEATH catches the abort: either RecordingDelegate's magic-sentinel
-// ASSERT_EQ inside schedulerShouldRenderTransactions trips, or ASan reports
-// heap-use-after-free on the vptr load before our assertion runs.
+// Retargeted from a JS-throw trigger, which can no longer reach this race:
+// handleTaskError clears pendingRenderingUpdates_ before the host error
+// handler runs, so the queue is already empty by the time the delegate goes
+// away (Test 3). A plain setDelegate swap never reaches handleTaskError, so
+// with the guard OFF the lambda enqueued in (a) still holds a raw pointer to
+// freed memory when the queue drains in (c).
 // ---------------------------------------------------------------------------
 #if GTEST_HAS_DEATH_TEST
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardDisabled_JSThrowInitiatedTeardownIsUAF) {
+    GuardDisabled_DelegateDestroyedWithoutError_IsUAF) {
   EXPECT_DEATH(
       {
         setUp(/*guardEnabled=*/false);
 
-        // (a) Pre-throw transaction: lambda lands in
-        // pendingRenderingUpdates_.
+        // (a) Enqueue a rendering-update lambda capturing delegate_ raw.
         scheduler_->uiManagerDidFinishTransaction(
             coordinator_, /*mountSynchronously=*/false);
 
-        // (b) Uncaught JS throw → onTaskError → teardown drops the delegate.
-        // (c) Note: with guard DISABLED, setDelegate(nullptr) does NOT flip
-        // the invalidation token — Scheduler::setDelegate gates that branch
-        // on the feature flag — so the pending lambda has no signal that
-        // the delegate is going away.
-        scheduleJSThrowingTask();
-        executorQueue_->flush();
+        // (b) Host swaps the delegate out and destroys it. No JS throw, so
+        // nothing clears the rendering-update queue. With the guard ON,
+        // setDelegate would flip the invalidation token here.
+        scheduler_->setDelegate(nullptr);
+        delegate_.reset();
 
-        // (d) Drain the pending rendering update. The lambda dereferences
-        // the destroyed delegate → UAF.
+        // (c) Drain — the lambda dereferences the destroyed delegate.
         runOneEventLoopTick();
       },
       "");
@@ -605,34 +587,7 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 6 — Same race as Test 3, but enqueued via
-// Scheduler::uiManagerDidDispatchCommand. Guard OFF → lambda dereferences
-// the destroyed delegate → UAF caught by the magic sentinel inside
-// schedulerDidDispatchCommand or by ASan on the vptr load.
-// ---------------------------------------------------------------------------
-#if GTEST_HAS_DEATH_TEST
-TEST_F(
-    SchedulerDelegateInvalidationTest,
-    GuardDisabled_DispatchCommandLambda_JSThrowInitiatedTeardownIsUAF) {
-  EXPECT_DEATH(
-      {
-        setUp(/*guardEnabled=*/false);
-        ASSERT_NE(rootShadowNode_, nullptr);
-
-        scheduler_->uiManagerDidDispatchCommand(
-            rootShadowNode_, "scrollTo", folly::dynamic::array());
-
-        scheduleJSThrowingTask();
-        executorQueue_->flush();
-
-        runOneEventLoopTick();
-      },
-      "");
-}
-#endif
-
-// ---------------------------------------------------------------------------
-// Test 7 — Architectural assertion: surface-shutdown alone does NOT drain
+// Test 6 — Architectural assertion: surface-shutdown alone does NOT drain
 // pendingRenderingUpdates_ in RuntimeScheduler_Modern.
 //
 // This is the explicit refutation of the implicit reading "if the host just

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/tests/SchedulerDelegateInvalidationTest.cpp
@@ -12,8 +12,9 @@
 // uiManagerDidDispatchCommand). The lambda captures the delegate by raw
 // pointer; if the delegate is destroyed (as part of an instance teardown
 // triggered by an uncaught fatal error) before the lambda runs, the
-// dereference is a use-after-free unless the invalidation-token guard in
-// Scheduler::setDelegate is enabled at queue time.
+// dereference is a use-after-free. What closes the race is
+// RuntimeScheduler_Modern::handleTaskError, which clears the pending
+// rendering updates before the host error handler drops the delegate.
 //
 // The test drives the *real* Scheduler::uiManagerDidFinishTransaction so the
 // rendering-update lambda is enqueued via the regular code path into a real
@@ -196,26 +197,16 @@ class TestExecutorQueue {
   std::queue<std::function<void()>> queue_;
 };
 
-// Feature flags relevant to this test:
-//   - enableSchedulerDelegateInvalidation: the token guard under test.
-//   - enableBridgelessArchitecture: forced ON so the Scheduler picks
-//     RuntimeScheduler_Modern. Modern queues rendering updates in
-//     pendingRenderingUpdates_ and drains them at end-of-tick, which is the
-//     ordering required to expose the race. RuntimeScheduler_Legacy runs
-//     scheduleRenderingUpdate inline, collapsing the window we want to test.
+// enableBridgelessArchitecture is forced ON so the Scheduler picks
+// RuntimeScheduler_Modern. Modern queues rendering updates in
+// pendingRenderingUpdates_ and drains them at end-of-tick, which is the
+// ordering required to expose the race. RuntimeScheduler_Legacy runs
+// scheduleRenderingUpdate inline, collapsing the window we want to test.
 class TestFeatureFlags : public ReactNativeFeatureFlagsDefaults {
  public:
-  explicit TestFeatureFlags(bool guardEnabled) : guardEnabled_(guardEnabled) {}
-
   bool enableBridgelessArchitecture() override {
     return true;
   }
-  bool enableSchedulerDelegateInvalidation() override {
-    return guardEnabled_;
-  }
-
- private:
-  bool guardEnabled_;
 };
 
 // Builds a ComponentRegistryFactory with just the descriptors needed for the
@@ -242,9 +233,8 @@ ComponentRegistryFactory makeComponentRegistryFactory() {
 // a real Scheduler and drive uiManagerDidFinishTransaction end-to-end.
 class SchedulerDelegateInvalidationTest : public ::testing::Test {
  protected:
-  void setUp(bool guardEnabled) {
-    ReactNativeFeatureFlags::override(
-        std::make_unique<TestFeatureFlags>(guardEnabled));
+  void setUp() {
+    ReactNativeFeatureFlags::override(std::make_unique<TestFeatureFlags>());
 
     runtime_ = facebook::hermes::makeHermesRuntime(
         ::hermes::vm::RuntimeConfig::Builder()
@@ -433,7 +423,7 @@ class SchedulerDelegateInvalidationTest : public ::testing::Test {
 TEST_F(
     SchedulerDelegateInvalidationTest,
     Sanity_LambdaRunsOnNextTickWhenDelegateAlive) {
-  setUp(/*guardEnabled=*/true);
+  setUp();
 
   scheduler_->uiManagerDidFinishTransaction(
       coordinator_, /*mountSynchronously=*/false);
@@ -451,7 +441,7 @@ TEST_F(
 }
 
 // ---------------------------------------------------------------------------
-// Test 2 — JS-throw-initiated teardown, guard ENABLED.
+// Test 2 — JS-throw-initiated teardown.
 //
 // Cascade replicated in C++:
 //   (a) earlier transaction enqueued a rendering-update lambda into
@@ -461,13 +451,12 @@ TEST_F(
 //       host-driven instance teardown by dropping the delegate
 //   (d) the next tick drains the previously-queued rendering update
 //
-// With the guard ON, step (c) flipped the invalidation token; the pending
-// lambda observes that and returns before touching the freed delegate. Safe.
+// RuntimeScheduler_Modern clears pendingRenderingUpdates_ in handleTaskError
+// before running onTaskError, so by (d) there is no stale delegate lambda
+// left to drain. The post-error task is dropped by the same clearing.
 // ---------------------------------------------------------------------------
-TEST_F(
-    SchedulerDelegateInvalidationTest,
-    GuardEnabled_JSThrowInitiatedTeardownIsSafe) {
-  setUp(/*guardEnabled=*/true);
+TEST_F(SchedulerDelegateInvalidationTest, JSThrowInitiatedTeardownIsSafe) {
+  setUp();
 
   // (a) Pre-throw transaction: lambda lands in pendingRenderingUpdates_.
   scheduler_->uiManagerDidFinishTransaction(
@@ -477,73 +466,43 @@ TEST_F(
   // (b) Schedule a JS task that throws uncaught. Draining the executor queue
   // runs the task; the throw flows through to onTaskError → teardown.
   scheduleJSThrowingTask();
+  schedulePostErrorTask();
   executorQueue_->flush();
 
   // Sanity: the simulated fatal cascade fired and the delegate is gone.
   EXPECT_TRUE(jsThrowObserved_);
   EXPECT_EQ(scheduler_->getDelegate(), nullptr);
-
-  // (d) Drain the pending rendering update. Guard is on → lambda no-ops.
-  runOneEventLoopTick();
-
-  SUCCEED();
-}
-
-// ---------------------------------------------------------------------------
-// Test 3 — JS-throw-initiated teardown, guard DISABLED.
-//
-// Same cascade as Test 2 but with the scheduler invalidation guard OFF. The
-// runtime scheduler clears pendingRenderingUpdates_ before onTaskError tears
-// down the delegate, so the later tick has no stale delegate lambda to drain
-// even without the guard.
-// ---------------------------------------------------------------------------
-TEST_F(
-    SchedulerDelegateInvalidationTest,
-    GuardDisabled_JSThrowInitiatedTeardownIsSafe) {
-  setUp(/*guardEnabled=*/false);
-
-  scheduler_->uiManagerDidFinishTransaction(
-      coordinator_, /*mountSynchronously=*/false);
-  EXPECT_EQ(delegate_->shouldRenderTransactionsCount(), 0);
-
-  scheduleJSThrowingTask();
-  schedulePostErrorTask();
-  executorQueue_->flush();
-  EXPECT_TRUE(jsThrowObserved_);
-  EXPECT_EQ(scheduler_->getDelegate(), nullptr);
   EXPECT_FALSE(postErrorTaskRan_);
 
+  // (d) Drain the rendering-update queue — already emptied by the clearing.
   runOneEventLoopTick();
 
   SUCCEED();
 }
 
 // ---------------------------------------------------------------------------
-// Test 4 — The window the guard still closes: a delegate dropped and
-// destroyed with no error involved.
+// Test 3 — The window that remains open: a delegate dropped and destroyed
+// with no error involved.
 //
-// Retargeted from a JS-throw trigger, which can no longer reach this race:
 // handleTaskError clears pendingRenderingUpdates_ before the host error
-// handler runs, so the queue is already empty by the time the delegate goes
-// away (Test 3). A plain setDelegate swap never reaches handleTaskError, so
-// with the guard OFF the lambda enqueued in (a) still holds a raw pointer to
-// freed memory when the queue drains in (c).
+// handler runs, so an error-driven teardown is safe (Test 3). A plain
+// setDelegate swap never reaches handleTaskError, so the lambda enqueued in
+// (a) still holds a raw pointer to freed memory when the queue drains in (c).
 // ---------------------------------------------------------------------------
 #if GTEST_HAS_DEATH_TEST
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardDisabled_DelegateDestroyedWithoutError_IsUAF) {
+    DelegateDestroyedWithoutError_PendingRenderingUpdateIsUAF) {
   EXPECT_DEATH(
       {
-        setUp(/*guardEnabled=*/false);
+        setUp();
 
         // (a) Enqueue a rendering-update lambda capturing delegate_ raw.
         scheduler_->uiManagerDidFinishTransaction(
             coordinator_, /*mountSynchronously=*/false);
 
         // (b) Host swaps the delegate out and destroys it. No JS throw, so
-        // nothing clears the rendering-update queue. With the guard ON,
-        // setDelegate would flip the invalidation token here.
+        // nothing clears the rendering-update queue.
         scheduler_->setDelegate(nullptr);
         delegate_.reset();
 
@@ -555,21 +514,20 @@ TEST_F(
 #endif
 
 // ---------------------------------------------------------------------------
-// Test 5 — Same race as Test 2, but enqueued via the second lambda site:
+// Test 4 — Same race as Test 2, but enqueued via the second lambda site:
 // Scheduler::uiManagerDidDispatchCommand. This is the path the in-app
 // reproduction observed (a `scrollTo` command issued from a tap, queued
-// just before the cascade fatal). With the guard ON the lambda observes
-// the invalidation token and no-ops.
+// just before the cascade fatal).
 // ---------------------------------------------------------------------------
 TEST_F(
     SchedulerDelegateInvalidationTest,
-    GuardEnabled_DispatchCommandLambda_JSThrowInitiatedTeardownIsSafe) {
-  setUp(/*guardEnabled=*/true);
+    DispatchCommandLambda_JSThrowInitiatedTeardownIsSafe) {
+  setUp();
   ASSERT_NE(rootShadowNode_, nullptr);
 
   // (a) Pre-throw command: enqueues a rendering-update lambda inside
   // Scheduler::uiManagerDidDispatchCommand that captures the delegate by
-  // raw pointer and the invalidation token by shared_ptr.
+  // raw pointer.
   scheduler_->uiManagerDidDispatchCommand(
       rootShadowNode_, "scrollTo", folly::dynamic::array());
   EXPECT_EQ(delegate_->didDispatchCommandCount(), 0);
@@ -580,14 +538,14 @@ TEST_F(
   EXPECT_TRUE(jsThrowObserved_);
   EXPECT_EQ(scheduler_->getDelegate(), nullptr);
 
-  // (c) Drain the pending rendering update. Guard ON → lambda no-ops.
+  // (c) Drain the rendering-update queue — already emptied by the clearing.
   runOneEventLoopTick();
 
   SUCCEED();
 }
 
 // ---------------------------------------------------------------------------
-// Test 6 — Architectural assertion: surface-shutdown alone does NOT drain
+// Test 5 — Architectural assertion: surface-shutdown alone does NOT drain
 // pendingRenderingUpdates_ in RuntimeScheduler_Modern.
 //
 // This is the explicit refutation of the implicit reading "if the host just
@@ -595,13 +553,13 @@ TEST_F(
 // race wouldn't be reachable." It would not — surface-shutdown clears the
 // per-surface UIManager pointer but doesn't touch the runtime scheduler's
 // pending-rendering-updates queue. The lambda still runs and still calls
-// the delegate. Only the invalidation-token guard (or, longer-term, a
-// runtime-scheduler-level shutdown signal) closes this race.
+// the delegate. Only an error-driven queue clear, or a longer-term
+// runtime-scheduler-level shutdown signal, closes this race.
 // ---------------------------------------------------------------------------
 TEST_F(
     SchedulerDelegateInvalidationTest,
     UnregisterSurface_DoesNotDrainPendingRenderingUpdates) {
-  setUp(/*guardEnabled=*/true);
+  setUp();
 
   // (a) Enqueue a rendering-update lambda for the registered surface.
   scheduler_->uiManagerDidFinishTransaction(

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -506,7 +506,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableRuntimeSchedulerQueueClearingOnError: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-05-19',
         description:
@@ -514,7 +514,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'experimental',
+      ossReleaseStage: 'none',
     },
     enableSchedulerDelegateInvalidation: {
       defaultValue: false,

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -505,17 +505,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    enableSchedulerDelegateInvalidation: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2026-05-04',
-        description:
-          'Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'experimental',
-    },
     enableSwiftUIBasedFilters: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -505,17 +505,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    enableRuntimeSchedulerQueueClearingOnError: {
-      defaultValue: true,
-      metadata: {
-        dateAdded: '2026-05-19',
-        description:
-          'When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     enableSchedulerDelegateInvalidation: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2adcae106ae1e758061a91ee20f902fd>>
+ * @generated SignedSource<<9bdc0e5397839b38c408db16dd2fffdc>>
  * @flow strict
  * @noformat
  */
@@ -92,7 +92,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   enablePreparedTextLayout: Getter<boolean>,
   enablePropsUpdateReconciliationAndroid: Getter<boolean>,
   enableResizeObserverByDefault: Getter<boolean>,
-  enableRuntimeSchedulerQueueClearingOnError: Getter<boolean>,
   enableSchedulerDelegateInvalidation: Getter<boolean>,
   enableSwiftUIBasedFilters: Getter<boolean>,
   enableViewCulling: Getter<boolean>,
@@ -384,10 +383,6 @@ export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNat
  * Enables the ResizeObserver Web API in React Native.
  */
 export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGetter('enableResizeObserverByDefault', false);
-/**
- * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
- */
-export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', true);
 /**
  * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9bdc0e5397839b38c408db16dd2fffdc>>
+ * @generated SignedSource<<0774261e9f27a2df5005e11317556f83>>
  * @flow strict
  * @noformat
  */
@@ -92,7 +92,6 @@ export type ReactNativeFeatureFlags = Readonly<{
   enablePreparedTextLayout: Getter<boolean>,
   enablePropsUpdateReconciliationAndroid: Getter<boolean>,
   enableResizeObserverByDefault: Getter<boolean>,
-  enableSchedulerDelegateInvalidation: Getter<boolean>,
   enableSwiftUIBasedFilters: Getter<boolean>,
   enableViewCulling: Getter<boolean>,
   enableViewRecycling: Getter<boolean>,
@@ -383,10 +382,6 @@ export const enablePropsUpdateReconciliationAndroid: Getter<boolean> = createNat
  * Enables the ResizeObserver Web API in React Native.
  */
 export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGetter('enableResizeObserverByDefault', false);
-/**
- * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
- */
-export const enableSchedulerDelegateInvalidation: Getter<boolean> = createNativeFlagGetter('enableSchedulerDelegateInvalidation', false);
 /**
  * When enabled, it will use SwiftUI for filter effects like blur on iOS.
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fbab08ee89a2969b45034a45b6425581>>
+ * @generated SignedSource<<2adcae106ae1e758061a91ee20f902fd>>
  * @flow strict
  * @noformat
  */
@@ -387,7 +387,7 @@ export const enableResizeObserverByDefault: Getter<boolean> = createNativeFlagGe
 /**
  * When enabled, RuntimeScheduler_Modern clears pending tasks and rendering updates before handling an error.
  */
-export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', false);
+export const enableRuntimeSchedulerQueueClearingOnError: Getter<boolean> = createNativeFlagGetter('enableRuntimeSchedulerQueueClearingOnError', true);
 /**
  * Gates a defensive guard around Scheduler::uiManagerDidDispatchCommand and uiManagerDidFinishTransaction that prevents queued rendering-update lambdas from dereferencing the SchedulerDelegate after it has been destroyed (use-after-free).
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9b62a9e25b6088e25d9c39be7650a1d2>>
+ * @generated SignedSource<<f777c1ad56b2e5b38ddee06e327319c5>>
  * @flow strict
  * @noformat
  */
@@ -68,7 +68,6 @@ export interface Spec extends TurboModule {
   readonly enablePreparedTextLayout?: () => boolean;
   readonly enablePropsUpdateReconciliationAndroid?: () => boolean;
   readonly enableResizeObserverByDefault?: () => boolean;
-  readonly enableRuntimeSchedulerQueueClearingOnError?: () => boolean;
   readonly enableSchedulerDelegateInvalidation?: () => boolean;
   readonly enableSwiftUIBasedFilters?: () => boolean;
   readonly enableViewCulling?: () => boolean;

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f777c1ad56b2e5b38ddee06e327319c5>>
+ * @generated SignedSource<<ef68eeadf134320796321987f2cf2d8e>>
  * @flow strict
  * @noformat
  */
@@ -68,7 +68,6 @@ export interface Spec extends TurboModule {
   readonly enablePreparedTextLayout?: () => boolean;
   readonly enablePropsUpdateReconciliationAndroid?: () => boolean;
   readonly enableResizeObserverByDefault?: () => boolean;
-  readonly enableSchedulerDelegateInvalidation?: () => boolean;
   readonly enableSwiftUIBasedFilters?: () => boolean;
   readonly enableViewCulling?: () => boolean;
   readonly enableViewRecycling?: () => boolean;


### PR DESCRIPTION
Summary:
`enableSchedulerDelegateInvalidation` gated a defensive invalidation token in
`Scheduler`: a `shared_ptr<atomic<bool>>` captured into every rendering-update
lambda, flipped on delegate swap and on `Scheduler` destruction, so a lambda
that outlived its captured raw delegate pointer would no-op instead of
dereferencing freed memory.

We are not keeping it. The dominant path into that race - a pending rendering
update draining after an uncaught error tore down the delegate - is now closed
upstream in `RuntimeScheduler_Modern::handleTaskError`, which clears the pending
task and rendering-update queues before the host error handler runs. That leaves
the token as a second mechanism guarding an already-closed window, at the cost
of an atomic allocation per delegate swap and a branch in every deferred
rendering update.

So the flag and the guard both go: the token, its reallocation in `setDelegate`,
the destructor flip, and the per-lambda `guardEnabled` capture are all removed,
returning `setDelegate` to a plain assignment.

The test suite keeps its coverage of the underlying race - teardown via both
`uiManagerDidFinishTransaction` and `uiManagerDidDispatchCommand`, plus the
assertion that surface unregistration alone does not drain pending updates - now
exercising the queue-clearing behaviour that actually closes it. The two tests
that differed only in the flag's value collapse into one.

One window is genuinely left open, and is now pinned by a new death test: a
delegate dropped and destroyed with no error involved never reaches
`handleTaskError`, so nothing clears the queue and the drained lambda
dereferences freed memory. Closing that properly needs a
runtime-scheduler-level shutdown signal rather than a per-`Scheduler` token.

Changelog: [Internal]

Differential Revision: D117328638
