### PR TITLE
Cover `nativemodule/cputime` with guards (#58142)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_nativemodule_cpu PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_cpu
         react_codegen_rncore
+        react_cxxstableapi
 )
 target_compile_reactnative_options(react_nativemodule_cpu PRIVATE)
 target_compile_options(react_nativemodule_cpu PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if defined USE_POSIX_TIME
 #include <time.h>
 #elif defined __MACH__

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #if __has_include("rncoreJSI.h") // Cmake headers on Android
 #include "rncoreJSI.h"
 #elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple


### PR DESCRIPTION
Summary:

Classifies `react/nativemodule/cputime:cputime` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to both of the module's exported headers (`CPUTime.h` and `NativeCPUTime.h`), and wires the guard dependency into BUCK and CMake.

No pod ships this module and it is not exported through prefab, so there is no podspec or SwiftPM change to make.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D117340507


