### PR TITLE
Preserve Error prototypes in structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -226,22 +226,30 @@ describe('structuredClone', () => {
     // Valid error names
     value.name = 'Error';
     expect(structuredClone(value).name).toBe('Error');
+    expect(structuredClone(value)).toBeInstanceOf(Error);
     value.name = 'EvalError';
     expect(structuredClone(value).name).toBe('EvalError');
+    expect(structuredClone(value)).toBeInstanceOf(EvalError);
     value.name = 'RangeError';
     expect(structuredClone(value).name).toBe('RangeError');
+    expect(structuredClone(value)).toBeInstanceOf(RangeError);
     value.name = 'ReferenceError';
     expect(structuredClone(value).name).toBe('ReferenceError');
+    expect(structuredClone(value)).toBeInstanceOf(ReferenceError);
     value.name = 'SyntaxError';
     expect(structuredClone(value).name).toBe('SyntaxError');
+    expect(structuredClone(value)).toBeInstanceOf(SyntaxError);
     value.name = 'TypeError';
     expect(structuredClone(value).name).toBe('TypeError');
+    expect(structuredClone(value)).toBeInstanceOf(TypeError);
     value.name = 'URIError';
     expect(structuredClone(value).name).toBe('URIError');
+    expect(structuredClone(value)).toBeInstanceOf(URIError);
 
     // Invalid error names
     value.name = 'FooError';
     expect(structuredClone(value).name).toBe('Error');
+    expect(structuredClone(value)).toBeInstanceOf(Error);
   });
 
   it('clones values deeply', () => {

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -14,14 +14,14 @@ import {
   isPlatformObject,
 } from '../webidl/PlatformObjects';
 
-const VALID_ERROR_NAMES = new Set([
-  'Error',
-  'EvalError',
-  'RangeError',
-  'ReferenceError',
-  'SyntaxError',
-  'TypeError',
-  'URIError',
+const ERROR_CONSTRUCTORS: Map<string, Class<Error>> = new Map([
+  ['Error', Error],
+  ['EvalError', EvalError],
+  ['RangeError', RangeError],
+  ['ReferenceError', ReferenceError],
+  ['SyntaxError', SyntaxError],
+  ['TypeError', TypeError],
+  ['URIError', URIError],
 ]);
 
 const BASIC_CONSTRUCTORS = [Number, String, Boolean, Date];
@@ -149,16 +149,11 @@ function structuredCloneInternal<T>(value: T): T {
   }
 
   if (value instanceof Error) {
+    const ErrorConstructor = ERROR_CONSTRUCTORS.get(value.name) ?? Error;
     const result = value.cause
-      ? new Error(value.message, {cause: value.cause})
-      : new Error(value.message);
+      ? new ErrorConstructor(value.message, {cause: value.cause})
+      : new ErrorConstructor(value.message);
     memory.set(value, result);
-
-    if (VALID_ERROR_NAMES.has(value.name)) {
-      result.name = value.name;
-    } else {
-      result.name = 'Error';
-    }
 
     result.stack = value.stack;
 


### PR DESCRIPTION
## Summary:

The structured-clone polyfill validates standard Error names but always creates a base Error, producing objects whose `.name` disagrees with their prototype. Map each serialized standard name to its built-in constructor, instantiate that type directly, and retain base Error as the invalid-name fallback.

Fixes #58214.

## Changelog:

[GENERAL] [FIXED] - Preserve specialized standard Error prototypes in structuredClone.

## Test Plan:

- Exact Hermes baseline first failed `EvalError` prototype identity.
- Fixed focused Fantom suite: 32/32 passed for all seven standard/fallback prototypes, matching native `structuredClone`.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
