### PR TITLE
Add Maestro Cloud CI for RNTester (#58151)

### DIFF
--- a/.github/workflows/maestro-cloud-rntester.yml
+++ b/.github/workflows/maestro-cloud-rntester.yml
@@ -1,0 +1,77 @@
+name: Maestro Cloud RNTester
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Platform name shown in the Maestro Cloud run'
+        required: true
+        type: string
+      artifact-name:
+        description: 'Name of the RNTester build artifact'
+        required: true
+        type: string
+      download-path:
+        description: 'Directory where the build artifact is downloaded'
+        required: true
+        type: string
+      app-file:
+        description: 'Path to the app bundle or APK passed to Maestro Cloud'
+        required: true
+        type: string
+      app-id:
+        description: 'RNTester application identifier'
+        required: true
+        type: string
+      exclude-tags:
+        description: 'Maestro flow tags to exclude'
+        required: true
+        type: string
+    secrets:
+      MAESTRO_CLOUD_API_KEY:
+        required: true
+      MAESTRO_CLOUD_PROJECT_ID:
+        required: true
+
+jobs:
+  test:
+    name: Maestro Cloud ${{ inputs.platform }} RNTester
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Download RNTester app
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.download-path }}
+      - name: Validate Maestro Cloud inputs
+        env:
+          MAESTRO_APP_FILE: ${{ inputs.app-file }}
+          MAESTRO_CLOUD_API_KEY: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+          MAESTRO_CLOUD_PROJECT_ID: ${{ secrets.MAESTRO_CLOUD_PROJECT_ID }}
+        run: |
+          test -e "$MAESTRO_APP_FILE"
+          test -n "$MAESTRO_CLOUD_API_KEY"
+          test -n "$MAESTRO_CLOUD_PROJECT_ID"
+          test -z "$(find packages/rn-tester/.maestro -type l -print -quit)"
+      - name: Run flows on Maestro Cloud
+        uses: mobile-dev-inc/action-maestro-cloud@5759506b4ec7ee0a1ece4b7e6574bba2b282f241 # v3.0.1
+        with:
+          api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
+          project-id: ${{ secrets.MAESTRO_CLOUD_PROJECT_ID }}
+          app-file: ${{ inputs.app-file }}
+          workspace: packages/rn-tester/.maestro
+          branch: ${{ github.head_ref || github.ref_name }}
+          name: RNTester ${{ inputs.platform }} - ${{ github.event.pull_request.title || github.sha }}
+          exclude-tags: ${{ inputs.exclude-tags }}
+          env: |
+            APP_ID=${{ inputs.app-id }}
+          maestro-cli-version: 2.6.1
+          timeout: 60

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -163,6 +163,30 @@ jobs:
           use-prebuilds: true
           flavor: ${{ matrix.flavor }}
 
+  test_maestro_cloud_ios:
+    needs: test_ios_rntester
+    # test_ios_rntester is continue-on-error. If its Release artifact is missing,
+    # the reusable workflow fails explicitly while downloading or validating it.
+    if: |
+      needs.test_ios_rntester.result == 'success' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        )
+      )
+    uses: ./.github/workflows/maestro-cloud-rntester.yml
+    with:
+      platform: iOS
+      artifact-name: RNTesterApp-NewArch-Release
+      download-path: /tmp/RNTesterBuild/RNTester.app
+      app-file: /tmp/RNTesterBuild/RNTester.app
+      app-id: com.meta.RNTester.localDevelopment
+      exclude-tags: android-only
+    secrets: inherit
+
   test_e2e_ios_rntester:
     needs: test_ios_rntester
     if: ${{ needs.test_ios_rntester.result == 'success' }}
@@ -328,6 +352,28 @@ jobs:
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
+  test_maestro_cloud_android:
+    needs: build_android
+    if: |
+      needs.build_android.result == 'success' &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          github.actor != 'dependabot[bot]'
+        )
+      )
+    uses: ./.github/workflows/maestro-cloud-rntester.yml
+    with:
+      platform: Android
+      artifact-name: rntester-release
+      download-path: /tmp/rntester-android
+      app-file: /tmp/rntester-android/app-arm64-v8a-release.apk
+      app-id: com.facebook.react.uiapp
+      exclude-tags: ios-only
+    secrets: inherit
 
   test_e2e_android_rntester:
     needs: build_android


### PR DESCRIPTION
Summary:

Run the release RNTester Maestro flows in Maestro Cloud for iOS and Android on pushes to main and same-repository pull requests. Reuse the existing build artifacts and read both the API key and project ID from repository secrets.

The existing local Maestro jobs remain unchanged because debug flows require a running bundler that is unavailable in Maestro Cloud.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D117513755


