### PR TITLE
Fix native component event property checks

### DIFF
--- a/packages/react-native/Libraries/ReactNative/__tests__/getNativeComponentAttributes-test.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/getNativeComponentAttributes-test.js
@@ -10,11 +10,13 @@
 
 'use strict';
 
+let mockDefaultEventTypes: {[string]: unknown} = {};
+
 jest.mock('../UIManager', () => ({
   __esModule: true,
   default: {
     getConstants: () => ({ViewManagerNames: []}),
-    getDefaultEventTypes: () => ({}),
+    getDefaultEventTypes: () => mockDefaultEventTypes,
     getViewManagerConfig: name =>
       name === 'TestView'
         ? {
@@ -33,6 +35,10 @@ const getNativeComponentAttributes =
   require('../getNativeComponentAttributes').default;
 
 describe('getNativeComponentAttributes', () => {
+  beforeEach(() => {
+    mockDefaultEventTypes = {};
+  });
+
   it('processes object font variation settings from native view configs', () => {
     const viewConfig = getNativeComponentAttributes('TestView');
 
@@ -45,5 +51,14 @@ describe('getNativeComponentAttributes', () => {
         opsz: 17.25,
       }),
     ).toBe("'opsz' 17.25, 'wght' 552.5");
+  });
+
+  it('merges event types that shadow Object prototype properties', () => {
+    const hasOwnPropertyEvent = {registrationName: 'onHasOwnProperty'};
+    mockDefaultEventTypes = {hasOwnProperty: hasOwnPropertyEvent};
+
+    const viewConfig = getNativeComponentAttributes('TestView');
+
+    expect(viewConfig.hasOwnProperty).toBe(hasOwnPropertyEvent);
   });
 });

--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -134,6 +134,9 @@ function attachDefaultEventTypes(viewConfig: any) {
   }
 }
 
+// $FlowFixMe[method-unbinding]
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
 // TODO: Figure out how to avoid all this runtime initialization cost.
 function merge(destination: ?Object, source: ?Object): ?Object {
   if (!source) {
@@ -144,12 +147,12 @@ function merge(destination: ?Object, source: ?Object): ?Object {
   }
 
   for (const key in source) {
-    if (!source.hasOwnProperty(key)) {
+    if (!hasOwnProperty.call(source, key)) {
       continue;
     }
 
     let sourceValue = source[key];
-    if (destination.hasOwnProperty(key)) {
+    if (hasOwnProperty.call(destination, key)) {
       const destinationValue = destination[key];
       if (
         typeof sourceValue === 'object' &&


### PR DESCRIPTION
## Summary:

Legacy native component event merging invokes `hasOwnProperty` directly on native/default event maps. An own event named `hasOwnProperty` shadows that method and crashes component initialization. Use a bound intrinsic own-property check for both source and destination maps, and add an exact regression.

Hosted Flow caught two stale-server misses in the first patches: method unbinding/exact-object inference, then the deprecated `mixed` annotation. The final head uses the repository-standard suppression around the captured intrinsic and an explicit `unknown` indexer for the mutable test map.

Fixes #58194.

## Changelog:

[GENERAL] [FIXED] - Handle native component event names that shadow Object prototype properties.

## Test Plan:

- Focused `getNativeComponentAttributes` Jest suite: 2 tests passed on the original regression/fix run.
- Final-head targeted ESLint, Prettier check, and `git diff --check` passed.
- Hosted full Flow/lint passed on the final amended head.

No UI change; screenshots are not applicable.
