### PR TITLE
Continue MutationObserver batches after stale records

### DIFF
--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -23,6 +23,7 @@ import {createRef} from 'react';
 import {View} from 'react-native';
 import setUpMutationObserver from 'react-native/src/private/setup/setUpMutationObserver';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import * as MutationObserverManager from 'react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager';
 
 declare const MutationObserver: Class<MutationObserverType>;
 declare const MutationRecord: Class<MutationRecordType>;
@@ -657,6 +658,46 @@ describe('MutationObserver', () => {
         expect(observer2Records2.length).toBe(1);
         expect([...observer2Records2[0].addedNodes]).toEqual([]);
         expect([...observer2Records2[0].removedNodes]).toEqual([childNode111]);
+      });
+
+      it('should dispatch other observers after ignoring disconnected records', () => {
+        const nodeRef = createRef<HostInstance>();
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+        const activeCallback = jest.fn();
+        const activeObserver = new MutationObserver(activeCallback);
+        activeObserver.observe(node, {childList: true});
+        const disconnectedCallback = jest.fn();
+        const disconnectedObserver = new MutationObserver(disconnectedCallback);
+        disconnectedObserver.observe(node, {childList: true});
+
+        Fantom.runTask(() => {
+          root.render(
+            <View>
+              <View />
+            </View>,
+          );
+
+          Fantom.scheduleTask(() => {
+            const disconnectedObserverId =
+              disconnectedObserver.__getObserverID();
+            if (disconnectedObserverId == null) {
+              throw new Error(
+                'Expected the disconnected observer to be registered',
+              );
+            }
+            MutationObserverManager.unregisterObserver(disconnectedObserverId);
+          });
+        });
+
+        expect(disconnectedCallback).not.toHaveBeenCalled();
+        expect(activeCallback).toHaveBeenCalledTimes(1);
+        activeObserver.disconnect();
       });
     });
 

--- a/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
@@ -181,7 +181,7 @@ function doNotifyMutationObservers(): void {
     if (!registeredObserver) {
       // This could happen if the observer is disconnected between commit
       // and mount. In this case, we can just ignore the entries.
-      return;
+      continue;
     }
 
     const {observer, callback} = registeredObserver;


### PR DESCRIPTION
## Summary:

MutationObserverManager intentionally tolerates stale native records after an observer disconnects, but currently returns from the complete notification pass and drops callbacks for every later active observer in that batch. Skip only the stale observer, matching the equivalent ResizeObserver path, and add a deterministic queued-record regression.

Fixes #58236.

## Changelog:

[GENERAL] [FIXED] - Continue dispatching active MutationObserver callbacks after a stale observer record.

## Test Plan:

- Exact upstream focused Fantom run: 27 existing tests passed and the new stale-batch regression failed.
- Fixed focused Fantom run: 28/28 passed across two suites.
- The regression unregisters the stale observer at the manager boundary to preserve its already queued native record and model the documented commit-to-mount race.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

No UI change; screenshots are not applicable.