### PR TITLE
Make AppRegistry keys prototype-safe

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -30,8 +30,8 @@ import invariant from 'invariant';
 type TaskCanceller = () => void;
 type TaskCancelProvider = () => TaskCanceller;
 
-const runnables: Runnables = {};
-const sections: Runnables = {};
+const runnables = Object.create(null) as any as Runnables;
+const sections = Object.create(null) as any as Runnables;
 const taskProviders: Map<string, TaskProvider> = new Map();
 const taskCancelProviders: Map<string, TaskCancelProvider> = new Map();
 let componentProviderInstrumentationHook: ComponentProviderInstrumentationHook =

--- a/packages/react-native/Libraries/ReactNative/__tests__/AppRegistry-test.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/AppRegistry-test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const AppRegistry = require('../AppRegistryImpl');
+
+describe('AppRegistry', () => {
+  it('does not return inherited Object properties as registered apps', () => {
+    expect(AppRegistry.getRunnable('constructor')).toBeUndefined();
+  });
+
+  it('registers app and section keys named __proto__', () => {
+    const app = jest.fn();
+    const section = () =>
+      function Section() {
+        return null;
+      };
+
+    AppRegistry.registerRunnable('__proto__', app);
+    AppRegistry.registerSection('__proto__', section);
+
+    expect(AppRegistry.getRunnable('__proto__')).toBeInstanceOf(Function);
+    expect(AppRegistry.getAppKeys()).toContain('__proto__');
+    expect(AppRegistry.getSectionKeys()).toContain('__proto__');
+    expect(Object.keys(AppRegistry.getSections())).toContain('__proto__');
+  });
+});


### PR DESCRIPTION
## Summary:

AppRegistry stores public app and section keys in plain objects. Inherited names such as `constructor` resolve without registration, while `__proto__` mutates the registry prototype and disappears from key enumeration. Use prototype-free internal registries and add exact app/section regressions.

Fixes #58196.

## Changelog:

[GENERAL] [FIXED] - Store AppRegistry app and section keys without Object prototype collisions.

## Test Plan:

- Focused AppRegistry Jest regressions: 2 tests passed.
- Full Flow: 0 errors.
- Targeted ESLint, Prettier check, and `git diff --check` passed.

No UI change; screenshots are not applicable.