### PR TITLE
Cover `react/renderer/animated` with guards (#58269)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(react_renderer_animated PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_renderer_animated
       react_codegen_rncore
+      react_cxxstableapi
       react_debug
       react_renderer_core
       react_renderer_graphics

--- a/packages/react-native/ReactCommon/react/renderer/animated/EventEmitterListener.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/EventEmitterListener.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <mutex>
 #include <shared_mutex>
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/MergedValueDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/MergedValueDispatcher.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <functional>

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
 #include "FBReactNativeSpecJSI.h"
 #else

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/animated/MergedValueDispatcher.h>
 #include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
 #include "NativeAnimatedNodesManager.h"

--- a/packages/react-native/ReactCommon/react/renderer/animated/drivers/AnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/drivers/AnimationDriver.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/drivers/AnimationDriverUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/drivers/AnimationDriverUtils.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/drivers/DecayAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/drivers/DecayAnimationDriver.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/drivers/FrameAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/drivers/FrameAnimationDriver.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/drivers/SpringAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/drivers/SpringAnimationDriver.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/event_drivers/EventAnimationDriver.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/event_drivers/EventAnimationDriver.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/MountingTransaction.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <string>
 #include <unordered_set>
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/primitives.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 
 namespace facebook::react::animated {

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/AdditionAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/AdditionAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/AnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/AnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/ColorAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/ColorAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/DiffClampAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/DiffClampAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/DivisionAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/DivisionAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/InterpolationAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/InterpolationAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/ModulusAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/ModulusAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/MultiplicationAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/MultiplicationAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/ObjectAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/ObjectAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/PropsAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/PropsAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/RoundAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/RoundAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/StyleAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/StyleAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/SubtractionAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/SubtractionAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/TrackingAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/TrackingAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/TransformAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/TransformAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/ValueAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/ValueAnimatedNode.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 /*
  * Adapted from react-native-windows under the MIT license.
  */


### PR DESCRIPTION
Summary:

Classifies `react/renderer/animated:animated` as a "for frameworks" target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's 30 non-test headers, and wires the guard dependency into BUCK and CMake. No CocoaPods change is needed: the module ships as a subspec of `React-Fabric`, whose parent spec already declares `React-cxxstableapi` and calls `mark_as_react_native_build`.

Consumers that opt into `RN_STRICT_API` now get a warning if they include these headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D118256232
