### PR TITLE
Make native event type cache prototype-safe

### DIFF
--- a/packages/react-native/src/private/renderer/events/ReactNativeEventTypeMapping.js
+++ b/packages/react-native/src/private/renderer/events/ReactNativeEventTypeMapping.js
@@ -30,7 +30,7 @@ type EventPropNames = {
 };
 
 // Cache of already-resolved event types.
-const eventTypeToProps: {[string]: EventPropNames} = {};
+const eventTypeToProps = new Map<string, EventPropNames>();
 
 /**
  * Converts a topLevelType (e.g., "topPointerUp") to a DOM event type
@@ -90,13 +90,13 @@ export function getEventTypePropName(
   eventType: string,
   isCapture: boolean,
 ): string | null {
-  const cached = eventTypeToProps[eventType];
+  const cached = eventTypeToProps.get(eventType);
   if (cached !== undefined) {
     return isCapture ? cached.captured : cached.bubbled;
   }
   const entry = findEventPropNames(eventType);
   if (entry != null) {
-    eventTypeToProps[eventType] = entry;
+    eventTypeToProps.set(eventType, entry);
     return isCapture ? entry.captured : entry.bubbled;
   }
   return null;

--- a/packages/react-native/src/private/renderer/events/__tests__/ReactNativeEventTypeMapping-test.js
+++ b/packages/react-native/src/private/renderer/events/__tests__/ReactNativeEventTypeMapping-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {customDirectEventTypes} from '../../../../../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+import {getEventTypePropName} from '../ReactNativeEventTypeMapping';
+
+describe('ReactNativeEventTypeMapping', () => {
+  afterEach(() => {
+    delete customDirectEventTypes.topConstructor;
+  });
+
+  it('resolves event types that shadow Object prototype properties', () => {
+    customDirectEventTypes.topConstructor = {
+      registrationName: 'onConstructor',
+    };
+
+    expect(getEventTypePropName('constructor', false)).toBe('onConstructor');
+    expect(getEventTypePropName('constructor', true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary:

The EventTarget declarative-prop cache is an ordinary object, so event names such as `constructor` resolve inherited Object properties as cached entries and silently skip their registered handler. Use a typed `Map` for exact event-name keys and add a custom native direct-event regression.

Fixes #58202.

## Changelog:

[GENERAL] [FIXED] - Resolve native EventTarget names that overlap Object prototype properties.

## Test Plan:

- Exact baseline regression expected `onConstructor` and received `undefined`; fixed test passes 1/1.
- Focused Jest suite passed.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
