### PR TITLE
Sort IntersectionObserver thresholds numerically

### DIFF
--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -323,7 +323,7 @@ function normalizeThreshold(
       return threshold
         .map(t => normalizeThresholdValue(t, 'threshold'))
         .map(t => t ?? 0)
-        .sort();
+        .sort((a, b) => a - b);
     } else if (defaultEmpty) {
       return [];
     } else {
@@ -359,7 +359,7 @@ function normalizeRootThreshold(
     const normalizedArr = rootThreshold
       .map(rt => normalizeThresholdValue(rt, 'rnRootThreshold'))
       .filter((rt): rt is number => rt != null)
-      .sort();
+      .sort((a, b) => a - b);
     return normalizedArr.length === 0 ? null : normalizedArr;
   }
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -321,6 +321,10 @@ describe('IntersectionObserver', () => {
       expect(
         new IntersectionObserver(() => {}, {threshold: [0.5, 0, 1]}).thresholds,
       ).toEqual([0, 0.5, 1]);
+      expect(
+        new IntersectionObserver(() => {}, {threshold: [0.000001, 1e-7]})
+          .thresholds,
+      ).toEqual([1e-7, 0.000001]);
 
       // Does NOT deduplicate (browsers don't do it - shrug)
       expect(
@@ -427,6 +431,11 @@ describe('IntersectionObserver', () => {
         new IntersectionObserver(() => {}, {rnRootThreshold: [0.5, 0, 1]})
           .rnRootThresholds,
       ).toEqual([0, 0.5, 1]);
+      expect(
+        new IntersectionObserver(() => {}, {
+          rnRootThreshold: [0.000001, 1e-7],
+        }).rnRootThresholds,
+      ).toEqual([1e-7, 0.000001]);
 
       // Does NOT deduplicate (browsers don't do it - shrug)
       expect(


### PR DESCRIPTION
## Summary:

Both standard `threshold` and React Native `rnRootThreshold` arrays currently use default lexicographic sorting. Add numeric comparators so valid small values whose string forms use exponent notation are exposed in ascending numeric order, and cover both normalization paths.

Fixes #58244.

## Changelog:

[GENERAL] [FIXED] - Sort IntersectionObserver threshold arrays numerically.

## Test Plan:

- Exact upstream focused run: 108 existing tests passed and both new threshold assertions failed.
- Fixed focused Fantom run: 110/110 passed across two suites.
- Fresh Flow check: 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` passed.

Only incorrectly ordered threshold arrays change.