### PR TITLE
Resolve setup-env from the Metro project root

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -61,7 +61,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
     serializer: {
       // NOTE: Overridden in community-cli-plugin
       getModulesRunBeforeMainModule: () => [
-        require.resolve('react-native/setup-env'),
+        require.resolve('react-native/setup-env', {paths: [projectRoot]}),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
       isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {


### PR DESCRIPTION
## Summary:

`@react-native/metro-config` currently resolves `react-native/setup-env` relative to its own package location. In strict or multi-version installs, that can select a different React Native copy—or fail—even though the configured `projectRoot` contains the correct export.

Resolve the bootstrap module with `require.resolve(..., {paths: [projectRoot]})`, matching `community-cli-plugin`'s existing project-scoped behavior. This does not change normal single-version layouts; it makes the existing `projectRoot` contract deterministic across package-manager layouts.

## Changelog:

[GENERAL] [FIXED] - Resolve the React Native setup module from the configured Metro project root.

## Test Plan:

- Built `metro-config` and verified the generated configuration resolves the same `react-native/setup-env` as `require.resolve(..., {paths: [projectRoot]})` for a separate React Native project.
- A synthetic strict project fixture reproduced the baseline selecting the repository React Native; the patch selected `<projectRoot>/node_modules/react-native/setup-env.js`.
- `yarn build metro-config`
- fresh full Flow check: 0 errors
- targeted ESLint and Prettier checks
- `git diff --check`

`metro-config` currently has no Jest tests. Its source wrapper loads `index.flow.js`, which the root Jest Node transform leaves as ESM, so a direct package test fails before execution; this change therefore uses built-output resolution verification rather than adding a bespoke compile/eval-only harness for the one-line fix.
