### PR TITLE
Ignore RegExp property overrides when cloning

### DIFF
--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -192,10 +192,24 @@ describe('structuredClone', () => {
 
   it('clones regular expressions', () => {
     const value = new RegExp('foo', 'g');
+    // $FlowExpectedError[prop-missing] these flags are feature-detected at runtime.
+    Object.defineProperties(value, {
+      source: {value: 'bar'},
+      flags: {value: ''},
+      hasIndices: {value: true},
+      global: {value: false},
+      ignoreCase: {value: false},
+      multiline: {value: true},
+      dotAll: {value: true},
+      unicode: {value: true},
+      unicodeSets: {value: true},
+      sticky: {value: true},
+    });
     const clone = structuredClone(value);
     expect(clone).not.toBe(value);
     expect(clone).toBeInstanceOf(RegExp);
-    expect(clone).toEqual(value);
+    expect(clone.source).toBe('foo');
+    expect(clone.flags).toBe('g');
   });
 
   it('clones dates', () => {

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -28,6 +28,57 @@ const BASIC_CONSTRUCTORS = [Number, String, Boolean, Date];
 
 const ObjectPrototype = Object.prototype;
 
+function getRegExpGetter<T>(property: string): ?() => T {
+  return Object.getOwnPropertyDescriptor<T>(RegExp.prototype, property)?.get;
+}
+
+function requireRegExpGetter<T>(property: string): () => T {
+  const getter = getRegExpGetter<T>(property);
+  if (getter == null) {
+    throw new Error(`RegExp ${property} getter is required`);
+  }
+  return getter;
+}
+
+const regExpSourceGetter = requireRegExpGetter<string>('source');
+const regExpHasIndicesGetter = getRegExpGetter<boolean>('hasIndices');
+const regExpGlobalGetter = requireRegExpGetter<boolean>('global');
+const regExpIgnoreCaseGetter = requireRegExpGetter<boolean>('ignoreCase');
+const regExpMultilineGetter = requireRegExpGetter<boolean>('multiline');
+const regExpDotAllGetter = requireRegExpGetter<boolean>('dotAll');
+const regExpUnicodeGetter = requireRegExpGetter<boolean>('unicode');
+const regExpUnicodeSetsGetter = getRegExpGetter<boolean>('unicodeSets');
+const regExpStickyGetter = requireRegExpGetter<boolean>('sticky');
+
+function getRegExpFlags(value: RegExp): string {
+  let flags = '';
+  if (regExpHasIndicesGetter?.call(value)) {
+    flags += 'd';
+  }
+  if (regExpGlobalGetter.call(value)) {
+    flags += 'g';
+  }
+  if (regExpIgnoreCaseGetter.call(value)) {
+    flags += 'i';
+  }
+  if (regExpMultilineGetter.call(value)) {
+    flags += 'm';
+  }
+  if (regExpDotAllGetter.call(value)) {
+    flags += 's';
+  }
+  if (regExpUnicodeGetter.call(value)) {
+    flags += 'u';
+  }
+  if (regExpUnicodeSetsGetter?.call(value)) {
+    flags += 'v';
+  }
+  if (regExpStickyGetter.call(value)) {
+    flags += 'y';
+  }
+  return flags;
+}
+
 // Technically the memory value should be a parameter in
 // `structuredCloneInternal` but as an optimization we can reuse the same map
 // and avoid allocating a new one in every call to `structuredClone`.
@@ -132,7 +183,9 @@ function structuredCloneInternal<T>(value: T): T {
   }
 
   if (value instanceof RegExp) {
-    const result = new RegExp(value.source, value.flags);
+    const source = regExpSourceGetter.call(value);
+    const flags = getRegExpFlags(value);
+    const result = new RegExp(source, flags);
     memory.set(value, result);
 
     // $FlowExpectedError[incompatible-type] we know result is T


### PR DESCRIPTION
## Summary:

The structured-clone polyfill reads user-visible RegExp `source`/`flags`, allowing own overrides to replace internal state. Capture and call the built-in source and individual flag getters, feature-detecting `d`/`v`, and construct canonical `dgimsuvy` flags directly from internal slots.

Fixes #58224.

## Changelog:

[GENERAL] [FIXED] - Clone RegExp internal source and flags without using property overrides.

## Test Plan:

- Exact Hermes baseline cloned internal `/foo/g` with shadowed properties as `/bar/`.
- Final regression shadows `source`, aggregate `flags`, and every individual flag property with conflicting values; the clone remains `/foo/g`.
- Fixed focused Fantom suite: 32/32 passed, matching native `structuredClone`.
- Fresh `yarn flow-check`: 0 errors.
- Targeted ESLint, Prettier, and `git diff --check` passed.

Root review caught that the first draft's captured aggregate `flags` getter still read per-flag overrides; the final head uses the individual intrinsics. No UI change; screenshots are not applicable.
