### PR TITLE
Stop using `paperComponentName` in React Native core component specs

### DIFF
--- a/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxNotificationContainer-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxNotificationContainer-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LogBoxNotificationContainer should render both an error and warning notification 1`] = `
-<RCTSafeAreaView
+<SafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -101,7 +101,7 @@ exports[`LogBoxNotificationContainer should render both an error and warning not
       totalLogCount={1}
     />
   </View>
-</RCTSafeAreaView>
+</SafeAreaView>
 `;
 
 exports[`LogBoxNotificationContainer should render null with no logs 1`] = `null`;
@@ -113,7 +113,7 @@ exports[`LogBoxNotificationContainer should render selected fatal error even whe
 exports[`LogBoxNotificationContainer should render selected syntax error even when disabled 1`] = `null`;
 
 exports[`LogBoxNotificationContainer should render the latest error notification 1`] = `
-<RCTSafeAreaView
+<SafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -168,11 +168,11 @@ exports[`LogBoxNotificationContainer should render the latest error notification
       totalLogCount={2}
     />
   </View>
-</RCTSafeAreaView>
+</SafeAreaView>
 `;
 
 exports[`LogBoxNotificationContainer should render the latest warning notification 1`] = `
-<RCTSafeAreaView
+<SafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -227,5 +227,5 @@ exports[`LogBoxNotificationContainer should render the latest warning notificati
       totalLogCount={2}
     />
   </View>
-</RCTSafeAreaView>
+</SafeAreaView>
 `;

--- a/packages/react-native/src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/src/private/components/activityindicator/specs/ActivityIndicatorViewNativeComponent.js
@@ -50,7 +50,4 @@ type RCTActivityIndicatorViewNativeProps = Readonly<{
 
 export default codegenNativeComponent<RCTActivityIndicatorViewNativeProps>(
   'ActivityIndicatorView',
-  {
-    paperComponentName: 'RCTActivityIndicatorView',
-  },
 ) as HostComponent<RCTActivityIndicatorViewNativeProps>;

--- a/packages/react-native/src/private/components/modal/specs/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/components/modal/specs/RCTModalHostViewNativeComponent.js
@@ -146,6 +146,5 @@ export default codegenNativeComponent<RCTModalHostViewNativeProps>(
   'ModalHostView',
   {
     interfaceOnly: true,
-    paperComponentName: 'RCTModalHostView',
   },
 ) as HostComponent<RCTModalHostViewNativeProps>;

--- a/packages/react-native/src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/src/private/components/refreshcontrol/specs/PullToRefreshViewNativeComponent.js
@@ -68,7 +68,6 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 export default codegenNativeComponent<PullToRefreshNativeProps>(
   'PullToRefreshView',
   {
-    paperComponentName: 'RCTRefreshControl',
     excludedPlatforms: ['android'],
   },
 ) as HostComponent<PullToRefreshNativeProps>;

--- a/packages/react-native/src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/src/private/components/safeareaview/specs/RCTSafeAreaViewNativeComponent.js
@@ -22,7 +22,6 @@ type RCTSafeAreaViewNativeProps = Readonly<{
 export default codegenNativeComponent<RCTSafeAreaViewNativeProps>(
   'SafeAreaView',
   {
-    paperComponentName: 'RCTSafeAreaView',
     interfaceOnly: true,
   },
 ) as HostComponent<RCTSafeAreaViewNativeProps>;

--- a/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
@@ -59,7 +59,6 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 });
 
 export default codegenNativeComponent<SwitchNativeProps>('Switch', {
-  paperComponentName: 'RCTSwitch',
   excludedPlatforms: ['android'],
   interfaceOnly: true,
 }) as ComponentType;


### PR DESCRIPTION
Summary:
`paperComponentName` is a `codegenNativeComponent` option that makes the generated
view config announce the old-architecture (Paper) `RCT`-prefixed ViewManager name
instead of the component's own name. We no longer support the old architecture, so
core components should announce their real Fabric names.

Removes the option from the five core specs where it is provably redundant:

| Spec | Name in view config |
|---|---|
| `ActivityIndicatorViewNativeComponent.js` | `RCTActivityIndicatorView` -> `ActivityIndicatorView` |
| `RCTModalHostViewNativeComponent.js` | `RCTModalHostView` -> `ModalHostView` |
| `PullToRefreshViewNativeComponent.js` | `RCTRefreshControl` -> `PullToRefreshView` |
| `RCTSafeAreaViewNativeComponent.js` | `RCTSafeAreaView` -> `SafeAreaView` |
| `SwitchNativeComponent.js` | `RCTSwitch` -> `Switch` |

Each new name already resolves natively, so this is a no-op at runtime:

- **iOS Fabric** — the plugin keys in `RCTFabricComponentsPlugins.mm` and the
  `react_fabric_component_plugin_provider` entries in `BUCK` are all unprefixed and
  match the spec names exactly. Previously the `RCT` prefix was simply stripped again
  by `componentNameByReactViewName()`, which exists only to undo this legacy prefixing.
- **Android Fabric** — mount items carry the C++ descriptor name, not the JS name
  (`IntBufferBatchMountItem`), so Android is unaffected. `ModalHostView` still maps via
  `FabricNameComponentMapping`, and `SafeAreaView` still resolves to
  `ReactSafeAreaViewManager` through the generic `"RCT$className"` fallback in
  `ViewManagerRegistry`. `PullToRefreshView` and `Switch` are Android-excluded.

Deliberately out of scope:

- **The codegen option itself is retained.** 24 Meta-internal specs outside
  `react-native-github` still pass `paperComponentName` (`RCTMapNativeComponent.js`,
  `SliderNativeComponent.js`, the `AdsLWI` previews, MagicIsland, ...), as do
  third-party OSS libraries. `getOptions()` does not validate keys, so removing support
  would silently resolve those components to an unregistered name instead of erroring.
- **`RCTInputAccessoryViewNativeComponent.js` keeps the option**, where it is
  load-bearing: the spec name is `InputAccessory` but the C++ `ComponentName` is
  `InputAccessoryView`, so dropping it would fall through to
  `RCTUnimplementedViewComponentView`. Aligning those needs a rename of the codegen'd
  `InputAccessoryProps`/`InputAccessoryEventEmitter` symbols in handwritten C++/ObjC.
- **`paperComponentNameDeprecated`**, which still has 6 internal users.
- **Documentation.** The `paperComponentName` section of the `name_mapping.md` docs is
  refreshed in a separate diff, so this one touches no Markdown.

Also updates the `RCTSwitch` fiber-type checks in `ReactTreeSerializer.js` to accept
`Switch`, mirroring the existing check in its sibling `DebugInteractions.js`.

Snapshot churn is the renamed element names only. The `RCTRefreshControl` entries in
the `VirtualizedList`/`RelayPaginationView` snapshots are unchanged because they come
from the hardcoded `packages/jest-preset/jest/mocks/RefreshControl.js` mock, not from
the view config.

## Changelog:
[General][Changed] - Core components (`ActivityIndicatorView`, `ModalHostView`, `PullToRefreshView`, `SafeAreaView`, `Switch`) no longer report legacy `RCT`-prefixed names in their view configs

Differential Revision: D117877024


