### PR TITLE
Fix XMLHttpRequest prototype-key headers

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -191,11 +191,11 @@ class XMLHttpRequest extends EventTarget {
 
     this._cachedResponse = undefined;
     this._hasError = false;
-    this._headers = {};
+    this._headers = Object.create(null);
     this._response = '';
     this._responseType = '';
     this._sent = false;
-    this._lowerCaseResponseHeaders = {};
+    this._lowerCaseResponseHeaders = Object.create(null);
 
     this._clearSubscriptions();
     this._timedOut = false;
@@ -671,13 +671,12 @@ class XMLHttpRequest extends EventTarget {
   setResponseHeaders(responseHeaders: ?Object): void {
     this.responseHeaders = responseHeaders || null;
     const headers = responseHeaders || {};
-    this._lowerCaseResponseHeaders = Object.keys(headers).reduce<{
-      [string]: any,
-    }>((lcaseHeaders, headerName) => {
+    const lowerCaseResponseHeaders: Object = Object.create(null);
+    for (const headerName of Object.keys(headers)) {
       // $FlowFixMe[invalid-computed-prop]
-      lcaseHeaders[headerName.toLowerCase()] = headers[headerName];
-      return lcaseHeaders;
-    }, {});
+      lowerCaseResponseHeaders[headerName.toLowerCase()] = headers[headerName];
+    }
+    this._lowerCaseResponseHeaders = lowerCaseResponseHeaders;
   }
 
   setReadyState(newState: number): void {

--- a/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -295,6 +295,20 @@ describe('XMLHttpRequest', function () {
     expect(xhr._headers['content-type']).toBe('application/json, text/plain');
   });
 
+  it('should support request headers that match Object prototype keys', function () {
+    xhr.open('GET', 'blabla');
+    xhr.setRequestHeader('Constructor', 'first');
+    xhr.setRequestHeader('constructor', 'second');
+    xhr.setRequestHeader('__proto__', 'value');
+
+    // $FlowFixMe[prop-missing]
+    const headers = xhr._headers;
+    expect(headers.constructor).toBe('first, second');
+    expect(Object.getOwnPropertyDescriptor(headers, '__proto__')?.value).toBe(
+      'value',
+    );
+  });
+
   it('should throw when setRequestHeader is called before open', function () {
     expect(() => {
       xhr.setRequestHeader('foo', 'bar');
@@ -317,5 +331,16 @@ describe('XMLHttpRequest', function () {
     expect(xhr.getAllResponseHeaders()).toBe(
       'also-here: Mr. PB\r\newok: lego\r\nfoo-test: 1, 2\r\n__custom: token\r\n',
     );
+  });
+
+  it('should support response headers that match Object prototype keys', function () {
+    xhr.setResponseHeaders({
+      Constructor: 'constructor-value',
+      ['__proto__']: 'proto-value',
+    });
+
+    expect(xhr.getResponseHeader('constructor')).toBe('constructor-value');
+    expect(xhr.getResponseHeader('__proto__')).toBe('proto-value');
+    expect(xhr.getResponseHeader('toString')).toBe(null);
   });
 });


### PR DESCRIPTION
## Summary:

React Native XMLHttpRequest stores request and normalized response headers in ordinary objects, so valid names such as `constructor`, `__proto__`, and `toString` collide with inherited properties. Use prototype-free header maps on reset and response normalization, simplify normalization to a direct loop, and cover request combination plus response lookup behavior.

Fixes #58232.

## Changelog:

[GENERAL] [FIXED] - Support XMLHttpRequest header names that overlap Object prototype properties.

## Test Plan:

- Exact upstream suite: 14 existing tests passed and both new regressions failed.
- Fixed focused Jest suite: 16/16 passed.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.