### PR TITLE
Cover `react/renderer/animations` with guards (#58185)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(react_renderer_animations
         glog
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationCallbackWrapper.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationCallbackWrapper.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/animations/LayoutAnimationKeyFrameManager.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/renderer/animations/LayoutAnimationCallbackWrapper.h>
 #include <react/renderer/animations/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <glog/logging.h>
 #include <react/renderer/animations/primitives.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/animations/LayoutAnimationCallbackWrapper.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/graphics/Float.h>

--- a/packages/react-native/ReactCommon/react/renderer/animations/utils.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/utils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/animations/primitives.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>


### PR DESCRIPTION
Summary:

Classifies `react/renderer/animations:animations` as a "for frameworks" target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's six exported headers (`LayoutAnimationCallbackWrapper.h`, `LayoutAnimationDriver.h`, `LayoutAnimationKeyFrameManager.h`, `conversions.h`, `primitives.h`, `utils.h`), and wires the guard dependency into BUCK and CMake. No CocoaPods change is needed: the module ships as a subspec of `React-Fabric`, whose parent spec already declares `React-cxxstableapi` and calls `mark_as_react_native_build`.

Consumers that opt into `RN_STRICT_API` now get a warning if they include these headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D117863703


