### PR TITLE
Validate PerformanceObserver callbacks

### DIFF
--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -121,6 +121,18 @@ export class PerformanceObserver {
   #calledAtLeastOnce = false;
 
   constructor(callback: PerformanceObserverCallback) {
+    if (arguments.length === 0) {
+      throw new TypeError(
+        "Failed to construct 'PerformanceObserver': 1 argument required, but only 0 present.",
+      );
+    }
+
+    if (typeof callback !== 'function') {
+      throw new TypeError(
+        "Failed to construct 'PerformanceObserver': parameter 1 is not of type 'Function'.",
+      );
+    }
+
     this.#callback = callback;
   }
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -14,6 +14,32 @@ import {PerformanceObserverEntryList_public} from '../PerformanceObserver';
 import * as Fantom from '@react-native/fantom';
 
 describe('PerformanceObserver', () => {
+  describe('constructor', () => {
+    it('requires a callback', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-type]
+        return new PerformanceObserver();
+      }).toThrow(
+        "Failed to construct 'PerformanceObserver': 1 argument required, but only 0 present.",
+      );
+    });
+
+    it('requires the callback to be a function', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-type]
+        return new PerformanceObserver(null);
+      }).toThrow(
+        "Failed to construct 'PerformanceObserver': parameter 1 is not of type 'Function'.",
+      );
+      expect(() => {
+        // $FlowExpectedError[incompatible-type]
+        return new PerformanceObserver('not a function');
+      }).toThrow(
+        "Failed to construct 'PerformanceObserver': parameter 1 is not of type 'Function'.",
+      );
+    });
+  });
+
   it('receives notifications for marks and measures', () => {
     const callback = jest.fn();
     const observer = new PerformanceObserver(callback);


### PR DESCRIPTION
## Summary:

`PerformanceObserver` currently accepts missing and non-function callbacks, creating invalid instances that fail only when native delivery tries to invoke the stored value. Validate construction synchronously, distinguish an omitted required argument from an explicitly supplied non-function, and cover both error paths.

Fixes #58238.

## Changelog:

[GENERAL] [FIXED] - Reject missing and non-function PerformanceObserver callbacks during construction.

## Test Plan:

- Exact upstream focused regression: both new constructor assertions failed.
- Fixed Fantom suite: 5 passed with one pre-existing skip.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

Invalid constructor calls now throw synchronously as required; valid callers and UI behavior are unchanged.