### PR TITLE
Forward Keyboard listener context

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -104,7 +104,7 @@ class KeyboardImpl {
     listener: (...KeyboardEventDefinitions[K]) => unknown,
     context?: unknown,
   ): EventSubscription {
-    return this._emitter.addListener(eventType, listener);
+    return this._emitter.addListener(eventType, listener, context);
   }
 
   /**

--- a/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
+++ b/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+const RCTDeviceEventEmitter =
+  require('../../../EventEmitter/RCTDeviceEventEmitter').default;
 const LayoutAnimation =
   require('../../../LayoutAnimation/LayoutAnimation').default;
 const dismissKeyboard = require('../../../Utilities/dismissKeyboard').default;
@@ -24,6 +26,25 @@ describe('Keyboard', () => {
   it('uses dismissKeyboard utility', () => {
     Keyboard.dismiss();
     expect(dismissKeyboard).toHaveBeenCalled();
+  });
+
+  it('invokes listeners with the specified context', () => {
+    const context = {};
+    let that;
+    const listener = jest.fn(function (this: unknown, _event: unknown) {
+      that = this;
+    });
+    const subscription = Keyboard.addListener(
+      'keyboardDidShow',
+      listener,
+      context,
+    );
+
+    RCTDeviceEventEmitter.emit('keyboardDidShow', {});
+
+    expect(listener).toHaveBeenCalled();
+    expect(that).toBe(context);
+    subscription.remove();
   });
 
   describe('scheduling layout animation', () => {


### PR DESCRIPTION
## Summary:

`Keyboard.addListener` publicly accepts an optional listener context but drops it before delegating to `NativeEventEmitter`. Forward that argument and cover the callback receiver through the underlying device event emitter.

Fixes #58230.

## Changelog:

[GENERAL] [FIXED] - Honor the optional context passed to `Keyboard.addListener`.

## Test Plan:

- Exact upstream regression failed because the listener receiver was not the supplied context.
- Fixed focused Jest suite: 8/8 passed.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.