### PR TITLE
Preserve null NodeList forEach context

### DIFF
--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
@@ -75,7 +75,7 @@ export default class NodeList<T> implements Iterable<T>, ArrayLike<T> {
     const arrayLike: ArrayLike<T> = this;
 
     for (let index = 0; index < this._length; index++) {
-      if (thisArg == null) {
+      if (thisArg === undefined) {
         callbackFn(arrayLike[index], index, this);
       } else {
         callbackFn.call(thisArg, arrayLike[index], index, this);

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-itest.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-itest.js
@@ -166,6 +166,18 @@ describe('NodeList', () => {
         i++;
       }, explicitThis);
     });
+
+    it('preserves an explicit null `this` argument', () => {
+      const collection = createNodeList(['a']);
+      let that;
+
+      collection.forEach(function (this: unknown) {
+        'use strict';
+        that = this;
+      }, null);
+
+      expect(that).toBe(null);
+    });
   });
 
   describe('global constructor', () => {


### PR DESCRIPTION
## Summary:

`NodeList.forEach` currently treats both null and undefined as the omitted-context fast path, so a strict callback receives undefined when the caller explicitly supplied null. Use the fast path only for undefined and cover the standards-compatible null receiver.

Fixes #58242.

## Changelog:

[GENERAL] [FIXED] - Preserve an explicit null `thisArg` in NodeList.forEach callbacks.

## Test Plan:

- Exact upstream focused suite: 12 existing tests passed and the new null-context regression failed.
- Fixed focused Fantom suite: 13/13 passed.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

Only the observably incorrect explicit-null context changes; omitted and undefined contexts are unchanged.