### PR TITLE
Clone boxed BigInt values in structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -82,6 +82,18 @@ describe('structuredClone', () => {
     expect(booleanClone).not.toBe(booleanValue);
     expect(booleanClone).toBeInstanceOf(Boolean);
     expect(booleanClone.valueOf()).toBe(true);
+
+    const bigintValue = Object(1n);
+    // $FlowExpectedError[incompatible-use] this intentionally shadows the method.
+    Object.defineProperty(bigintValue, 'valueOf', {
+      value() {
+        throw new Error('Unexpected coercion');
+      },
+    });
+    const bigintClone = structuredClone(bigintValue);
+    expect(bigintClone).not.toBe(bigintValue);
+    expect(bigintClone).toBeInstanceOf(BigInt);
+    expect(bigintClone.valueOf()).toBe(1n);
   });
 
   it('throws with symbols, functions, WeakMap, WeakSet, Promise', () => {

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -27,6 +27,8 @@ const VALID_ERROR_NAMES = new Set([
 const BASIC_CONSTRUCTORS = [Number, String, Boolean, Date];
 
 const ObjectPrototype = Object.prototype;
+// $FlowFixMe[method-unbinding] this is always called with an explicit receiver.
+const bigintValueOf = BigInt.prototype.valueOf;
 
 // Technically the memory value should be a parameter in
 // `structuredCloneInternal` but as an optimization we can reuse the same map
@@ -102,6 +104,13 @@ function structuredCloneInternal<T>(value: T): T {
       // $FlowExpectedError[incompatible-type] we know result is T
       return result;
     }
+  }
+
+  if (value instanceof BigInt) {
+    const result = Object(bigintValueOf.call(value));
+    memory.set(value, result);
+    // $FlowExpectedError[incompatible-type] we know result is T
+    return result;
   }
 
   if (value instanceof Map) {


### PR DESCRIPTION
## Summary:

The structured-clone polyfill handles boxed Boolean, Number, and String objects but returns a plain empty object for boxed BigInt. Capture the built-in BigInt `valueOf`, read the internal primitive without user overrides, clone the wrapper through that value, and register it in clone memory.

Fixes #58210.

## Changelog:

[GENERAL] [FIXED] - Preserve boxed BigInt values in structuredClone without user coercion.

## Test Plan:

- Exact Hermes baseline failed the BigInt-wrapper assertion.
- Final regression shadows the source wrapper's `valueOf` with a throwing function; the clone is distinct, remains a BigInt wrapper, and returns `1n`, matching native `structuredClone`.
- Fixed focused Fantom suite: 32/32 passed.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
