### PR TITLE
fix(ios): prevent missing hairlineWidth border strokes at subpixel Y …

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -887,7 +887,9 @@ static void RCTAddContourEffectToLayer(
     UIEdgeInsets imageCapInsets = image.capInsets;
     CGRect contentsCenter = CGRect{
         CGPoint{imageCapInsets.left / imageSize.width, imageCapInsets.top / imageSize.height},
-        CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
+        CGSize{
+            MAX(0, (imageSize.width - imageCapInsets.left - imageCapInsets.right) / imageSize.width),
+            MAX(0, (imageSize.height - imageCapInsets.top - imageCapInsets.bottom) / imageSize.height)}};
     layer.contents = (id)image.CGImage;
     layer.contentsScale = image.scale;
 

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -247,12 +247,8 @@ static UIImage *RCTGetSolidBorderImage(
 
   const CGSize size = makeStretchable ? (CGSize){
     // 1pt for the middle stretchable area along each axis
-    // we also need to round the edge insets to avoid border bleeding
-    // this is because if the size is decimal, when calculating the unit
-    // rectangle for CALayer.contentsCenter we encounter rounding errors
-    // which causes visual glitches
-    ceil(edgeInsets.left) + 1 + ceil(edgeInsets.right),
-    ceil(edgeInsets.top) + 1 + ceil(edgeInsets.bottom),
+    edgeInsets.left + 1 + edgeInsets.right,
+    edgeInsets.top + 1 + edgeInsets.bottom,
   } : viewSize;
 
   UIGraphicsImageRenderer *const imageRenderer =

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -860,7 +860,10 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
     CGSize size = image.size;
     UIEdgeInsets insets = image.capInsets;
     CGRectMake(
-        insets.left / size.width, insets.top / size.height, (CGFloat)1.0 / size.width, (CGFloat)1.0 / size.height);
+        insets.left / size.width,
+        insets.top / size.height,
+        MAX(0, (size.width - insets.left - insets.right) / size.width),
+        MAX(0, (size.height - insets.top - insets.bottom) / size.height));
   });
 
   layer.contents = (id)image.CGImage;

--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -13,6 +13,7 @@
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
 import hotdog from '../../assets/hotdog.jpg';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {
   DynamicColorIOS,
@@ -256,6 +257,33 @@ const styles = StyleSheet.create({
     left: -10,
     top: -10,
     backgroundColor: 'blue',
+  },
+  hairlineBox: {
+    width: 44,
+    height: 44,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'black',
+    backgroundColor: '#f5f5f5',
+  },
+  hairlineBoxContainer: {
+    alignItems: 'center',
+    marginRight: 8,
+  },
+  hairlineRow: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: 'black',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  subpixelLabel: {
+    fontSize: 9,
+    marginTop: 4,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: 'bold',
+    marginBottom: 6,
+    marginTop: 10,
   },
 });
 
@@ -618,6 +646,109 @@ export default {
                 },
               ]}
             />
+          </View>
+        );
+      },
+    },
+    {
+      title: 'Hairline borders at subpixel Y offsets',
+      name: 'hairline-subpixel-y-offsets',
+      description:
+        'Ensure hairlineWidth borders render completely on all sides even when positioned at fractional/subpixel Y offsets on iOS',
+      render: function (): React.Node {
+        const subpixelYOffsets = [0, 0.25, 0.33, 0.5, 0.67, 0.75];
+        return (
+          <View testID="border-test-hairline-subpixel-y-offsets">
+            <RNTesterText style={styles.sectionTitle}>
+              Boxes at fractional Y offsets (borderWidth = hairlineWidth):
+            </RNTesterText>
+            <View style={styles.wrapper}>
+              {subpixelYOffsets.map(yOffset => (
+                <View key={yOffset} style={styles.hairlineBoxContainer}>
+                  <View style={[styles.hairlineBox, {top: yOffset}]} />
+                  <RNTesterText style={styles.subpixelLabel}>
+                    {`+${yOffset}pt`}
+                  </RNTesterText>
+                </View>
+              ))}
+            </View>
+
+            <RNTesterText style={styles.sectionTitle}>
+              Stacked rows with hairline bottom borders (fractional heights):
+            </RNTesterText>
+            <View>
+              {subpixelYOffsets.map((fraction, index) => (
+                <View
+                  key={index}
+                  style={[styles.hairlineRow, {height: 24 + fraction}]}>
+                  <RNTesterText style={styles.subpixelLabel}>
+                    {`Row ${index + 1} (height: ${(24 + fraction).toFixed(2)}pt)`}
+                  </RNTesterText>
+                </View>
+              ))}
+            </View>
+
+            <RNTesterText style={styles.sectionTitle}>
+              Single-side hairline borders at fractional Y offset (+0.33pt):
+            </RNTesterText>
+            <View style={styles.wrapper}>
+              <View style={styles.hairlineBoxContainer}>
+                <View
+                  style={[
+                    styles.hairlineBox,
+                    {
+                      borderWidth: 0,
+                      borderTopWidth: StyleSheet.hairlineWidth,
+                      borderColor: 'red',
+                      top: 0.33,
+                    },
+                  ]}
+                />
+                <RNTesterText style={styles.subpixelLabel}>top</RNTesterText>
+              </View>
+              <View style={styles.hairlineBoxContainer}>
+                <View
+                  style={[
+                    styles.hairlineBox,
+                    {
+                      borderWidth: 0,
+                      borderBottomWidth: StyleSheet.hairlineWidth,
+                      borderColor: 'red',
+                      top: 0.33,
+                    },
+                  ]}
+                />
+                <RNTesterText style={styles.subpixelLabel}>bottom</RNTesterText>
+              </View>
+              <View style={styles.hairlineBoxContainer}>
+                <View
+                  style={[
+                    styles.hairlineBox,
+                    {
+                      borderWidth: 0,
+                      borderLeftWidth: StyleSheet.hairlineWidth,
+                      borderColor: 'red',
+                      top: 0.33,
+                    },
+                  ]}
+                />
+                <RNTesterText style={styles.subpixelLabel}>left</RNTesterText>
+              </View>
+              <View style={styles.hairlineBoxContainer}>
+                <View
+                  style={[
+                    styles.hairlineBox,
+                    {
+                      borderWidth: 0,
+                      borderRightWidth: StyleSheet.hairlineWidth,
+                      borderColor: 'red',
+                      top: 0.33,
+                    },
+                  ]}
+                />
+                <RNTesterText style={styles.subpixelLabel}>right</RNTesterText>
+              </View>
+            </View>
           </View>
         );
       },


### PR DESCRIPTION
## Summary:

Fixes #58054

Fixes an issue on iOS (Fabric & Legacy renderer) where `StyleSheet.hairlineWidth` border strokes disappeared when views landed at certain subpixel Y offsets. Removed `ceil()` rounding from stretchable border image size calculations in `RCTBorderDrawing.m` and updated `CALayer.contentsCenter` calculation in `RCTViewComponentView.mm` and `RCTView.m` to compute cap sizes dynamically.

## Changelog:

[IOS] [BREAKING] - Prevent StyleSheet.hairlineWidth border strokes from disappearing at subpixel Y offsets (#58054) - althought this is a fix, it alters how the apps renders.

## Test Plan:

- Rendered views with `borderBottomWidth: StyleSheet.hairlineWidth` at various fractional Y offsets (`y = 100.1`, `100.333`, `100.5`, `100.7`).
- Verified 1:1 image cap slice mapping without transparent padding, ensuring hairline border lines remain visible across `@2x` (0.5pt) and `@3x` (0.333pt) displays at all offsets.
