### PR TITLE
Cover `react/renderer/element` with Stable API guards (#58178)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -16,6 +16,7 @@ target_include_directories(react_renderer_element PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_element
         folly_runtime
         glog
+        react_cxxstableapi
         react_renderer_core
         react_renderer_componentregistry
 )

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <memory>
 
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>

--- a/packages/react-native/ReactCommon/react/renderer/element/Element.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/Element.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <functional>
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <functional>
 #include <memory>
 #include <vector>

--- a/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
 #include <react/renderer/components/root/RootComponentDescriptor.h>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/element:element` as a private target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/PrivateGuard.h>` to the module's four exported headers (`Element.h`, `ElementFragment.h`, `ComponentBuilder.h`, `testUtils.h`), and wires the guard dependency into BUCK and CMake.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog: [Internal]

Differential Revision: D117837637


