### PR TITLE
feat(iOS) - `url` function support in `backgroundImage`

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -455,6 +455,7 @@ let reactCore = RNTarget(
 let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
+  searchPaths: ["ReactCommon/react/renderer/imagemanager/platform/ios"],
   excludedPaths: [
     "animated/tests",
     "animations/tests",

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+#import <React/RCTImageResponseDelegate.h>
+#import <react/renderer/components/view/ViewShadowNode.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTBackgroundImageURLLoaderDelegate <RCTImageResponseDelegate>
+
+- (void)backgroundImagesDidLoad;
+
+@end
+
+@interface RCTBackgroundImageURLLoader : NSObject
+
+@property (nonatomic, weak) id<RCTBackgroundImageURLLoaderDelegate> delegate;
+
+- (void)updateStateWithNewState:(facebook::react::ViewShadowNode::ConcreteState::Shared)state oldState:(facebook::react::ViewShadowNode::ConcreteState::Shared)oldState;
+- (nullable UIImage *)loadedImageForUri:(NSString *)uri;
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTBackgroundImageURLLoader.h"
+
+#import <React/RCTImageResponseObserverProxy.h>
+#import <React/RCTLog.h>
+#import <react/renderer/components/view/ViewState.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+using namespace facebook::react;
+
+@implementation RCTBackgroundImageURLLoader {
+  ViewShadowNode::ConcreteState::Shared _state;
+  std::map<std::string, std::shared_ptr<RCTImageResponseObserverProxy>> _uriToObserver;
+  NSMutableDictionary<NSString *, UIImage *> *_loadedImages;
+  NSMutableSet<NSString *> *_completedUris;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _loadedImages = [NSMutableDictionary new];
+    _completedUris = [NSMutableSet new];
+  }
+  return self;
+}
+
+- (void)updateStateWithNewState:(ViewShadowNode::ConcreteState::Shared)state
+                       oldState:(ViewShadowNode::ConcreteState::Shared)oldState
+{
+  const auto *oldRequests = oldState ? &oldState->getData().getBackgroundImageRequests() : nullptr;
+  const auto *newRequests = state ? &state->getData().getBackgroundImageRequests() : nullptr;
+
+  if (oldRequests && newRequests && *oldRequests == *newRequests) {
+    return;
+  }
+
+  if (oldRequests) {
+    for (const auto &request : *oldRequests) {
+      if (request.imageRequest) {
+        auto it = _uriToObserver.find(request.imageSource.uri);
+        if (it != _uriToObserver.end()) {
+          auto &observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.removeObserver(it->second);
+        }
+      }
+    }
+  }
+
+  _state = state;
+  _uriToObserver.clear();
+  [_loadedImages removeAllObjects];
+  [_completedUris removeAllObjects];
+
+  if (newRequests) {
+    // `addObserver` replays a cached image synchronously, so register every uri
+    // first. Otherwise the completion check in notifyDelegateIfAllImagesLoaded
+    // runs against a half-filled map.
+    for (const auto &request : *newRequests) {
+      if (request.imageRequest) {
+        _uriToObserver.try_emplace(request.imageSource.uri);
+      }
+    }
+
+    for (const auto &request : *newRequests) {
+      if (request.imageRequest) {
+        auto it = _uriToObserver.find(request.imageSource.uri);
+        // A null entry is a uri that has not been attached yet. Duplicated uris
+        // share a single observer, matching the previous behaviour.
+        if (it != _uriToObserver.end() && it->second == nullptr) {
+          it->second = std::make_shared<RCTImageResponseObserverProxy>(self);
+          auto &observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.addObserver(it->second);
+        }
+      }
+    }
+  }
+}
+
+- (UIImage *)loadedImageForUri:(NSString *)uri
+{
+  return _loadedImages[uri];
+}
+
+- (void)reset
+{
+  if (_state) {
+    const auto &requests = _state->getData().getBackgroundImageRequests();
+    for (const auto &request : requests) {
+      if (request.imageRequest) {
+        auto it = _uriToObserver.find(request.imageSource.uri);
+        if (it != _uriToObserver.end()) {
+          auto &observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.removeObserver(it->second);
+        }
+      }
+    }
+  }
+
+  _state = nullptr;
+  _uriToObserver.clear();
+  [_loadedImages removeAllObjects];
+  [_completedUris removeAllObjects];
+}
+
+#pragma mark - RCTImageResponseDelegate
+
+- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer
+{
+  for (const auto &[uri, observerProxy] : _uriToObserver) {
+    if (observerProxy.get() == observer) {
+      NSString *nsUri = [NSString stringWithUTF8String:uri.c_str()];
+      _loadedImages[nsUri] = image;
+      [_completedUris addObject:nsUri];
+      break;
+    }
+  }
+
+  [self notifyDelegateIfAllImagesLoaded];
+}
+
+- (void)didReceiveProgress:(float)progress
+                    loaded:(int64_t)loaded
+                     total:(int64_t)total
+              fromObserver:(const void *)observer
+{
+  // Progress tracking not needed for background images
+}
+
+- (void)didReceiveFailure:(NSError *)error fromObserver:(const void *)observer
+{
+  for (const auto &[uri, observerProxy] : _uriToObserver) {
+    if (observerProxy.get() == observer) {
+      NSString *nsUri = [NSString stringWithUTF8String:uri.c_str()];
+      RCTLogWarn(@"Failed to load background image: %@ - %@", nsUri, error);
+      [_completedUris addObject:nsUri];
+      break;
+    }
+  }
+
+  [self notifyDelegateIfAllImagesLoaded];
+}
+
+- (void)notifyDelegateIfAllImagesLoaded
+{
+  if (_completedUris.count == _uriToObserver.size()) {
+    [_delegate backgroundImagesDidLoad];
+  }
+}
+
+@end

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -17,12 +17,14 @@
 #import <react/renderer/core/LayoutMetrics.h>
 #import <react/renderer/core/Props.h>
 
+#import "RCTBackgroundImageURLLoader.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * UIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, RCTBackgroundImageURLLoaderDelegate> {
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -122,6 +122,7 @@ static BOOL RCTViewIsInteractiveAccessibilityElement(UIView *view, const ViewPro
   NSMutableSet<NSString *> *_accessibilityOrderNativeIDs;
   RCTSwiftUIContainerViewWrapper *_swiftUIWrapper;
   BOOL _focusable;
+  RCTBackgroundImageURLLoader *_backgroundImageLoader;
 }
 
 #ifdef RCT_DYNAMIC_FRAMEWORKS
@@ -136,6 +137,8 @@ static BOOL RCTViewIsInteractiveAccessibilityElement(UIView *view, const ViewPro
   if (self = [super initWithFrame:frame]) {
     _props = ViewShadowNode::defaultSharedProps();
     _reactSubviews = [NSMutableArray new];
+    _backgroundImageLoader = [RCTBackgroundImageURLLoader new];
+    _backgroundImageLoader.delegate = self;
 #if !TARGET_OS_TV
     self.multipleTouchEnabled = YES;
 #endif
@@ -675,6 +678,13 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   _eventEmitter = std::static_pointer_cast<const ViewEventEmitter>(eventEmitter);
 }
 
+- (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
+{
+  auto newViewState = std::static_pointer_cast<const ViewShadowNode::ConcreteState>(state);
+  auto oldViewState = oldState ? std::static_pointer_cast<const ViewShadowNode::ConcreteState>(oldState) : nullptr;
+  [_backgroundImageLoader updateStateWithNewState:newViewState oldState:oldViewState];
+}
+
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
@@ -774,6 +784,9 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   [_filterLayer removeFromSuperlayer];
   _filterLayer = nil;
   [self clearExistingBackgroundImageLayers];
+
+  // Clean up background image observers
+  [_backgroundImageLoader reset];
 
   _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN = nil;
   _eventEmitter.reset();
@@ -1310,29 +1323,55 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
         backgroundRepeat = _props->backgroundRepeat[imageIndex % _props->backgroundRepeat.size()];
       }
 
-      CGSize backgroundImageSize = [RCTBackgroundImageUtils calculateBackgroundImageSize:backgroundPositioningArea
-                                                                       itemIntrinsicSize:backgroundPositioningArea.size
-                                                                          backgroundSize:backgroundSize
-                                                                        backgroundRepeat:backgroundRepeat];
-
-      CALayer *gradientLayer;
+      CALayer *itemLayer = nil;
 
       if (std::holds_alternative<LinearGradient>(backgroundImage)) {
+        CGSize backgroundImageSize =
+            [RCTBackgroundImageUtils calculateBackgroundImageSize:backgroundPositioningArea
+                                                itemIntrinsicSize:backgroundPositioningArea.size
+                                                   backgroundSize:backgroundSize
+                                                 backgroundRepeat:backgroundRepeat];
         const auto &linearGradient = std::get<LinearGradient>(backgroundImage);
-        gradientLayer = [RCTLinearGradient gradientLayerWithSize:backgroundImageSize gradient:linearGradient];
+        itemLayer = [RCTLinearGradient gradientLayerWithSize:backgroundImageSize gradient:linearGradient];
       } else if (std::holds_alternative<RadialGradient>(backgroundImage)) {
+        CGSize backgroundImageSize =
+            [RCTBackgroundImageUtils calculateBackgroundImageSize:backgroundPositioningArea
+                                                itemIntrinsicSize:backgroundPositioningArea.size
+                                                   backgroundSize:backgroundSize
+                                                 backgroundRepeat:backgroundRepeat];
         const auto &radialGradient = std::get<RadialGradient>(backgroundImage);
-        gradientLayer = [RCTRadialGradient gradientLayerWithSize:backgroundImageSize gradient:radialGradient];
+        itemLayer = [RCTRadialGradient gradientLayerWithSize:backgroundImageSize gradient:radialGradient];
+      } else if (std::holds_alternative<URLBackgroundImage>(backgroundImage)) {
+        const auto &urlBgImage = std::get<URLBackgroundImage>(backgroundImage);
+        NSString *uri = [NSString stringWithUTF8String:urlBgImage.uri.c_str()];
+        UIImage *loadedImage = [_backgroundImageLoader loadedImageForUri:uri];
+        if (loadedImage != nil) {
+          // Bundled assets carry their natural size in layout units. A plain url
+          // has none, so fall back to the decoded image.
+          CGSize intrinsicSize = (urlBgImage.intrinsicWidth > 0 && urlBgImage.intrinsicHeight > 0)
+              ? CGSizeMake(urlBgImage.intrinsicWidth, urlBgImage.intrinsicHeight)
+              : loadedImage.size;
+          CGSize backgroundImageSize = [RCTBackgroundImageUtils calculateBackgroundImageSize:backgroundPositioningArea
+                                                                           itemIntrinsicSize:intrinsicSize
+                                                                              backgroundSize:backgroundSize
+                                                                            backgroundRepeat:backgroundRepeat];
+          CALayer *imageLayer = [CALayer layer];
+          imageLayer.frame = CGRectMake(0, 0, backgroundImageSize.width, backgroundImageSize.height);
+          imageLayer.contents = (__bridge id)loadedImage.CGImage;
+          imageLayer.contentsGravity = kCAGravityResizeAspectFill;
+          itemLayer = imageLayer;
+        }
       }
 
-      if (gradientLayer != nil) {
+      if (itemLayer != nil) {
+        CGSize itemSize = itemLayer.frame.size;
         CALayer *backgroundImageLayer =
             [RCTBackgroundImageUtils createBackgroundImageLayerWithSize:backgroundPositioningArea
                                                            paintingArea:backgroundPaintingArea
-                                                               itemSize:backgroundImageSize
+                                                               itemSize:itemSize
                                                      backgroundPosition:backgroundPosition
                                                        backgroundRepeat:backgroundRepeat
-                                                              itemLayer:gradientLayer];
+                                                              itemLayer:itemLayer];
         [self shapeLayerToMatchView:backgroundImageLayer borderMetrics:borderMetricsBI];
         backgroundImageLayer.masksToBounds = YES;
         backgroundImageLayer.zPosition = BACKGROUND_COLOR_ZPOSITION;
@@ -1444,6 +1483,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     [backgroundImageLayer removeFromSuperlayer];
   }
   [_backgroundImageLayers removeAllObjects];
+}
+
+#pragma mark - RCTBackgroundImageURLLoaderDelegate
+
+- (void)backgroundImagesDidLoad
+{
+  [self invalidateLayer];
 }
 
 #pragma mark - Accessibility

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -149,6 +149,9 @@ Pod::Spec.new do |s|
       sss.dependency             "Yoga"
       sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
+      sss.pod_target_xcconfig  = {
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/react/renderer/imagemanager/platform/ios\""
+      }
     end
 
     ss.subspec "viewUmbrella" do |sss|

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -22,7 +22,10 @@ add_library(rrc_view OBJECT ${rrc_view_SRC})
 react_native_android_selector(platform_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
-target_include_directories(rrc_view PUBLIC ${REACT_COMMON_DIR} ${platform_DIR})
+react_native_android_selector(imagemanager_platform_DIR
+        ${REACT_COMMON_DIR}/react/renderer/imagemanager/platform/android/
+        ${REACT_COMMON_DIR}/react/renderer/imagemanager/platform/cxx/)
+target_include_directories(rrc_view PUBLIC ${REACT_COMMON_DIR} ${platform_DIR} ${imagemanager_platform_DIR})
 
 target_link_libraries(rrc_view
         folly_runtime

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ViewComponentDescriptor.h"
+#include <react/renderer/imagemanager/ImageManager.h>
+
+namespace facebook::react {
+
+extern const char ImageManagerKey[];
+
+ViewComponentDescriptor::ViewComponentDescriptor(
+    const ComponentDescriptorParameters& parameters)
+    : ConcreteComponentDescriptor(parameters),
+      imageManager_(
+          getManagerByName<ImageManager>(contextContainer_, ImageManagerKey)) {}
+
+State::Shared ViewComponentDescriptor::createInitialState(
+    const Props::Shared& /*props*/,
+    const ShadowNodeFamily::Shared& /*family*/) const {
+  return nullptr;
+}
+
+void ViewComponentDescriptor::adopt(ShadowNode& shadowNode) const {
+  ConcreteComponentDescriptor::adopt(shadowNode);
+
+  auto& viewShadowNode = static_cast<ViewShadowNode&>(shadowNode);
+  viewShadowNode.setImageManager(imageManager_);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -14,12 +14,18 @@
 
 namespace facebook::react {
 
+class ImageManager;
+
 class ViewComponentDescriptor : public ConcreteComponentDescriptor<ViewShadowNode> {
  public:
-  ViewComponentDescriptor(const ComponentDescriptorParameters &parameters)
-      : ConcreteComponentDescriptor<ViewShadowNode>(parameters)
-  {
-  }
+  ViewComponentDescriptor(const ComponentDescriptorParameters &parameters);
+
+  void adopt(ShadowNode &shadowNode) const override;
+
+  State::Shared createInitialState(const Props::Shared &props, const ShadowNodeFamily::Shared &family) const override;
+
+ private:
+  const std::shared_ptr<ImageManager> imageManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -8,6 +8,9 @@
 #include "ViewShadowNode.h"
 #include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/primitives.h>
+#include <react/renderer/graphics/BackgroundImage.h>
+#include <react/renderer/imagemanager/ImageManager.h>
+#include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
 
@@ -84,6 +87,81 @@ void ViewShadowNode::initialize() noexcept {
     traits_.set(ShadowNodeTraits::Trait::ChildrenFormStackingContext);
   } else {
     traits_.unset(ShadowNodeTraits::Trait::ChildrenFormStackingContext);
+  }
+}
+
+void ViewShadowNode::setImageManager(
+    const std::shared_ptr<ImageManager>& imageManager) {
+  ensureUnsealed();
+  imageManager_ = imageManager;
+  updateStateIfNeeded();
+}
+
+void ViewShadowNode::updateStateIfNeeded() {
+  if (!imageManager_) {
+    return;
+  }
+
+  ensureUnsealed();
+
+  const auto& viewProps = static_cast<const ViewProps&>(*props_);
+  const auto& backgroundImages = viewProps.backgroundImage;
+
+  std::vector<BackgroundImageURLRequest> newRequests;
+  for (const auto& bgImage : backgroundImages) {
+    if (std::holds_alternative<URLBackgroundImage>(bgImage)) {
+      const auto& urlBgImage = std::get<URLBackgroundImage>(bgImage);
+      if (!urlBgImage.uri.empty()) {
+        BackgroundImageURLRequest request;
+        request.imageSource.uri = urlBgImage.uri;
+        // `resolveAssetSource` already turns bundled assets into a uri on the
+        // JS side, so everything reaching here is addressed by url.
+        request.imageSource.type = ImageSource::Type::Remote;
+        // ImageSource::scale defaults to 3, which would make the decoded image
+        // report a third of its real size. Bundled assets carry their natural
+        // size in the props instead, so treat the decoded pixels as 1x here.
+        request.imageSource.scale = 1;
+        newRequests.push_back(std::move(request));
+      }
+    }
+  }
+
+  if (newRequests.empty()) {
+    return;
+  }
+
+  // A view only gets state once it has a url() background image, so there may
+  // be nothing to compare against yet.
+  if (state_) {
+    const auto& savedState = getStateData();
+    const auto& oldRequests = savedState.getBackgroundImageRequests();
+
+    bool requestsChanged = newRequests.size() != oldRequests.size();
+    if (!requestsChanged) {
+      for (size_t i = 0; i < newRequests.size(); ++i) {
+        if (newRequests[i].imageSource != oldRequests[i].imageSource) {
+          requestsChanged = true;
+          break;
+        }
+      }
+    }
+
+    if (!requestsChanged) {
+      return;
+    }
+  }
+
+  for (auto& request : newRequests) {
+    request.imageRequest = std::make_shared<ImageRequest>(
+        imageManager_->requestImage(request.imageSource, getSurfaceId()));
+  }
+
+  ViewState state{std::move(newRequests)};
+  if (state_) {
+    setStateData(std::move(state));
+  } else {
+    state_ = std::make_shared<const ConcreteState>(
+        std::make_shared<const ViewState>(std::move(state)), getFamilyShared());
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -11,8 +11,11 @@
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/view/ViewState.h>
 
 namespace facebook::react {
+
+class ImageManager;
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 extern const char ViewComponentName[];
@@ -22,14 +25,19 @@ using ViewShadowNodeProps = ViewProps;
 /*
  * `ShadowNode` for <View> component.
  */
-class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewProps, ViewEventEmitter> {
+class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewProps, ViewEventEmitter, ViewState> {
  public:
   ViewShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits);
 
   ViewShadowNode(const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment);
 
+  void setImageManager(const std::shared_ptr<ImageManager> &imageManager);
+
  private:
   void initialize() noexcept;
+  void updateStateIfNeeded();
+
+  std::shared_ptr<ImageManager> imageManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ViewState.h"
+
+namespace facebook::react {
+
+const std::vector<BackgroundImageURLRequest>& ViewState::getBackgroundImageRequests()
+    const {
+  return backgroundImageRequests_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/BackgroundImage.h>
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
+namespace facebook::react {
+
+struct BackgroundImageURLRequest {
+  ImageSource imageSource{};
+  std::shared_ptr<ImageRequest> imageRequest{};
+
+  bool operator==(const BackgroundImageURLRequest& rhs) const {
+    return imageSource == rhs.imageSource && imageRequest == rhs.imageRequest;
+  }
+};
+
+class ViewState final {
+ public:
+  ViewState() = default;
+
+  explicit ViewState(std::vector<BackgroundImageURLRequest> backgroundImageRequests)
+      : backgroundImageRequests_(std::move(backgroundImageRequests)) {}
+
+  const std::vector<BackgroundImageURLRequest>& getBackgroundImageRequests() const;
+
+#ifdef RN_SERIALIZABLE_STATE
+  ViewState(const ViewState& previousState, folly::dynamic data) {}
+
+  folly::dynamic getDynamic() const {
+    return {};
+  }
+#endif
+
+ private:
+  std::vector<BackgroundImageURLRequest> backgroundImageRequests_;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
## Summary:

- Adds support for loading images with `url` syntax. e.g. `backgroundImage: url("https://example.com/1.png")`.
- This PR only includes iOS code changes. To fully test the PR, merge #58246 (JS/parser) and #58247 (Android).

> Recreated from #54996, which was auto-closed when my fork was deleted. GitHub does not allow reopening a PR whose head repository is gone. Rebased onto current `main`.

### How:
- The background image fetching on iOS follows a similar approach to the Image component.
- Fetching starts in the `adopt` function. `RCTViewComponentView` attaches itself as a delegate to receive image fetch updates via `RCTBackgroundImageURLLoader`.

## Changelog:

[IOS] [ADDED] - `url` support with `backgroundImage`

## Test Plan:

- Merge #58246, #58247 and this PR, then test the example added in the JS PR.
- Added testcases for `url` syntax in JS and native parser.
- Verified in RN Tester on the iOS simulator.

### Notes


This PR depends on `URLBackgroundImage` from #58246. `ViewShadowNode.cpp` is compiled into `rrc_view` on Android, so `build_android` and the C++ API snapshot check cannot pass until #58246 lands. 