### PR TITLE
Use Metro runtime's public asyncRequire export

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -86,7 +86,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       allowOptionalDependencies: true,
       assetRegistryPath: 'react-native/asset-registry',
       asyncRequireModulePath:
-        require.resolve('metro-runtime/src/modules/asyncRequire'),
+        require.resolve('metro-runtime/modules/asyncRequire'),
       babelTransformerPath:
         require.resolve('@react-native/metro-babel-transformer'),
       getTransformOptions: async () => ({


### PR DESCRIPTION
## Summary:

`@react-native/metro-config` still resolves Metro's deprecated `src/modules/asyncRequire` deep path. Metro exposes `metro-runtime/modules/asyncRequire` as the stable public API specifically to replace `src/...` imports.

Use that public boundary for `asyncRequireModulePath`. Both specifiers currently resolve to the identical implementation, so bundle behavior is unchanged while the config no longer depends on a deprecated private layout.

## Changelog:

[GENERAL] [CHANGED] - Use Metro runtime's public async-require module export.

## Test Plan:

- Verified both old and new specifiers resolve to the same Metro 0.87 implementation file.
- `yarn build metro-config`
- fresh full Flow check: 0 errors
- targeted ESLint and Prettier checks
- `git diff --check`
- `yarn test packages/metro-config --runInBand --passWithNoTests` (the package currently has no Jest tests)
