### PR TITLE
Pass accessibilityLabelledBy through Button and Touchable

### DIFF
--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -159,6 +159,21 @@ export type ButtonProps = Readonly<{
   accessibilityHint?: ?string,
 
   /**
+   * Identifies the element that labels this button. The value should match
+   * the `nativeID` of the related element.
+   *
+   * @platform android
+   */
+  accessibilityLabelledBy?: ?string | ?Array<string>,
+
+  /**
+   * Alias for `accessibilityLabelledBy`.
+   *
+   * @platform android
+   */
+  'aria-labelledby'?: ?string,
+
+  /**
    * A BCP 47 language tag for the screen reader to use when reading text
    * content.
    *
@@ -211,8 +226,10 @@ const Button: component(
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
     'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
     'aria-selected': ariaSelected,
     importantForAccessibility,
+    accessibilityLabelledBy,
     color,
     onPress,
     touchSoundDisabled,
@@ -269,10 +286,13 @@ const Button: component(
     Platform.OS === 'android' ? title.toUpperCase() : title;
 
   // If `no` is specified for `importantForAccessibility`, it will be changed to `no-hide-descendants` because the text inside should not be focused.
-  const _importantForAccessibility =
+  let _importantForAccessibility =
     importantForAccessibility === 'no'
       ? 'no-hide-descendants'
       : importantForAccessibility;
+
+  const _accessibilityLabelledBy =
+    ariaLabelledBy?.split(/\s*,\s*/g) ?? accessibilityLabelledBy;
 
   return (
     <NativeTouchable
@@ -282,6 +302,7 @@ const Button: component(
       accessibilityLabel={ariaLabel || accessibilityLabel}
       accessibilityHint={accessibilityHint}
       accessibilityLanguage={accessibilityLanguage}
+      accessibilityLabelledBy={_accessibilityLabelledBy}
       accessibilityRole="button"
       accessibilityState={_accessibilityState}
       importantForAccessibility={_importantForAccessibility}

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -252,10 +252,14 @@ class TouchableHighlightImpl extends React.Component<
 
     const accessibilityLabel =
       this.props['aria-label'] ?? this.props.accessibilityLabel;
+    const accessibilityLabelledBy =
+      this.props['aria-labelledby']?.split(/\s*,\s*/g) ??
+      this.props.accessibilityLabelledBy;
     return (
       <View
         accessible={this.props.accessible !== false}
         accessibilityLabel={accessibilityLabel}
+        accessibilityLabelledBy={accessibilityLabelledBy}
         accessibilityHint={this.props.accessibilityHint}
         accessibilityLanguage={this.props.accessibilityLanguage}
         accessibilityRole={this.props.accessibilityRole}

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -317,6 +317,9 @@ class TouchableNativeFeedback extends React.Component<
 
     const accessibilityLabel =
       this.props['aria-label'] ?? this.props.accessibilityLabel;
+    const accessibilityLabelledBy =
+      this.props['aria-labelledby']?.split(/\s*,\s*/g) ??
+      this.props.accessibilityLabelledBy;
     return cloneElement(
       element,
       {
@@ -331,6 +334,7 @@ class TouchableNativeFeedback extends React.Component<
         accessibilityHint: this.props.accessibilityHint,
         accessibilityLanguage: this.props.accessibilityLanguage,
         accessibilityLabel: accessibilityLabel,
+        accessibilityLabelledBy: accessibilityLabelledBy,
         accessibilityRole: this.props.accessibilityRole,
         accessibilityState: _accessibilityState,
         accessibilityActions: this.props.accessibilityActions,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -228,10 +228,14 @@ class TouchableOpacity extends React.Component<
 
     const accessibilityLabel =
       this.props['aria-label'] ?? this.props.accessibilityLabel;
+    const accessibilityLabelledBy =
+      this.props['aria-labelledby']?.split(/\s*,\s*/g) ??
+      this.props.accessibilityLabelledBy;
     return (
       <Animated.View
         accessible={this.props.accessible !== false}
         accessibilityLabel={accessibilityLabel}
+        accessibilityLabelledBy={accessibilityLabelledBy}
         accessibilityHint={this.props.accessibilityHint}
         accessibilityLanguage={this.props.accessibilityLanguage}
         accessibilityRole={this.props.accessibilityRole}

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -133,6 +133,8 @@ const PASSTHROUGH_PROPS = [
   'accessibilityLanguage',
   'accessibilityIgnoresInvertColors',
   'accessibilityLabel',
+  'accessibilityLabelledBy',
+  'aria-labelledby',
   'accessibilityLiveRegion',
   'accessibilityRole',
   'accessibilityValue',

--- a/packages/react-native/Libraries/Components/__tests__/Button-itest.js
+++ b/packages/react-native/Libraries/Components/__tests__/Button-itest.js
@@ -244,6 +244,46 @@ describe('<Button>', () => {
       });
     });
 
+    describe('accessibilityLabelledBy', () => {
+      it('propagates accessibilityLabelledBy', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(
+            <Button title="Hello" accessibilityLabelledBy="formLabel" />,
+          );
+        });
+
+        expect(
+          root
+            .getRenderedOutput({props: ['accessibilityLabelledBy']})
+            .toJSX(),
+        ).toEqual(
+          <rn-view accessibilityLabelledBy="formLabel">
+            <rn-paragraph>HELLO</rn-paragraph>
+          </rn-view>,
+        );
+      });
+
+      it('maps aria-labelledby to accessibilityLabelledBy', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Button title="Hello" aria-labelledby="formLabel" />);
+        });
+
+        expect(
+          root
+            .getRenderedOutput({props: ['accessibilityLabelledBy']})
+            .toJSX(),
+        ).toEqual(
+          <rn-view accessibilityLabelledBy={['formLabel']}>
+            <rn-paragraph>HELLO</rn-paragraph>
+          </rn-view>,
+        );
+      });
+    });
+
     describe('importantForAccessibility', () => {
       it('propagates "no-hide-descendants"', () => {
         const root = Fantom.createRoot();

--- a/packages/react-native/Libraries/Components/__tests__/Button-itest.js
+++ b/packages/react-native/Libraries/Components/__tests__/Button-itest.js
@@ -259,7 +259,7 @@ describe('<Button>', () => {
             .getRenderedOutput({props: ['accessibilityLabelledBy']})
             .toJSX(),
         ).toEqual(
-          <rn-view accessibilityLabelledBy="formLabel">
+          <rn-view accessibilityLabelledBy="[formLabel]">
             <rn-paragraph>HELLO</rn-paragraph>
           </rn-view>,
         );
@@ -277,7 +277,7 @@ describe('<Button>', () => {
             .getRenderedOutput({props: ['accessibilityLabelledBy']})
             .toJSX(),
         ).toEqual(
-          <rn-view accessibilityLabelledBy={['formLabel']}>
+          <rn-view accessibilityLabelledBy="[formLabel]">
             <rn-paragraph>HELLO</rn-paragraph>
           </rn-view>,
         );

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -283,6 +283,10 @@ SharedDebugStringConvertibleList AccessibilityProps::getDebugProps() const {
           accessibilityLabel,
           defaultProps.accessibilityLabel),
       debugStringConvertibleItem(
+          "accessibilityLabelledBy",
+          accessibilityLabelledBy.value,
+          defaultProps.accessibilityLabelledBy.value),
+      debugStringConvertibleItem(
           "accessibilityLiveRegion",
           accessibilityLiveRegion,
           defaultProps.accessibilityLiveRegion),

--- a/packages/react-native/types_DEPRECATED/Libraries/Components/Button.d.ts
+++ b/packages/react-native/types_DEPRECATED/Libraries/Components/Button.d.ts
@@ -15,6 +15,7 @@ import {TouchableOpacityProps} from './Touchable/TouchableOpacity';
 export interface ButtonProps extends Pick<
   TouchableNativeFeedbackProps & TouchableOpacityProps,
   | 'accessibilityLabel'
+  | 'accessibilityLabelledBy'
   | 'accessibilityState'
   | 'hasTVPreferredFocus'
   | 'nextFocusDown'
@@ -27,6 +28,8 @@ export interface ButtonProps extends Pick<
   | 'onPress'
   | 'touchSoundDisabled'
 > {
+  'aria-labelledby'?: string | undefined;
+
   /**
    * Text to display inside the button. On Android the given title will be converted to the uppercased form.
    */

--- a/private/react-native-fantom/tester/third-party/folly/CMakeLists.txt
+++ b/private/react-native-fantom/tester/third-party/folly/CMakeLists.txt
@@ -71,8 +71,3 @@ target_compile_options(folly_runtime PUBLIC ${folly_FLAGS})
 
 target_include_directories(folly_runtime PUBLIC .)
 target_link_libraries(folly_runtime glog double-conversion boost fmt fast_float)
-if(APPLE)
-  # Newer Apple ld does not pull c++abi into shared libs (e.g. libjsi.dylib)
-  # that link folly Exception.cpp (__cxa_*_exception_refcount).
-  target_link_libraries(folly_runtime c++abi)
-endif()

--- a/private/react-native-fantom/tester/third-party/folly/CMakeLists.txt
+++ b/private/react-native-fantom/tester/third-party/folly/CMakeLists.txt
@@ -71,3 +71,8 @@ target_compile_options(folly_runtime PUBLIC ${folly_FLAGS})
 
 target_include_directories(folly_runtime PUBLIC .)
 target_link_libraries(folly_runtime glog double-conversion boost fmt fast_float)
+if(APPLE)
+  # Newer Apple ld does not pull c++abi into shared libs (e.g. libjsi.dylib)
+  # that link folly Exception.cpp (__cxa_*_exception_refcount).
+  target_link_libraries(folly_runtime c++abi)
+endif()


### PR DESCRIPTION
## Summary:

`View` already maps `accessibilityLabelledBy` / `aria-labelledby`. `Button` does not extend `AccessibilityProps` and does not spread leftover props, so those values were dropped.

Forwarding them only from `Button` is not enough. `TouchableNativeFeedback` and `TouchableOpacity` copy a fixed accessibility list onto the host view; `accessibilityHint` is on that list, labelledBy was not. This change forwards labelledBy the same way so it reaches the native view.

## Changelog:

[GENERAL] [ADDED] - Pass accessibilityLabelledBy and aria-labelledby through Button and Touchable

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Fantom: 12 tests passing, including the native `accessibilityLabelledBy` prop and the `aria-labelledby` alias:

```bash
yarn fantom 'Libraries/Components/__tests__/Button-itest'
```

Result:

<img width="1216" height="453" alt="Captura de pantalla 2026-08-27 a las 20 56 38" src="https://github.com/user-attachments/assets/67e31a26-5547-4cbf-a34b-029754723991" />
