### PR TITLE
Preserve __proto__ keys in structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -100,6 +100,39 @@ describe('structuredClone', () => {
     expect(clone).toEqual(value);
   });
 
+  it('clones __proto__ as an own data property', () => {
+    const propertyValue = {key: 'value'};
+    const objectValue = {['__proto__']: propertyValue};
+    const arrayValue: Array<unknown> = [];
+    // $FlowExpectedError[cannot-write] the property is defined, not the prototype.
+    Object.defineProperty(arrayValue, '__proto__', {
+      configurable: true,
+      enumerable: true,
+      value: propertyValue,
+      writable: true,
+    });
+
+    function expectClonedDataProperty(
+      value: interface {},
+      expectedPrototype: interface {},
+    ) {
+      const clone = structuredClone(value);
+      const property = Object.getOwnPropertyDescriptor(clone, '__proto__');
+
+      expect(Object.getPrototypeOf(clone)).toBe(expectedPrototype);
+      expect(property).toEqual({
+        configurable: true,
+        enumerable: true,
+        value: propertyValue,
+        writable: true,
+      });
+      expect(property?.value).not.toBe(propertyValue);
+    }
+
+    expectClonedDataProperty(objectValue, Object.prototype);
+    expectClonedDataProperty(arrayValue, Array.prototype);
+  });
+
   it('does NOT clone non-enumerable properties', () => {
     const value = {foo: 'bar'};
     // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -35,6 +35,25 @@ const ObjectPrototype = Object.prototype;
 // any given point we only have one memory object alive anyway.
 const memory: Map<unknown, unknown> = new Map();
 
+function setClonedProperty(
+  target: interface {},
+  key: string,
+  value: unknown,
+): void {
+  if (key === '__proto__') {
+    // $FlowExpectedError[cannot-write] the property is defined, not the prototype.
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+  } else {
+    // $FlowExpectedError[prop-missing]
+    target[key] = value;
+  }
+}
+
 function structuredCloneInternal<T>(value: T): T {
   // Handles `null` and `undefined`.
   if (value == null) {
@@ -67,11 +86,11 @@ function structuredCloneInternal<T>(value: T): T {
 
   // Handles arrays.
   if (Array.isArray(value)) {
-    const result = [];
+    const result: Array<unknown> = [];
     memory.set(value, result);
 
     for (const key of Object.keys(value)) {
-      result[key] = structuredCloneInternal(value[key]);
+      setClonedProperty(result, key, structuredCloneInternal(value[key]));
     }
 
     // $FlowExpectedError[incompatible-type] we know result is T
@@ -85,8 +104,7 @@ function structuredCloneInternal<T>(value: T): T {
     memory.set(value, result);
 
     for (const key of Object.keys(value)) {
-      // $FlowExpectedError[prop-missing]
-      result[key] = structuredCloneInternal(value[key]);
+      setClonedProperty(result, key, structuredCloneInternal(value[key]));
     }
 
     // $FlowExpectedError[incompatible-type] we know result is T
@@ -181,8 +199,7 @@ function structuredCloneInternal<T>(value: T): T {
   // We need to use Object.keys instead of iterating by indices because we
   // also need to copy arbitrary fields set in the array.
   for (const key of Object.keys(value)) {
-    // $FlowExpectedError[prop-missing]
-    result[key] = structuredCloneInternal(value[key]);
+    setClonedProperty(result, key, structuredCloneInternal(value[key]));
   }
 
   // $FlowExpectedError[incompatible-type] we know result is T


### PR DESCRIPTION
## Summary:

The structured-clone polyfill writes enumerable keys through assignment, so an own `__proto__` data property mutates the clone's prototype and disappears. Route property writes through one helper that retains ordinary assignment on the common path and uses `defineProperty` only for this exceptional key across array, fast-object, and slow-object traversal.

Fixes #58216.

## Changelog:

[GENERAL] [FIXED] - Preserve own __proto__ data properties and normal prototypes in structuredClone.

## Test Plan:

- Exact Hermes baseline produced no own descriptors and replaced both Object/Array clone prototypes with the property value.
- Fixed focused Fantom suite: 33/33 passed; own descriptors, ordinary prototypes, and deeply cloned values match native `structuredClone`.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
