### PR TITLE
Reject boxed Symbols in structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -86,6 +86,7 @@ describe('structuredClone', () => {
 
   it('throws with symbols, functions, WeakMap, WeakSet, Promise', () => {
     expectDataCloneError(() => structuredClone(Symbol()));
+    expectDataCloneError(() => structuredClone(Object(Symbol())));
     expectDataCloneError(() => structuredClone(() => {}));
     expectDataCloneError(() => structuredClone(new WeakMap()));
     expectDataCloneError(() => structuredClone(new WeakSet()));

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -166,6 +166,13 @@ function structuredCloneInternal<T>(value: T): T {
     return result;
   }
 
+  if (value instanceof Symbol) {
+    throw new DOMException(
+      "Failed to execute 'structuredClone' on 'Window': Symbol object could not be cloned.",
+      'DataCloneError',
+    );
+  }
+
   // Known non-serializable objects.
   if (isNonSerializableObject(value) || isPlatformObject(value)) {
     throw new DOMException(


### PR DESCRIPTION
## Summary:

The structured-clone polyfill rejects primitive Symbols but silently converts boxed Symbols to plain empty objects. Recognize Symbol wrappers and throw the expected `DataCloneError` without coercing the wrapper to a string.

Fixes #58212.

## Changelog:

[GENERAL] [FIXED] - Reject boxed Symbol values in structuredClone.

## Test Plan:

- Exact Hermes baseline reported no exception for `structuredClone(Object(Symbol()))`.
- Fixed focused Fantom suite: 32/32 passed, matching native `structuredClone`.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
