### PR TITLE
Apply preset defaults without a Babel API

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
@@ -171,6 +171,18 @@ function transformCode(
   return result?.code ?? null;
 }
 
+function transformWithoutBabelApi(code: string): string | null {
+  const config = preset.getPreset(code, {dev: false});
+  const result = babel.transformSync(code, {
+    ...config,
+    babelrc: false,
+    configFile: false,
+    filename: MOCK_FILENAME,
+    sourceMaps: false,
+  });
+  return result?.code ?? null;
+}
+
 function getSnapshotPath(configName: string): string {
   return path.join(OUTPUT_DIR, `${configName}.js`);
 }
@@ -267,6 +279,15 @@ describe('react-native-babel-preset transform snapshots', () => {
   );
 
   describe('specific feature transformations', () => {
+    it('builds the default config without options or a Babel API', () => {
+      expect(() => preset()).not.toThrow();
+    });
+
+    it('uses the default transform profile without a Babel API', () => {
+      const result = transformWithoutBabelApi('class Animal {}');
+      expect(result).toContain('class Animal');
+    });
+
     it('handles async generators', () => {
       const code = `
         async function* gen() {

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -63,16 +63,18 @@ function getInlinePlatform(caller) {
 // use `this.foo = bar` instead of `this.defineProperty('foo', ...)`
 const loose = true;
 
-const getPreset = (src, options, babel) => {
+const getPreset = (src, options = {}, babel) => {
   const transformProfile =
-    options?.unstable_transformProfile ?? babel?.caller(getTransformProfile);
+    options.unstable_transformProfile ??
+    babel?.caller(getTransformProfile) ??
+    'hermes-stable';
 
-  const dev = options?.dev ?? babel?.env('development') ?? false;
+  const dev = options.dev ?? babel?.env('development') ?? false;
 
-  const platform = options?.platform ?? babel?.caller(getPlatform);
+  const platform = options.platform ?? babel?.caller(getPlatform);
 
   const inlinePlatform =
-    options?.inlinePlatform ?? babel?.caller(getInlinePlatform) ?? false;
+    options.inlinePlatform ?? babel?.caller(getInlinePlatform) ?? false;
 
   // Hermes V1 uses more optimised transform profiles. There is currently no
   // difference between stable and canary, but canary may in future be used to
@@ -96,22 +98,22 @@ const getPreset = (src, options, babel) => {
 
   // Preserve private class fields and methods if the experiment is enabled.
   const preserveClassPrivate = TRUE_VALS.has(
-    options?.customTransformOptions?.unstable_preserveClassPrivate,
+    options.customTransformOptions?.unstable_preserveClassPrivate,
   );
 
   // Preserve async/await syntax if the experiment is enabled.
   const preserveAsync = TRUE_VALS.has(
-    options?.customTransformOptions?.unstable_preserveAsync,
+    options.customTransformOptions?.unstable_preserveAsync,
   );
 
   // Preserve block scoping (let/const) if the experiment is enabled.
   const preserveBlockScoping = TRUE_VALS.has(
-    options?.customTransformOptions?.unstable_preserveBlockScoping,
+    options.customTransformOptions?.unstable_preserveBlockScoping,
   );
 
   // Preserve destructuring syntax if the experiment is enabled.
   const preserveDestructuring = TRUE_VALS.has(
-    options?.customTransformOptions?.unstable_preserveDestructuring,
+    options.customTransformOptions?.unstable_preserveDestructuring,
   );
 
   const isNull = src == null;
@@ -144,7 +146,7 @@ const getPreset = (src, options, babel) => {
     extraPlugins.push([require('@react-native/babel-plugin-codegen')]);
   }
 
-  if (!options || !options.disableImportExportTransform) {
+  if (!options.disableImportExportTransform) {
     extraPlugins.push(
       [require('@babel/plugin-proposal-export-default-from')],
       [
@@ -153,7 +155,7 @@ const getPreset = (src, options, babel) => {
           strict: false,
           strictMode: false, // prevent "use strict" injections
           lazy:
-            options && options.lazyImportExportTransform != null
+            options.lazyImportExportTransform != null
               ? options.lazyImportExportTransform
               : importSpecifier => lazyImports.has(importSpecifier),
           allowTopLevelThis: true, // dont rewrite global `this` -> `undefined`
@@ -210,11 +212,11 @@ const getPreset = (src, options, babel) => {
     ]);
   }
 
-  if (options && dev && !options.disableDeepImportWarnings) {
+  if (dev && !options.disableDeepImportWarnings) {
     firstPartyPlugins.push([require('../plugin-warn-on-deep-imports.js')]);
   }
 
-  if (options && dev && !options.useTransformReactJSXExperimental) {
+  if (dev && !options.useTransformReactJSXExperimental) {
     extraPlugins.push([require('@babel/plugin-transform-react-jsx-source')]);
     extraPlugins.push([require('@babel/plugin-transform-react-jsx-self')]);
   }
@@ -230,9 +232,9 @@ const getPreset = (src, options, babel) => {
     ]);
   }
 
-  if (!options || options.enableBabelRuntime !== false) {
+  if (options.enableBabelRuntime !== false) {
     // Allows configuring a specific runtime version to optimize output
-    const isVersion = typeof options?.enableBabelRuntime === 'string';
+    const isVersion = typeof options.enableBabelRuntime === 'string';
 
     extraPlugins.push([
       require('@babel/plugin-transform-runtime'),


### PR DESCRIPTION
## Summary:

The preset's Babel-API accesses are optional, but invoking it without the Babel API still has two incomplete fallback paths: `preset()` can read properties from an undefined options object, and `getPreset(code, {dev: false})` receives no transform profile and silently falls back to legacy class transforms instead of the normal `hermes-stable` default.

Default options to an empty object, consistently rely on that non-null invariant throughout the configuration builder, and apply `hermes-stable` when neither explicit options nor `babel.caller` provides a profile. Explicit options and caller-provided profiles retain precedence.

## Changelog:

[GENERAL] [FIXED] - Apply normal preset defaults when invoked without a Babel API or options object.

## Test Plan:

- Added a regression proving `preset()` builds without options or a Babel API.
- Added a transform regression proving no-API invocation preserves classes under the default `hermes-stable` profile; exact baseline lowers the class to helpers.
- Full preset Jest passes: 4/4 suites, 112/112 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No breaking change: explicit profiles/caller behavior are unchanged, while standalone invocation now matches the preset's documented default path.
