### PR TITLE
Skip device-specific screenshot flows in Maestro Cloud

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -372,7 +372,7 @@ jobs:
       download-path: /tmp/rntester-android
       app-file: /tmp/rntester-android/app-arm64-v8a-release.apk
       app-id: com.facebook.react.uiapp
-      exclude-tags: ios-only
+      exclude-tags: ios-only,local-screenshot-baseline
     secrets: inherit
 
   test_e2e_android_rntester:

--- a/packages/rn-tester/.maestro/image-blur-prefetch.yml
+++ b/packages/rn-tester/.maestro/image-blur-prefetch.yml
@@ -1,6 +1,9 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 tags:
   - android-only
+  # The screenshot baseline is captured on the local CI emulator and is
+  # intentionally not portable across Maestro Cloud device profiles.
+  - local-screenshot-baseline
 ---
 # Android-only: prefetch an image, then render the same URI with blurRadius so
 # the blur postprocessor applies to the already-decoded bitmap. Flaky on the iOS

--- a/packages/rn-tester/.maestro/image-wide-gamut.yml
+++ b/packages/rn-tester/.maestro/image-wide-gamut.yml
@@ -1,6 +1,9 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 tags:
   - android-only
+  # The screenshot baseline is captured on the local CI emulator and is
+  # intentionally not portable across Maestro Cloud device profiles.
+  - local-screenshot-baseline
 ---
 # Android-only: alpha transparency + sRGB vs Display-P3 wide-gamut. Color
 # fidelity is covered by a screenshot captured from the ARM64 APK on the API 35

--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -14,7 +14,6 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: 'example_search'
 - inputText:
     text: 'Image.getSize'
-- hideKeyboard
 - tapOn:
     id: 'platform-test-results'
 - assertVisible: 'Results'


### PR DESCRIPTION
Summary:
The screenshot baselines used by two Android RNTester flows were captured on the local CI emulator and have fixed pixel dimensions that do not match the Maestro Cloud device profile.

Tag those flows as local screenshot baselines and exclude that tag from the Android Maestro Cloud job. The existing local Android E2E job continues to run both flows and validate their screenshots.

Changelog: [Internal]

Differential Revision: D117687713


