### PR TITLE
Continue IntersectionObserver batches after stale entries

### DIFF
--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -23,6 +23,7 @@ import {ScrollView, View} from 'react-native';
 import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import DOMRectReadOnly from 'react-native/src/private/webapis/geometry/DOMRectReadOnly';
+import * as IntersectionObserverManager from 'react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager';
 
 declare const IntersectionObserver: Class<IntersectionObserverType>;
 declare const IntersectionObserverEntry: Class<IntersectionObserverEntryType>;
@@ -4274,6 +4275,45 @@ describe('IntersectionObserver', () => {
           expect(intersectionObserverCallback).toHaveBeenCalledTimes(0);
         });
       });
+    });
+
+    it('should dispatch other observers after ignoring disconnected entries', () => {
+      const root = Fantom.createRoot();
+      const firstNodeRef = createRef<HostInstance>();
+      const secondNodeRef = createRef<HostInstance>();
+
+      Fantom.runTask(() => {
+        root.render(
+          <>
+            <View ref={firstNodeRef} />
+            <View ref={secondNodeRef} />
+          </>,
+        );
+      });
+
+      const firstNode = ensureReactNativeElement(firstNodeRef.current);
+      const secondNode = ensureReactNativeElement(secondNodeRef.current);
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+      let firstObserver: IntersectionObserver;
+
+      Fantom.runTask(() => {
+        firstObserver = new IntersectionObserver(firstCallback);
+        observer = new IntersectionObserver(secondCallback);
+        firstObserver.observe(firstNode);
+        observer.observe(secondNode);
+
+        Fantom.scheduleTask(() => {
+          const firstObserverId = firstObserver.__getObserverID();
+          if (firstObserverId == null) {
+            throw new Error('Expected the first observer to be registered');
+          }
+          IntersectionObserverManager.unregisterObserver(firstObserverId);
+        });
+      });
+
+      expect(firstCallback).not.toHaveBeenCalled();
+      expect(secondCallback).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
@@ -266,7 +266,7 @@ function doNotifyIntersectionObservers(): void {
     if (!registeredObserver) {
       // This could happen if the observer is disconnected between commit
       // and mount. In this case, we can just ignore the entries.
-      return;
+      continue;
     }
 
     const {observer, callback} = registeredObserver;


### PR DESCRIPTION
## Summary:

IntersectionObserverManager intentionally tolerates stale native entries after an observer disconnects, but currently returns from the complete notification pass and drops callbacks for every later active observer in that batch. Skip only the stale observer, matching the equivalent ResizeObserver path, and add a deterministic queued-record regression.

Fixes #58234.

## Changelog:

[GENERAL] [FIXED] - Continue dispatching active IntersectionObserver callbacks after a stale observer entry.

## Test Plan:

- Exact upstream focused Fantom run: 110 existing tests passed and the new stale-batch regression failed.
- Fixed focused Fantom run: 111/111 passed across two suites.
- The regression unregisters the first observer at the manager boundary to preserve its already queued native record; public `disconnect()` synchronously removes Fantom records and cannot represent the real commit-to-mount race.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.