### PR TITLE
Cover `jsitooling` with guards (#58262)

### DIFF
--- a/packages/react-native/ReactCommon/jsitooling/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsitooling/CMakeLists.txt
@@ -20,7 +20,8 @@ target_link_libraries(jsitooling
         react_cxxreact
         folly_runtime
         glog
-        jsi)
+        jsi
+        react_cxxstableapi)
 
 target_compile_reactnative_options(jsitooling PRIVATE)
 target_compile_options(jsitooling PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -16,6 +16,12 @@ else
   source[:tag] = "v#{version}"
 end
 
+header_search_paths = []
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/..\"" # ReactCommon, for <react/cxxstableapi/...>
+end
+
 Pod::Spec.new do |s|
   s.name                   = "React-jsitooling"
   s.version                = version
@@ -31,12 +37,14 @@ Pod::Spec.new do |s|
   resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "JSITooling")
 
   s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES",
   }
 
   s.dependency "React-cxxreact", version
   s.dependency "React-jsi", version
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.h
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 #include <string>
 

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef __cplusplus
 
 #include <jsi/jsi.h>

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.h
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Summary:

Classifies `jsitooling:jsitooling` as a for-frameworks target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's three exported headers (`JSRuntimeBindings.h`, `JSRuntimeFactory.h`, `JSRuntimeFactoryCAPI.h`), and wires the guard dependency into BUCK, CMake and CocoaPods.

Changelog: [Internal]

Differential Revision: D118118424


