### PR TITLE
Detect formatted React.createClass calls

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
@@ -171,6 +171,21 @@ function transformCode(
   return result?.code ?? null;
 }
 
+function transformCodeWithSourceOptimization(
+  code: string,
+  options: {[string]: unknown},
+): string | null {
+  const config = preset.getPreset(code, options);
+  const result = babel.transformSync(code, {
+    ...config,
+    babelrc: false,
+    configFile: false,
+    filename: MOCK_FILENAME,
+    sourceMaps: false,
+  });
+  return result?.code ?? null;
+}
+
 function getSnapshotPath(configName: string): string {
   return path.join(OUTPUT_DIR, `${configName}.js`);
 }
@@ -267,6 +282,16 @@ describe('react-native-babel-preset transform snapshots', () => {
   );
 
   describe('specific feature transformations', () => {
+    it('adds display names when React.createClass contains trivia', () => {
+      const code = `
+        const Component = React /* comment */ . createClass({
+          render() { return null; }
+        });
+      `;
+      const result = transformCodeWithSourceOptimization(code, {dev: false});
+      expect(result).toContain('displayName:"Component"');
+    });
+
     it('handles async generators', () => {
       const code = `
         async function* gen() {

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -190,7 +190,7 @@ const getPreset = (src, options, babel) => {
   }
   if (
     isNull ||
-    src.indexOf('React.createClass') !== -1 ||
+    src.indexOf('createClass') !== -1 ||
     src.indexOf('createReactClass') !== -1
   ) {
     extraPlugins.push([require('@babel/plugin-transform-react-display-name')]);


### PR DESCRIPTION
## Summary:

The source-optimized preset enables React's display-name transform only when the exact bytes `React.createClass` are present. Valid comments or whitespace around the member access, such as `React /* comment */ . createClass(...)`, bypass the transform and omit the inferred component `displayName`, unlike the full preset path.

Use the stable `createClass` identifier token as the cheap source probe while retaining the separate `createReactClass` probe. Formatting no longer changes output; unrelated token matches only enable an otherwise no-op Babel visitor.

## Changelog:

[GENERAL] [FIXED] - Detect trivia-separated React.createClass calls in optimized preset configuration.

## Test Plan:

- Added an optimized-source regression with comment/whitespace-separated member access.
- Exact baseline omits `displayName`; the fixed transform emits `displayName: "Component"`.
- Full preset Jest passes: 4/4 suites, 111/111 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No public API or breaking behavior change; optimized and full preset paths now agree for valid formatting.
