### PR TITLE
Inline the last duplicate Platform.select key

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
@@ -479,6 +479,10 @@ describe('Platform.select', () => {
     expect(select('{ios() { return 1; }}')).toContain('function');
   });
 
+  test('uses the last definition of a duplicate key', () => {
+    expect(select('{ios: 1, ios: 2}')).toContain('const value=2');
+  });
+
   test('does not inline computed keys', () => {
     expect(select('{[key]: 1, default: 2}')).toContain('Platform.select');
   });

--- a/packages/react-native-babel-preset/src/inline-platform-plugin.js
+++ b/packages/react-native-babel-preset/src/inline-platform-plugin.js
@@ -430,7 +430,9 @@ module.exports = function inlinePlatformPlugin(
     key /*: string */,
     fallback /*: () => Node */,
   ) /*: Node */ {
-    for (const property of objectExpression.properties) {
+    // Object literal evaluation keeps the last definition of a duplicate key.
+    for (let i = objectExpression.properties.length - 1; i >= 0; i--) {
+      const property = objectExpression.properties[i];
       if (!t.isObjectProperty(property) && !t.isObjectMethod(property)) {
         continue;
       }


### PR DESCRIPTION
## Summary:

The React Native Babel preset statically replaces `Platform.select({...})` for the target platform. Its property scan currently stops at the first matching key, while JavaScript object-literal evaluation keeps the last duplicate definition. For example, `Platform.select({ios: 1, ios: 2})` runs as `2` but the preset compiles it to `1`.

Scan the already-validated static properties from the end so compiled output matches runtime semantics while preserving O(n), allocation-free lookup. Metro has a parallel transform that can run first; companion [Metro PR #1889](https://github.com/react/metro/pull/1889) applies the same correction so output remains transform-order independent.

## Changelog:

[GENERAL] [FIXED] - Inline the last duplicate key from static Platform.select object literals.

## Test Plan:

- Added a focused preset regression; pristine main emits `const value=1`, while the fix emits `const value=2`.
- Full preset Jest passes: 4/4 suites, 111/111 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No behavior changes for object literals without duplicate static keys; no UI change.