### PR TITLE
Preserve nested Platform write targets in Babel preset

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
@@ -316,6 +316,18 @@ describe('unsafe positions', () => {
     `);
   });
 
+  test('replaces reads nested inside an assignment target', () => {
+    const output = transform(`
+      import {Platform} from 'react-native';
+      target[Platform.OS] = value;
+      [target[Platform.OS]] = values;
+      ({[Platform.OS]: target} = value);
+    `);
+
+    expect(output).not.toContain('Platform.OS');
+    expect(output.match(/"ios"/g)).toHaveLength(3);
+  });
+
   test('does not replace for-in or for-of assignment targets', () => {
     expectUnchanged(`
       import {Platform} from 'react-native';

--- a/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
@@ -308,6 +308,24 @@ describe('unsafe positions', () => {
     expect(output).toContain('delete Platform.OS');
   });
 
+  test('does not replace a target nested in an assignment pattern', () => {
+    expectUnchanged(`
+      import {Platform} from 'react-native';
+      [Platform.OS] = values;
+      ({os: Platform.OS} = value);
+    `);
+  });
+
+  test('does not replace for-in or for-of assignment targets', () => {
+    expectUnchanged(`
+      import {Platform} from 'react-native';
+      for (Platform.OS in object) {}
+      for ([Platform.OS] in nestedObject) {}
+      for (Platform.OS of values) {}
+      for ([Platform.OS] of nestedValues) {}
+    `);
+  });
+
   test('does not inline computed access', () => {
     const output = transform(`
       import {Platform} from 'react-native';

--- a/packages/react-native-babel-preset/src/inline-platform-plugin.js
+++ b/packages/react-native-babel-preset/src/inline-platform-plugin.js
@@ -395,15 +395,31 @@ module.exports = function inlinePlatformPlugin(
   function isWriteTarget(
     path /*: NodePath<MemberExpression> */,
   ) /*: boolean */ {
-    const {parent, node} = path;
-    if (parent.type === 'AssignmentExpression' && parent.left === node) {
-      return true;
-    }
-    if (parent.type === 'UpdateExpression' && parent.argument === node) {
-      return true;
-    }
-    if (parent.type === 'UnaryExpression' && parent.operator === 'delete') {
-      return true;
+    let child /*: Node */ = path.node;
+    let parentPath = path.parentPath;
+
+    while (parentPath != null) {
+      const parent = parentPath.node;
+      if (
+        (parent.type === 'AssignmentExpression' ||
+          parent.type === 'ForInStatement' ||
+          parent.type === 'ForOfStatement') &&
+        parent.left === child
+      ) {
+        return true;
+      }
+      if (parent.type === 'UpdateExpression' && parent.argument === child) {
+        return true;
+      }
+      if (
+        parent.type === 'UnaryExpression' &&
+        parent.operator === 'delete' &&
+        parent.argument === child
+      ) {
+        return true;
+      }
+      child = parent;
+      parentPath = parentPath.parentPath;
     }
     return false;
   }

--- a/packages/react-native-babel-preset/src/inline-platform-plugin.js
+++ b/packages/react-native-babel-preset/src/inline-platform-plugin.js
@@ -418,6 +418,17 @@ module.exports = function inlinePlatformPlugin(
       ) {
         return true;
       }
+
+      const nestedWriteTarget =
+        parent.type === 'ArrayPattern' ||
+        parent.type === 'ObjectPattern' ||
+        (parent.type === 'ObjectProperty' && parent.value === child) ||
+        (parent.type === 'RestElement' && parent.argument === child) ||
+        (parent.type === 'AssignmentPattern' && parent.left === child);
+      if (!nestedWriteTarget) {
+        return false;
+      }
+
       child = parent;
       parentPath = parentPath.parentPath;
     }


### PR DESCRIPTION
## Summary:

The React Native Babel preset replaces `Platform.OS` with a string literal even when the member expression is nested inside a destructuring assignment target. Direct and nested `for...in` / `for...of` targets are affected as well; direct loop targets can make Babel abort because a string literal is not a valid assignment target.

Walk the member expression's ancestors and preserve it whenever the containing expression is the left side of an assignment or loop, or the argument of an update/delete operation. This prevents invalid generated syntax and keeps write semantics intact. Metro has a parallel transform, so companion [Metro PR #1890](https://github.com/react/metro/pull/1890) applies the same guard there.

## Changelog:

[GENERAL] [FIXED] - Preserve nested Platform.OS write targets in the Babel preset.

## Test Plan:

- Added regressions for array/object destructuring assignments and direct/nested `for...in` and `for...of` targets.
- Exact baseline rewrites destructuring targets and fails Babel validation for a direct loop target; the fixed suite preserves every write target.
- Full preset Jest passes: 4/4 suites, 112/112 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No public API or intended read-transform behavior changes.
