### PR TITLE
Fix iOS 17 Metal errors when TextInput caret is hidden

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -17,6 +17,8 @@
   NSArray<UIBarButtonItemGroup *> *_initialValueLeadingBarButtonGroups;
   NSArray<UIBarButtonItemGroup *> *_initialValueTrailingBarButtonGroups;
   NSArray<NSString *> *_acceptDragAndDropTypes;
+  // Keep the requested tint while a transparent tint hides the caret.
+  UIColor *_requestedTintColor;
 }
 
 // This should not be needed but internal build were failing without it.
@@ -210,13 +212,31 @@
 
 #pragma mark - Caret Manipulation
 
-- (CGRect)caretRectForPosition:(UITextPosition *)position
+// Returning CGRectZero for a hidden caret causes oversized Metal surface errors on iOS
+// 17. A transparent tint hides the caret without changing its bounds. Restore the tint
+// for non-empty selections to preserve the selection highlight and handles.
+- (void)setCaretHidden:(BOOL)caretHidden
 {
-  if (_caretHidden) {
-    return CGRectZero;
+  if (_caretHidden == caretHidden) {
+    return;
   }
 
-  return [super caretRectForPosition:position];
+  _caretHidden = caretHidden;
+  [self _updateAppliedTintColor];
+}
+
+// Do not override the getter. UIKit reads the applied caret color through `-tintColor`.
+- (void)setTintColor:(UIColor *)tintColor
+{
+  _requestedTintColor = tintColor;
+  [self _updateAppliedTintColor];
+}
+
+- (void)_updateAppliedTintColor
+{
+  UITextRange *selectedTextRange = self.selectedTextRange;
+  BOOL shouldHideCaret = _caretHidden && (selectedTextRange == nil || selectedTextRange.isEmpty);
+  [super setTintColor:shouldHideCaret ? [UIColor clearColor] : _requestedTintColor];
 }
 
 #pragma mark - Positioning Overrides
@@ -239,6 +259,7 @@
 - (void)setSelectedTextRange:(UITextRange *)selectedTextRange
 {
   [super setSelectedTextRange:selectedTextRange];
+  [self _updateAppliedTintColor];
   [_textInputDelegateAdapter selectedTextRangeWasSet];
 }
 #pragma clang diagnostic pop
@@ -252,6 +273,7 @@
   }
 
   [super setSelectedTextRange:selectedTextRange];
+  [self _updateAppliedTintColor];
 }
 
 - (void)scrollRangeToVisible:(NSRange)range

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -849,6 +849,10 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   UIView<RCTBackedTextInputViewProtocol> *backedTextInputView = multiline ? [RCTUITextView new] : [RCTUITextField new];
   backedTextInputView.frame = _backedTextInputView.frame;
   RCTCopyBackedTextInput(_backedTextInputView, backedTextInputView);
+  // The copied tint can be transparent when the source hides its caret. Restore the
+  // selection color from props after changing the input type.
+  backedTextInputView.tintColor =
+      RCTUIColorFromSharedColor(static_cast<const TextInputProps &>(*_props).selectionColor);
   _backedTextInputView = backedTextInputView;
   [self addSubview:_backedTextInputView];
 }

--- a/packages/react-native/React/Tests/Text/RCTUITextFieldTests.mm
+++ b/packages/react-native/React/Tests/Text/RCTUITextFieldTests.mm
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTUITextField.h>
+#import <XCTest/XCTest.h>
+
+@interface RCTUITextFieldTests : XCTestCase
+@end
+
+@implementation RCTUITextFieldTests
+
+- (void)testCaretHiddenMakesTheCaretTransparent
+{
+  RCTUITextField *textField = [RCTUITextField new];
+  textField.tintColor = UIColor.redColor;
+
+  textField.caretHidden = YES;
+
+  XCTAssertEqualObjects(textField.tintColor, UIColor.clearColor);
+}
+
+- (void)testClearingCaretHiddenRestoresTheSelectionColor
+{
+  RCTUITextField *textField = [RCTUITextField new];
+  textField.tintColor = UIColor.redColor;
+  textField.caretHidden = YES;
+
+  textField.caretHidden = NO;
+
+  XCTAssertEqualObjects(textField.tintColor, UIColor.redColor);
+}
+
+- (void)testSelectionColorSetWhileCaretHiddenIsAppliedOnceTheCaretIsShown
+{
+  RCTUITextField *textField = [RCTUITextField new];
+  textField.caretHidden = YES;
+
+  textField.tintColor = UIColor.redColor;
+
+  XCTAssertEqualObjects(textField.tintColor, UIColor.clearColor);
+
+  textField.caretHidden = NO;
+
+  XCTAssertEqualObjects(textField.tintColor, UIColor.redColor);
+}
+
+- (void)testSelectionColorIsAppliedToANonEmptySelection
+{
+  RCTUITextField *textField = [RCTUITextField new];
+  textField.attributedText = [[NSAttributedString alloc] initWithString:@"Hello"];
+  textField.tintColor = UIColor.redColor;
+  textField.caretHidden = YES;
+
+  UITextPosition *start = textField.beginningOfDocument;
+  UITextPosition *end = [textField positionFromPosition:start offset:textField.attributedText.length];
+  [textField setSelectedTextRange:[textField textRangeFromPosition:start toPosition:end] notifyDelegate:NO];
+
+  XCTAssertEqualObjects(textField.tintColor, UIColor.redColor);
+}
+
+@end


### PR DESCRIPTION
## Summary:

Fixes #58157.

On iOS 17.2, `caretHidden` makes a single-line `TextInput` return `CGRectZero` from `caretRectForPosition:`. When the caret moves, Core Animation repeatedly logs `Surface 1073741823 x 1073741823 is too large`. This activity can prevent XCUITest from detecting an idle app.

This change keeps the caret geometry intact and hides a collapsed caret with a transparent tint. It restores the requested `selectionColor` for non-empty selections so the highlight and handles remain visible. Fabric also reapplies `selectionColor` after switching between single-line and multiline backing views.

## Changelog:

[IOS] [FIXED] - Prevent hidden TextInput carets from causing repeated Metal surface errors.

## Test Plan:

- Ran clang-format on all changed Objective-C files:

  ```sh
  yarn clang-format packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm packages/react-native/React/Tests/Text/RCTUITextFieldTests.mm
  ```

  Result: passed.

- Built the from-source HelloWorld app:

  ```sh
  xcodebuild -workspace private/helloworld/ios/HelloWorld.xcworkspace -scheme HelloWorld -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build
  ```

  Result: `BUILD SUCCEEDED`.

- Syntax-checked the new Objective-C++ test file:

  ```sh
  RN_SIM_SDK=$(xcrun --sdk iphonesimulator --show-sdk-path)
  RN_SIM_PLATFORM=$(xcrun --sdk iphonesimulator --show-sdk-platform-path)
  xcrun clang++ -fsyntax-only -x objective-c++ -std=c++20 -fobjc-arc -fmodules -fcxx-modules -target arm64-apple-ios15.1-simulator -isysroot "$RN_SIM_SDK" -F "$RN_SIM_PLATFORM/Developer/Library/Frameworks" -I private/helloworld/ios/Pods/Headers/Public/React-Core packages/react-native/React/Tests/Text/RCTUITextFieldTests.mm
  ```

  Result: passed.

- Tested `private/helloworld` on an iPhone SE 3 simulator with iOS 17.2:
  - Before this change: 615 matching Core Animation errors in 15 seconds.
  - After this change: 0 matching errors in 15 seconds.
  - The caret remained hidden while typing, after refocusing, in dark mode, and with a dimmed tint.
  - A non-empty selection kept its configured red highlight and handles.
  - `caretHidden={false}` kept its visible red caret.
- Tested the same states on iOS 18.0. Both the hidden caret and selection highlight behaved correctly, with no matching errors.
- Tested a native Mac Catalyst harness on macOS 26. A transparent tint hid the caret.

## Caret-hiding experiments

These results came from iOS 17.2 during 10 seconds of caret movement:

| Strategy | Caret hidden | Errors |
| --- | --- | ---: |
| Normal caret | No | 0 |
| `CGRectZero` | Yes | 160 |
| Zero width, valid origin and height | Yes | 66 |
| Zero height, valid origin and width | Yes | 160 |
| Valid rectangle moved off-screen | Yes | 164 |
| Valid rectangle above the text | Yes | 158 |
| `CGRectNull` | Yes | 169 |
| `0.01pt` width | No | 0 |
| **Transparent `tintColor`** | **Yes** | **0** |

## References

Apple documentation:

- [`caretRect(for:)`](https://developer.apple.com/documentation/uikit/uitextinput/caretrect(for:))
- [`UIView.tintColor`](https://developer.apple.com/documentation/uikit/uiview/tintcolor)
- [`UIView.TintAdjustmentMode.dimmed`](https://developer.apple.com/documentation/uikit/uiview/tintadjustmentmode-swift.enum/dimmed) — returns a desaturated tint colour; measurements showed alpha is scaled rather than reset, so a transparent tint stays transparent.
- [`UITextSelectionDisplayInteraction`](https://developer.apple.com/documentation/uikit/uitextselectiondisplayinteraction) — the iOS 17 API behind the rejected alternative.
- [WWDC23: What's new with text and text interactions](https://developer.apple.com/videos/play/wwdc2023/10058/)

Repository history:

- `e13b9c6e49` (2017-05-29) — the `CGRectZero` override already existed at this point, so the implementation predates iOS 17 by several years. It was correct when written; iOS 17 changed caret rendering underneath it.
- [#38679](https://github.com/facebook/react-native/pull/38679) — the `scrollRangeToVisible:` no-op referenced in `RCTUITextField.mm`.

Apple's documentation does not mention the oversized-surface behaviour, and no public report of the `Surface 1073741823 x 1073741823 is too large` message could be found. The version range in this document comes from local measurement.