### PR TITLE
Cover react/renderer/runtimescheduler with Stable API guards (#58150)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(react_renderer_runtimescheduler
         callinvoker
         jserrorhandler
         jsi
+        react_cxxstableapi
         react_debug
         react_performance_timeline
         react_renderer_consistency

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-callinvoker"
   s.dependency "React-cxxreact"
+  s.dependency "React-cxxstableapi"
   s.dependency "React-rendererdebug"
   s.dependency "React-utils"
   s.dependency "React-featureflags"

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/hermes-interfaces.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerBinding.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/CallInvoker.h>
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/timing/primitives.h>
 #include <unordered_set>
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerIntersectionObserverDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerIntersectionObserverDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <unordered_set>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerResizeObserverDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerResizeObserverDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <ReactCommon/RuntimeExecutor.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/SchedulerPriority.h>
 #include <react/debug/react_native_assert.h>
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/SchedulerPriority.h>
 #include <jsi/jsi.h>
 #include <react/timing/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 #include <react/renderer/runtimescheduler/Task.h>
 


### PR DESCRIPTION
Summary:

Classifies `react/renderer/runtimescheduler:runtimescheduler` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

`RuntimeScheduler_Legacy.h` gets its guard above the `RCT_REMOVE_LEGACY_ARCH` block so it is still evaluated when the legacy architecture is compiled out.

Changelog: [Internal]

Differential Revision: D117508561


