### PR TITLE
Avoid coercing structuredClone failures

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -92,6 +92,17 @@ describe('structuredClone', () => {
     expectDataCloneError(() => structuredClone(Promise.resolve(4)));
   });
 
+  it('does not coerce non-serializable values', () => {
+    const values: Array<$FlowFixMe> = [() => {}, new WeakMap()];
+    for (const value of values) {
+      value[Symbol.toPrimitive] = () => {
+        throw new Error('Unexpected coercion');
+      };
+
+      expectDataCloneError(() => structuredClone(value));
+    }
+  });
+
   it('clones simple objects', () => {
     const value = {foo: 'bar'};
     const clone = structuredClone(value);

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -35,6 +35,13 @@ const ObjectPrototype = Object.prototype;
 // any given point we only have one memory object alive anyway.
 const memory: Map<unknown, unknown> = new Map();
 
+function createDataCloneError(): DOMException {
+  return new DOMException(
+    "Failed to execute 'structuredClone' on 'Window': value could not be cloned.",
+    'DataCloneError',
+  );
+}
+
 function structuredCloneInternal<T>(value: T): T {
   // Handles `null` and `undefined`.
   if (value == null) {
@@ -52,11 +59,7 @@ function structuredCloneInternal<T>(value: T): T {
 
   // Handles unsupported types (symbols and functions).
   if (typeof value !== 'object') {
-    // value is symbol or function
-    throw new DOMException(
-      `Failed to execute 'structuredClone' on 'Window': ${String(value)} could not be cloned.`,
-      'DataCloneError',
-    );
+    throw createDataCloneError();
   }
 
   // Handles circular references.
@@ -168,10 +171,7 @@ function structuredCloneInternal<T>(value: T): T {
 
   // Known non-serializable objects.
   if (isNonSerializableObject(value) || isPlatformObject(value)) {
-    throw new DOMException(
-      `Failed to execute 'structuredClone' on 'Window': ${String(value)} could not be cloned.`,
-      'DataCloneError',
-    );
+    throw createDataCloneError();
   }
 
   // Arbitrary object slow path


### PR DESCRIPTION
## Summary:

The structured-clone polyfill stringifies unsupported inputs while building its error message, letting user coercion replace `DataCloneError` with an arbitrary exception. Centralize the duplicate error construction and use a value-independent message so rejection performs no user callback.

Fixes #58220.

## Changelog:

[GENERAL] [FIXED] - Avoid invoking user coercion while rejecting unsupported structuredClone values.

## Test Plan:

- Exact Hermes baseline let throwing `Symbol.toPrimitive` hooks replace the expected DOMException for a function and WeakMap.
- Fixed focused Fantom suite: 33/33 passed.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

The non-standard message text becomes value-independent; exception type, name, and code remain `DOMException` / `DataCloneError`. No UI change; screenshots are not applicable.
