### PR TITLE
Preserve DOMRect special number values

### DIFF
--- a/packages/react-native/src/private/webapis/geometry/DOMRectReadOnly.js
+++ b/packages/react-native/src/private/webapis/geometry/DOMRectReadOnly.js
@@ -26,7 +26,7 @@ export interface DOMRectInit {
 }
 
 function castToNumber(value: unknown): number {
-  return value ? Number(value) : 0;
+  return value == null ? 0 : Number(value);
 }
 
 /**

--- a/packages/react-native/src/private/webapis/geometry/__tests__/DOMRect-itest.js
+++ b/packages/react-native/src/private/webapis/geometry/__tests__/DOMRect-itest.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import DOMRect from '../DOMRect';
+import DOMRectReadOnly from '../DOMRectReadOnly';
+
+describe('DOMRect', () => {
+  it('preserves NaN and signed zero constructor values', () => {
+    const rect = new DOMRectReadOnly(-0, NaN, -0, NaN);
+
+    expect(Object.is(rect.x, -0)).toBe(true);
+    expect(Number.isNaN(rect.y)).toBe(true);
+    expect(Object.is(rect.width, -0)).toBe(true);
+    expect(Number.isNaN(rect.height)).toBe(true);
+  });
+
+  it('preserves NaN and signed zero assigned values', () => {
+    const rect = new DOMRect();
+
+    rect.x = -0;
+    rect.y = NaN;
+    rect.width = -0;
+    rect.height = NaN;
+
+    expect(Object.is(rect.x, -0)).toBe(true);
+    expect(Number.isNaN(rect.y)).toBe(true);
+    expect(Object.is(rect.width, -0)).toBe(true);
+    expect(Number.isNaN(rect.height)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary:

The shared DOMRect numeric conversion currently defaults every falsy value to zero, replacing valid `NaN` and changing `-0` to `+0`. Default only nullish optional values, otherwise apply normal Number conversion, and cover both read-only construction and mutable setters.

Fixes #58240.

## Changelog:

[GENERAL] [FIXED] - Preserve NaN and signed zero in DOMRect values.

## Test Plan:

- Exact upstream focused regression: 0/2 assertions passed.
- Fixed focused Fantom regression: 2/2 passed.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

Only observably incorrect special-number normalization changes; ordinary and omitted values are unchanged.