### PR TITLE
Complete deep import warning coverage

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
@@ -46,6 +46,30 @@ test('deep cjs import', () => {
   `);
 });
 
+test('does not warn for a shadowed require function', () => {
+  const code = `
+    function load(require) {
+      return require('react-native/Libraries/Components/View/View');
+    }
+  `;
+
+  expect(transform(code, [rnDeepImportsWarningPlugin])).not.toContain(
+    'console.warn',
+  );
+});
+
+test('warns for a dynamic import when require is shadowed', () => {
+  const code = `
+    function load(require) {
+      return import('react-native/Libraries/Utilities/Platform');
+    }
+  `;
+
+  expect(transform(code, [rnDeepImportsWarningPlugin])).toContain(
+    "Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Utilities/Platform').",
+  );
+});
+
 test('multiple deep imports', () => {
   const code = `
     import View from 'react-native/Libraries/Components/View/View';
@@ -71,6 +95,16 @@ test('deep reexport', () => {
     "export { PressabilityDebugView } from 'react-native/Libraries/Pressability/PressabilityDebug';
     console.warn(\\"Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Pressability/PressabilityDebug'). Source: path/to/project/foo.js 2:4\\");"
   `);
+});
+
+test('deep export all', () => {
+  const code = `
+    export * from 'react-native/Libraries/Utilities/Platform';
+  `;
+
+  expect(transform(code, [rnDeepImportsWarningPlugin])).toContain(
+    "console.warn(\"Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Utilities/Platform'). Source: path/to/project/foo.js 2:4\");",
+  );
 });
 
 test('import from other package', () => {

--- a/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
+++ b/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
@@ -45,6 +45,15 @@ function withLocation(node, loc) {
   return node;
 }
 
+function recordDeepExport(path, state) {
+  const source = path.node.source;
+
+  if (source && isDeepReactNativeImport(source.value)) {
+    const loc = path.node.loc;
+    state.export.push({source: source.value, loc});
+  }
+}
+
 module.exports = ({types: t}) => ({
   name: 'warn-on-deep-imports',
   visitor: {
@@ -61,7 +70,9 @@ module.exports = ({types: t}) => ({
       const args = path.get('arguments');
 
       if (
-        callee.isIdentifier({name: 'require'}) &&
+        ((callee.isIdentifier({name: 'require'}) &&
+          path.scope.getBinding('require') == null) ||
+          callee.node.type === 'Import') &&
         args.length === 1 &&
         args[0].isStringLiteral()
       ) {
@@ -73,14 +84,8 @@ module.exports = ({types: t}) => ({
         }
       }
     },
-    ExportNamedDeclaration(path, state) {
-      const source = path.node.source;
-
-      if (source && isDeepReactNativeImport(source.value)) {
-        const loc = path.node.loc;
-        state.export.push({source: source.value, loc});
-      }
-    },
+    ExportNamedDeclaration: recordDeepExport,
+    ExportAllDeclaration: recordDeepExport,
     Program: {
       enter(path, state) {
         state.require = [];


### PR DESCRIPTION
## Summary:

The development-only deep-import warning plugin covers static imports, CommonJS requires, and named re-exports, but has three inconsistent boundaries:

- `export * from "react-native/deep"` bypasses the warning even though a named re-export warns.
- literal dynamic `import("react-native/deep")` bypasses the same package-boundary diagnostic.
- a local function or parameter named `require` is mistaken for the free CommonJS loader and produces a false warning.

Share one recorder across both export declaration forms, recognize Babel literal dynamic-import callees, and require `require` to be unbound before treating it as CommonJS. A combined scope regression proves dynamic import still warns inside a function where the sibling local `require` is shadowed.

## Changelog:

[GENERAL] [FIXED] - Complete and scope React Native deep-import development warnings.

## Test Plan:

- Added focused regressions for export-all, literal dynamic import, and shadowed require behavior; each failed against pristine main.
- Full preset Jest passes: 4/4 suites, 113/113 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

This only corrects development diagnostics; runtime and release output are unchanged. No UI change.