### PR TITLE
Cover `idlecallbacks` with Stable API guards (#58139)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_nativemodule_idlecallbacks PUBLIC ${REACT_COMMO
 target_link_libraries(react_nativemodule_idlecallbacks
         react_codegen_rncore
         react_cxxreact
+        react_cxxstableapi
         react_renderer_runtimescheduler
 )
 target_compile_reactnative_options(react_nativemodule_idlecallbacks PRIVATE)

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-bridging"
   s.dependency "React-runtimescheduler"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/idlecallbacks:idlecallbacks` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`NativeIdleCallbacks.h`), and wires the guard dependency into BUCK, CMake, and the podspec.

The podspec needs no `USE_FRAMEWORKS` header search path edit: its existing `$(PODS_TARGET_SRCROOT)/../../..` already resolves to `ReactCommon`, so `<react/cxxstableapi/...>` is on the path.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117333873


