### PR TITLE
Remove unimplemented sendIntent from RCTLinkingManager (#58154)

### DIFF
--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -233,13 +233,6 @@ RCT_EXPORT_MODULE()
                 }];
 }
 
-RCT_EXPORT_METHOD(
-    sendIntent : (NSString *)action extras : (NSArray *_Nullable)extras resolve : (RCTPromiseResolveBlock)
-        resolve reject : (RCTPromiseRejectBlock)reject)
-{
-  RCTLogError(@"Not implemented: %@", NSStringFromSelector(_cmd));
-}
-
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {


### PR DESCRIPTION
Summary:

`sendIntent` is an Android-only Linking API. On iOS the JS layer never reaches
the native module at all — `Linking.sendIntent()` returns
`Promise.reject(new Error('Unsupported'))` for any non-Android platform, so the
exported ObjC method was unreachable. Its body was only
`RCTLogError(@"Not implemented: ...")`.

It is also absent from `NativeLinkingManagerSpec`, the codegen'd protocol
`RCTLinkingManager` conforms to, so a TurboModule call could not dispatch to it
either: only spec methods appear on `NativeLinkingManagerSpecJSI`. The
`sendIntent` declaration lives on the separate Android spec instead.

Removing the dead stub. No behaviour change — the JS-visible rejection on iOS is
produced in `Linking.js` and is untouched.

Changelog: [Internal]

Differential Revision: D117534390


