### PR TITLE
Make callable module lookup prototype-safe

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -57,7 +57,8 @@ class MessageQueue {
   __spy: ?(data: SpyData) => void;
 
   constructor() {
-    this._lazyCallableModules = {};
+    // $FlowFixMe[incompatible-type] Object.create(null) is used as a string-keyed map.
+    this._lazyCallableModules = Object.create(null);
     this._queue = [[], [], [], 0];
     this._successCallbacks = new Map();
     this._failureCallbacks = new Map();

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-itest.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-itest.js
@@ -137,6 +137,18 @@ describe('MessageQueue', () => {
     expect(queue.getCallableModule(name)).toEqual(dummyModule);
   });
 
+  it('should not return inherited Object properties as callable modules', () => {
+    expect(queue.getCallableModule('constructor')).toBeNull();
+    expect(queue.getCallableModule('__proto__')).toBeNull();
+  });
+
+  it('should register callable modules named __proto__', () => {
+    const dummyModule = {};
+    queue.registerCallableModule('__proto__', dummyModule);
+
+    expect(queue.getCallableModule('__proto__')).toBe(dummyModule);
+  });
+
   it('should not initialize lazily registered module before it was used for the first time', () => {
     const dummyModule = {},
       name = 'modulesName';


### PR DESCRIPTION
## Summary:

The legacy bridge stores lazy callable modules in an ordinary object. Unregistered names such as `constructor` therefore resolve through `Object.prototype`, while registering `__proto__` mutates the registry prototype. Store the internal string-keyed module map without a prototype and add exact lookup/registration regressions.

Fixes #58198.

## Changelog:

[GENERAL] [FIXED] - Prevent inherited Object properties from resolving as legacy callable modules.

## Test Plan:

- Exact Fantom baseline: 1 failed / 13 passed (`constructor` returned an inherited object).
- Fixed Hermes Fantom: 14/14 passed, including `__proto__` registration.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

The one-time local Fantom native build required `-Wno-error=deprecated-literal-operator` for a vendored nlohmann header under the installed Xcode Clang; the test execution itself is green. No UI change; screenshots are not applicable.
