### PR TITLE
Preserve sparse array length in structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -142,6 +142,21 @@ describe('structuredClone', () => {
     expect(clone).toEqual(value);
   });
 
+  it('preserves holes in sparse arrays', () => {
+    const value = new Array<string>(3);
+    value[1] = 'foo';
+
+    const clone = structuredClone(value);
+
+    expect({
+      length: clone.length,
+      keys: Object.keys(clone),
+    }).toEqual({
+      length: 3,
+      keys: ['1'],
+    });
+  });
+
   it('clones maps', () => {
     const value = new Map([
       ['key1', 'value1'],

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -67,7 +67,7 @@ function structuredCloneInternal<T>(value: T): T {
 
   // Handles arrays.
   if (Array.isArray(value)) {
-    const result = [];
+    const result = new Array<unknown>(value.length);
     memory.set(value, result);
 
     for (const key of Object.keys(value)) {


### PR DESCRIPTION
## Summary:

The structured-clone polyfill initializes array results at length zero, so sparse arrays with trailing holes are shortened. Initialize the clone at the source length before recursively copying enumerable keys, preserving both holes and declared length.

Fixes #58208.

## Changelog:

[GENERAL] [FIXED] - Preserve sparse array length and trailing holes in structuredClone.

## Test Plan:

- Exact baseline cloned a length-3 sparse array as length 2 while retaining key `1`.
- Fixed focused Fantom suite: 33/33 passed; behavior matches Node's native `structuredClone`.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
