### PR TITLE
Ignore custom Map and Set iterators when cloning

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -178,6 +178,24 @@ describe('structuredClone', () => {
     expect(clone).toEqual(value);
   });
 
+  it('clones maps and sets without invoking custom iterators', () => {
+    const map = new Map([['key', {value: 1}]]);
+    const set = new Set([{value: 2}]);
+    const throwUnexpectedIteration = () => {
+      throw new Error('Unexpected custom iteration');
+    };
+    // $FlowExpectedError[cannot-write] this intentionally shadows the method.
+    map[Symbol.iterator] = throwUnexpectedIteration;
+    // $FlowExpectedError[cannot-write] this intentionally shadows the method.
+    set[Symbol.iterator] = throwUnexpectedIteration;
+
+    const mapClone = structuredClone(map);
+    const setClone = structuredClone(set);
+
+    expect(mapClone.get('key')).toEqual({value: 1});
+    expect(setClone.values().next().value).toEqual({value: 2});
+  });
+
   it('does NOT clone arbitrary keys in sets', () => {
     const value = new Set(['key1', 'key2', 'key3']);
     // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -27,6 +27,10 @@ const VALID_ERROR_NAMES = new Set([
 const BASIC_CONSTRUCTORS = [Number, String, Boolean, Date];
 
 const ObjectPrototype = Object.prototype;
+// $FlowFixMe[method-unbinding] this is always called with an explicit receiver.
+const mapForEach = Map.prototype.forEach;
+// $FlowFixMe[method-unbinding] this is always called with an explicit receiver.
+const setForEach = Set.prototype.forEach;
 
 // Technically the memory value should be a parameter in
 // `structuredCloneInternal` but as an optimization we can reuse the same map
@@ -108,12 +112,12 @@ function structuredCloneInternal<T>(value: T): T {
     const result = new Map<unknown, unknown>();
     memory.set(value, result);
 
-    for (const [innerKey, innerValue] of value) {
+    mapForEach.call(value, (innerValue: unknown, innerKey: unknown) => {
       result.set(
         structuredCloneInternal(innerKey),
         structuredCloneInternal(innerValue),
       );
-    }
+    });
 
     // $FlowExpectedError[incompatible-type] we know result is T
     return result;
@@ -123,9 +127,9 @@ function structuredCloneInternal<T>(value: T): T {
     const result = new Set<unknown>();
     memory.set(value, result);
 
-    for (const innerValue of value) {
+    setForEach.call(value, (innerValue: unknown) => {
       result.add(structuredCloneInternal(innerValue));
-    }
+    });
 
     // $FlowExpectedError[incompatible-type] we know result is T
     return result;


### PR DESCRIPTION
## Summary:

The structured-clone polyfill traverses Map and Set with `for...of`, invoking user `Symbol.iterator` overrides. Capture and call the built-in `forEach` intrinsics instead so cloning reads the collections' internal entries and performs no iterator override callback.

Fixes #58222.

## Changelog:

[GENERAL] [FIXED] - Ignore custom Map and Set iterators during structuredClone.

## Test Plan:

- Exact Hermes baseline aborted with the custom iterator's error; native `structuredClone` ignored it.
- Fixed focused Fantom suite: 33/33 passed for both Map and Set.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.
