### PR TITLE
Make the umbrella context nest (#58261)

### DIFF
--- a/packages/react-native/ReactCommon/callinvoker/React/CallInvoker.h
+++ b/packages/react-native/ReactCommon/callinvoker/React/CallInvoker.h
@@ -18,10 +18,16 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/SchedulerPriority.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/cxxstableapi/UmbrellaGuard.h
+++ b/packages/react-native/ReactCommon/react/cxxstableapi/UmbrellaGuard.h
@@ -29,15 +29,25 @@
 //                        defining RN_STRICT_API.
 //
 //   RN_UMBRELLA_CONTEXT  Internal marker (implementation detail; consumers never
-//                        set it). A module umbrella defines it around its own
-//                        `#include`s to signal the blessed inclusion path:
-//                            #define RN_UMBRELLA_CONTEXT
+//                        set it). A module umbrella brackets its own `#include`s
+//                        with it to signal the blessed inclusion path:
+//                            #pragma push_macro("RN_UMBRELLA_CONTEXT")
+//                            #undef RN_UMBRELLA_CONTEXT
+//                            #define RN_UMBRELLA_CONTEXT 1
 //                            #include <react/.../PublicHeaderA.h>
 //                            #include <react/.../PublicHeaderB.h>
 //                            #undef RN_UMBRELLA_CONTEXT
-//                        The `#undef` matters: it keeps the marker scoped to the
-//                        umbrella's includes so later *direct* includes in the
-//                        same translation unit are still caught.
+//                            #pragma pop_macro("RN_UMBRELLA_CONTEXT")
+//                        Saving and restoring, rather than a bare
+//                        `#define`/`#undef` pair, is what makes the scope both
+//                        end at the umbrella -- later *direct* includes in the
+//                        same translation unit are still caught -- and nest: an
+//                        umbrella reached from inside another umbrella's
+//                        context leaves the outer one armed. A bare `#undef`
+//                        would disarm it, and every public header the outer
+//                        umbrella included afterwards would hard-error.
+//                        `scripts/add-cxxstableapi-guard.js --tier=public`
+//                        emits this block; do not hand-write or "simplify" it.
 //
 //   RN_BUILDING          Defined by React Native's own build targets so internal
 //                        sources may keep including the fine-grained headers

--- a/packages/react-native/ReactCommon/react/debug/React/Debug.h
+++ b/packages/react-native/ReactCommon/react/debug/React/Debug.h
@@ -21,11 +21,17 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/debug/flags.h>
 #include <react/debug/react_native_assert.h>
 #include <react/debug/react_native_expect.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/bridging/React/RendererBridging.h
+++ b/packages/react-native/ReactCommon/react/renderer/bridging/React/RendererBridging.h
@@ -23,11 +23,15 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
-// this block so later *direct* includes in the same translation unit are still
-// caught.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/bridging/bridging.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
@@ -18,8 +18,13 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/components/image/ImageComponentDescriptor.h>
 #include <react/renderer/components/image/ImageEventEmitter.h>
@@ -29,3 +34,4 @@
 #include <react/renderer/components/image/conversions.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/React/Modal.h
@@ -19,8 +19,13 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
@@ -28,3 +33,4 @@
 #include <react/renderer/components/modal/ModalHostViewUtils.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/React/Root.h
@@ -19,11 +19,17 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/components/root/RootProps.h>
 #include <react/renderer/components/root/RootShadowNode.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/React/ScrollView.h
@@ -20,8 +20,13 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/components/scrollview/BaseScrollViewProps.h>
 #include <react/renderer/components/scrollview/HostPlatformScrollViewProps.h>
@@ -40,3 +45,4 @@
 #endif
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/text/React/Text.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/React/Text.h
@@ -19,8 +19,13 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/components/text/BaseParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/BaseParagraphProps.h>
@@ -51,3 +56,4 @@
 #endif
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/React/View.h
@@ -19,9 +19,13 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
-// this block so later *direct* includes in the same TU are still caught.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
@@ -76,3 +80,4 @@
 #endif
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/React/MapBuffer.h
@@ -18,10 +18,16 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/timing/React/Timing.h
+++ b/packages/react-native/ReactCommon/react/timing/React/Timing.h
@@ -18,10 +18,15 @@
 // =============================================================================
 
 // Marks that the following headers are pulled in through the umbrella, so their
-// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. Scoped to
-// this block so later *direct* includes in the same TU are still caught.
-#define RN_UMBRELLA_CONTEXT
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
 
 #include <react/timing/primitives.h>
 
 #undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")


### PR DESCRIPTION
Summary:

Umbrellas bracketed their includes with a bare `#define`/`#undef` of
`RN_UMBRELLA_CONTEXT`. That does not nest: an umbrella reached from inside
another umbrella's context cleared it on the way out, so every public header
the outer umbrella included afterwards hit `UmbrellaGuard.h`. Switch the
bracket to `#pragma push_macro`/`pop_macro` so the inner umbrella restores the
outer context instead of clearing it.

Nothing nests today, it starts once a
for-frameworks header reaches a public module through its umbrella.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D118114589


