### PR TITLE
Run codegen for formatted native component calls

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/transform-snapshot-test.js
@@ -267,6 +267,33 @@ describe('react-native-babel-preset transform snapshots', () => {
   );
 
   describe('specific feature transformations', () => {
+    it('runs codegen when the type arguments are separated by trivia', () => {
+      const code = `
+        // @flow strict-local
+        import type {ViewProps} from 'react-native';
+        import type {HostComponent} from 'react-native';
+        import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+        type NativeProps = Readonly<{
+          ...ViewProps,
+        }>;
+
+        export default codegenNativeComponent /* comment */ <NativeProps>(
+          'View',
+        ) as HostComponent<NativeProps>;
+      `;
+      const config = preset.getPreset(code, {});
+      const result = babel.transformSync(code, {
+        ...config,
+        babelrc: false,
+        configFile: false,
+        filename: MOCK_FILENAME,
+        sourceMaps: false,
+      });
+
+      expect(result?.code).toContain('__INTERNAL_VIEW_CONFIG');
+    });
+
     it('handles async generators', () => {
       const code = `
         async function* gen() {

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -139,7 +139,7 @@ const getPreset = (src, options, babel) => {
 
   if (
     !options.disableStaticViewConfigsCodegen &&
-    (src === null || /\bcodegenNativeComponent</.test(src))
+    (isNull || src.indexOf('codegenNativeComponent') !== -1)
   ) {
     extraPlugins.push([require('@react-native/babel-plugin-codegen')]);
   }


### PR DESCRIPTION
## Summary:

The source-optimized preset enables native component codegen only when `codegenNativeComponent` is immediately followed by `<`. Valid Flow syntax permits comments or whitespace before the type arguments, so `codegenNativeComponent /* comment */ <NativeProps>(...)` bypasses codegen and emits an ordinary runtime call instead of the generated `__INTERNAL_VIEW_CONFIG` produced by the full preset path.

Use the stable `codegenNativeComponent` identifier token as the cheap source prefilter while retaining the existing null/undefined full-scan path. Formatting no longer changes build output; false-positive tokens only enable the codegen visitor, which remains a no-op without a matching call.

## Changelog:

[GENERAL] [FIXED] - Run native component codegen when Flow type arguments are separated by trivia.

## Test Plan:

- Added a valid Flow native-component spec containing a comment before `<NativeProps>`.
- Exact optimized baseline emits the ordinary call without `__INTERNAL_VIEW_CONFIG`; the fixed transform generates the static view config.
- Full preset Jest passes: 4/4 suites, 111/111 tests, 16 snapshots.
- Fresh Flow check reports 0 errors.
- Targeted no-ignore ESLint, Prettier, and `git diff --check` pass.

No public API or breaking behavior change; optimized and full preset paths now agree for valid formatting.
