### PR TITLE
Cover `componentregistry/native` with guards (#58141)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(rrc_native
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/NativeComponentRegistryBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string>
 
 #include <jsi/jsi.h>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/componentregistry/native:native` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's single exported header (`NativeComponentRegistryBinding.h`), and wires the guard dependency into BUCK and CMake.

The `React-Fabric` pod that ships this module already depends on `React-cxxstableapi` and is marked as a React Native build, so no podspec change is needed.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117338950


