### PR TITLE
Guard private syntax preservation by transform profile

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
@@ -444,6 +444,25 @@ describe('react-native-babel-preset transform snapshots', () => {
       expect(result).toContain('_classPrivateFieldLooseKey');
     });
 
+    it('transforms private class fields when the profile lowers classes', () => {
+      const code = `
+        class Counter {
+          #count = 0;
+          #privateMethod() { return this.#count; }
+        }
+      `;
+      const result = transformCode(code, {
+        dev: false,
+        unstable_transformProfile: 'hermes-legacy',
+        customTransformOptions: {
+          unstable_preserveClassPrivate: true,
+        },
+      });
+      expect(result).not.toContain('#count');
+      expect(result).not.toContain('#privateMethod');
+      expect(result).toContain('_classPrivateFieldLooseKey');
+    });
+
     it('preserves async/await with unstable_preserveAsync', () => {
       const code = `
         async function fetchData() {

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -94,10 +94,13 @@ const getPreset = (src, options, babel) => {
   // Preserve class syntax and related features for Hermes V1 profiles.
   const preserveClasses = isHermesProfile;
 
-  // Preserve private class fields and methods if the experiment is enabled.
-  const preserveClassPrivate = TRUE_VALS.has(
-    options?.customTransformOptions?.unstable_preserveClassPrivate,
-  );
+  // Private fields can only be preserved when the surrounding class syntax is
+  // also preserved. Babel's class transform requires the private transforms.
+  const preserveClassPrivate =
+    preserveClasses &&
+    TRUE_VALS.has(
+      options?.customTransformOptions?.unstable_preserveClassPrivate,
+    );
 
   // Preserve async/await syntax if the experiment is enabled.
   const preserveAsync = TRUE_VALS.has(


### PR DESCRIPTION
## Summary:

`customTransformOptions.unstable_preserveClassPrivate` currently disables private-field and private-method transforms for every profile. With `hermes-legacy`, the preset still lowers the surrounding class syntax, and Babel then aborts because its class transform requires the private transforms.

Only preserve private syntax when the selected profile also preserves class syntax. Stable and canary Hermes profiles keep their existing experimental behavior; legacy profiles continue lowering private fields and methods together with classes instead of crashing.

## Changelog:

[GENERAL] [FIXED] - Keep private class transforms enabled for profiles that lower classes.

## Test Plan:

- Added a focused `hermes-legacy` regression containing both a private field and private method with the preservation option enabled.
- Exact baseline throws Babel's private-method transform error; the fixed preset compiles and emits the normal private-field helpers.
- Full preset Jest passes: 4/4 suites, 111/111 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No breaking change: stable/canary preservation is unchanged, while an invalid legacy configuration now compiles correctly.
