### PR TITLE
Cover `jserrorhandler` with Stable API guards (#58180)

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(jserrorhandler
         callinvoker
         folly_runtime
         ${mapbufferjni}
+        react_cxxstableapi
         react_featureflags
 )
 target_compile_reactnative_options(jserrorhandler PRIVATE)

--- a/packages/react-native/ReactCommon/jserrorhandler/ErrorUtils.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/ErrorUtils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 #include <iosfwd>
 #include <optional>

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -18,6 +18,12 @@ end
 
 react_native_path = ".."
 
+header_search_paths = []
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/..\"" # ReactCommon, for <react/cxxstableapi/...>
+end
+
 Pod::Spec.new do |s|
   s.name                   = "React-jserrorhandler"
   s.version                = version
@@ -30,6 +36,7 @@ Pod::Spec.new do |s|
   s.header_dir             = "jserrorhandler"
   s.source_files           = podspec_sources(["ErrorUtils.{cpp,h}", "JsErrorHandler.{cpp,h}", "StackTraceParser.{cpp,h}"], ["ErrorUtils.h", "JsErrorHandler.h", "StackTraceParser.h"])
   s.pod_target_xcconfig = {
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
@@ -38,6 +45,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-jsi"
   s.dependency "React-bridging"
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-debug")
 

--- a/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <string>
 #include <vector>
 #include "JsErrorHandler.h"


### PR DESCRIPTION
Summary:

Classifies `jserrorhandler:jserrorhandler` as a "for frameworks" target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's three exported headers (`ErrorUtils.h`, `JsErrorHandler.h`, `StackTraceParser.h`), and wires the guard dependency into BUCK, CMake and CocoaPods.

Consumers that opt into `RN_STRICT_API` now get a warning if they include these headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D117842041


