### PR TITLE
fix: never round a text node below its measured width

### DIFF
--- a/packages/react-native/Libraries/Text/__tests__/Text-pixelGridRounding-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-pixelGridRounding-itest.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import type {HostInstance} from 'react-native';
+
+import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
+import {createRef} from 'react';
+import {Text, View} from 'react-native';
+
+// A non-integer screen density, as shipped by many Android devices. One
+// physical pixel is 1/2.75 dp.
+const DEVICE_PIXEL_RATIO = 2.75;
+
+// 23 physical pixels, as a float32 dp value. Android measures text in whole
+// physical pixels and hands Yoga the dp equivalent, so `TEXT_WIDTH * 2.75`
+// lands a hair under 23 (22.999999046) rather than exactly on it.
+const TEXT_WIDTH = 8.363636016845703;
+const TEXT_WIDTH_IN_PIXELS = 23;
+
+function measureTextWidthInPixels(paddingLeft: number): number {
+  const root = Fantom.createRoot({devicePixelRatio: DEVICE_PIXEL_RATIO});
+  const textRef = createRef<HostInstance>();
+
+  try {
+    Fantom.runTask(() => {
+      root.render(
+        <View collapsable={false} style={{paddingLeft}}>
+          <Text ref={textRef} style={{width: TEXT_WIDTH}}>
+            text
+          </Text>
+        </View>,
+      );
+    });
+
+    const {width} = nullthrows(textRef.current).getBoundingClientRect();
+    return Math.round(width * DEVICE_PIXEL_RATIO);
+  } finally {
+    root.destroy();
+  }
+}
+
+// The text node's edges land on opposite sides of the tolerance Yoga uses to
+// decide whether a value already sits on the pixel grid: the left edge falls on
+// 103.9999008 scaled units and is snapped up to 104, while the right edge falls
+// on 126.9998999, misses the tolerance, and is floored to 126. Rounding the two
+// edges independently then produced a 22 pixel wide box for 23 pixels of text,
+// and the view dropped the trailing glyph when it re-broke the text at that
+// width.
+test('does not round a text node below the width it measured', () => {
+  expect(measureTextWidthInPixels(37.818145751953125)).toBe(
+    TEXT_WIDTH_IN_PIXELS,
+  );
+});
+
+// The counterpart: a text node that already rounds to the width it measured
+// must not gain a pixel. Here the left edge falls on 28.875 scaled units, well
+// clear of the tolerance, and both edges floor consistently. Forcing the right
+// edge to ceil unconditionally would widen this node to 24 pixels.
+test('does not widen a text node that already fits', () => {
+  expect(measureTextWidthInPixels(10.5)).toBe(TEXT_WIDTH_IN_PIXELS);
+});

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -106,15 +106,37 @@ void roundLayoutResultsToPixelGrid(
     const bool hasFractionalHeight =
         !yoga::inexactEquals(round(scaledNodeHeight), scaledNodeHeight);
 
-    node->getLayout().setDimension(
-        Dimension::Width,
-        roundValueToPixelGrid(
-            absoluteNodeRight,
-            pointScaleFactor,
-            (textRounding && hasFractionalWidth),
-            (textRounding && !hasFractionalWidth)) -
-            roundValueToPixelGrid(
-                absoluteNodeLeft, pointScaleFactor, false, textRounding));
+    const float roundedNodeLeft = roundValueToPixelGrid(
+        absoluteNodeLeft, pointScaleFactor, false, textRounding);
+
+    float roundedNodeWidth = roundValueToPixelGrid(
+                                 absoluteNodeRight,
+                                 pointScaleFactor,
+                                 (textRounding && hasFractionalWidth),
+                                 (textRounding && !hasFractionalWidth)) -
+        roundedNodeLeft;
+
+    // Rounding the two edges independently can still narrow a node below the
+    // size it measured, which is what the comment above means to prevent. The
+    // left and right edge can fall on opposite sides of `inexactEquals`'
+    // tolerance: for text measured as 23 physical pixels on a 2.75 density
+    // screen the left edge lands on 103.9999008 scaled units and is snapped up
+    // to 104, while the right edge lands on 126.9998999, misses the tolerance,
+    // and is floored to 126 - a 22 pixel wide box for 23 pixels of text.
+    //
+    // Recompute the right edge with `forceCeil` in exactly those cases. Nodes
+    // that already round to at least the size they measured keep the width
+    // computed above.
+    const double scaledRoundedNodeWidth =
+        static_cast<double>(roundedNodeWidth) * pointScaleFactor;
+    if (textRounding && scaledRoundedNodeWidth < scaledNodeWith &&
+        !yoga::inexactEquals(scaledRoundedNodeWidth, scaledNodeWith)) {
+      roundedNodeWidth = roundValueToPixelGrid(
+                             absoluteNodeRight, pointScaleFactor, true, false) -
+          roundedNodeLeft;
+    }
+
+    node->getLayout().setDimension(Dimension::Width, roundedNodeWidth);
 
     node->getLayout().setDimension(
         Dimension::Height,


### PR DESCRIPTION
> [!NOTE]
> **This PR description is AI-generated.**

## Summary:

`roundLayoutResultsToPixelGrid` rounds a node's left and right edge to the pixel
grid independently and derives the width from the difference. For a node with a
measure function it aims to never round the size down, "as this could lead to
unwanted text truncation".

That guarantee leaks. `roundValueToPixelGrid` treats a value as already on the
grid when it is within `inexactEquals`' 0.0001 tolerance of a whole pixel, and
the two edges can fall on opposite sides of it. For text measured as 23 physical
pixels on a 2.75 density screen:

```
left   scaled=103.999900818  |1 - fract| = 9.92e-5   < 1e-4  -> snapped up to 104
right  scaled=126.999899864  |1 - fract| = 1.0014e-4 > 1e-4  -> floored to 126
width  = 126 - 104 = 22px, for 23px of text
```

`ReactTextView` re-breaks the text at the width it is mounted with, so the
missing pixel drops the trailing glyph rather than shaving a column off it. This
is the class of bug behind #39722 and #35574.

This is not Android-specific. `pointScaleFactor` 2 is immune because 1/2 is
exactly representable in binary, but 3 is not: at @3x the same shortfall occurs
(124376 of 1606527 probed offsets). Since #57698 now ceils iOS text measurements
onto the pixel grid, iOS text nodes land in exactly the
`hasFractionalWidth == false` branch this bug lives in - though I have only
verified that numerically, not on a device.

The fix recomputes the right edge with `forceCeil` only when the width came out
below what the node measured. Nodes that already round to at least their measured
size, and all nodes without a measure function, are byte-identical to before.

That conditional matters. An unconditional `forceCeil` on text nodes also fixes
the clipping, but it widens roughly a third of text nodes at 2.75 density by one
physical pixel, and it regresses Yoga's existing
`rounding_feature_with_custom_measure_and_fractial_matching_scale`. Moving a
pixel-exact baseline is what got #54260 backed out by D86791267, so this change is
deliberately scoped to only the cases that were already wrong.

Only the width dimension is changed. The height dimension has the same asymmetry,
but a height shortfall clips a row of pixels rather than triggering a re-break,
and `calculateHeight` already returns `getLineBottom()` which includes descent and
line spacing, so it has no comparable user-visible effect. Happy to extend it if
reviewers prefer symmetry.

X-link: https://github.com/react/yoga/pull/2016

## Changelog:

[GENERAL] [FIXED] - Never round a text node below the width it measured, which could clip its trailing glyph on screens with a non-integer pixel ratio

## Test Plan:

**New integration test** - `Text-pixelGridRounding-itest.js`, two cases that
bracket the fix from both sides, at `devicePixelRatio: 2.75`:

| Implementation | does not round below measured | does not widen one that fits |
| --- | --- | --- |
| `main` | FAILED, Expected 23 but received 22 | OK |
| unconditional `forceCeil` | OK | FAILED, Expected 23 but received 24 |
| this change | OK | OK |

```
$ yarn fantom packages/react-native/Libraries/Text/__tests__/Text-pixelGridRounding-itest.js
  does not round a text node below the width it measured (82 ms)
  does not widen a text node that already fits (4 ms)
Tests: 2 passed, 2 total
```

**Yoga unit tests** - the companion Yoga PR (react/yoga#2016) adds the same pair
to `YGRoundingMeasureFuncTest`. There, an unconditional `forceCeil` fails both the
new `does_not_widen_when_it_fits` case and the pre-existing
`rounding_feature_with_custom_measure_and_fractial_matching_scale`; this change
leaves the full suite green at 844 tests from 21 test suites.

**Regression** - `Libraries/Text`, `Libraries/Components/View`,
`webapis/dom/nodes` and `src/private/renderer` under Fantom: 654 passed, 0 failed,
three consecutive runs. `yarn jest packages/react-native/Libraries`: 433 passed,
10 snapshots.

**Numerical equivalence** - replicating `roundLayoutResultsToPixelGrid` over
7,305,900 inputs (7 densities x 3 width forms x 700 left offsets):

```
height output changed        : 0
non-text nodes changed       : 0
width output changed         : 1462
upstream truncating          : 1462   <- identical, so only broken cases change
proposed truncating          : 0
upstream wider than needed   : 2614097
proposed wider than needed   : 2614097 <- no added inflation
```

An adversarial sweep with offsets engineered on both sides of the 0.0001
tolerance (23,166,000 integer-pixel measurements) finds 376701 shortfalls on
`main` and 0 with this change. The residual shortfall is bounded at ~2e-4 of a
physical pixel, which `round()` in `FabricMountingManager.cpp:506` absorbs.

**On-device measurement** - Xiaomi 23049RAD8C, Android 15, 440 dpi
(`PixelRatio.get()` = 2.75).

The window of left positions that trigger the shortfall is only as wide, in
scaled units, as the gap between a text node's measured width and the whole pixel
above it. Android measures text in whole physical pixels, so for real text that
gap is around 1e-6 and the window cannot be hit by an incidental layout - a
fractional padding around right-aligned text in RNTester renders identically with
and without this change. The probe below widens the gap to 9.5e-5 (still under the
1e-4 tolerance, so Yoga still treats the width as sitting on the grid),
binary-searches the pixel boundary to absorb RNTester's ancestor offset, then
sweeps the window:

| | probes | laid out < 23px | laid out > 23px |
| --- | --- | --- | --- |
| `main` | 240 | 38 | 0 |
| this change | 240 | 0 | 0 |

| Before (`main`) | After (this change) |
| --- | --- |
|<img width="1080" height="2400" alt="BEFORE_device" src="https://github.com/user-attachments/assets/763c2520-bc0e-48f4-87e1-267df7a598da" />| <img width="1080" height="2400" alt="AFTER_device" src="https://github.com/user-attachments/assets/32a5bffa-b94e-40cc-bd3f-202c4a837705" /> |

<details>
<summary>Probe used, dropped into <code>RNTesterPlayground.js</code></summary>

```jsx
/**
 * On-device probe for the Yoga pixel-grid width rounding fix.
 *
 * NOT part of the pull request. Drop this into
 *   packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
 * run RNTester on a device with a non-integer pixel ratio, and open the
 * Playground tab. It reports how many text nodes were laid out narrower than
 * the width they measured.
 *
 * @flow strict-local
 * @format
 */

import type {RNTesterModuleExample} from '../../types/RNTesterTypes';

import RNTesterText from '../../components/RNTesterText';
import * as React from 'react';
import {useCallback, useEffect, useRef, useState} from 'react';
import {PixelRatio, StyleSheet, Text, View} from 'react-native';

const SCALE = PixelRatio.get();

// A text node ends up rounded below its measured width when its left edge sits
// just inside Yoga's 1e-4 rounding tolerance below a whole physical pixel (so it
// is snapped up) while its right edge sits just outside it (so it is floored).
//
// TARGET_PX is what the text needs. GAP keeps `WIDTH_DP * SCALE` that far below
// TARGET_PX: under 1e-4 so Yoga still treats the width as sitting on the grid,
// but as large as possible, because the window of left positions that trigger
// the shortfall is exactly GAP wide in scaled units. Android measures real text
// in whole physical pixels, which leaves a gap of only ~1e-6 - too narrow to hit
// by an incidental layout, which is why this widens it deliberately.
const TARGET_PX = 23;
const GAP = 9.5e-5;
const WIDTH_DP = (TARGET_PX - GAP) / SCALE;

const PERIOD_DP = 1 / SCALE;

// RNTester nests the Playground inside a scroll view and other containers, so
// the probe's absolute left carries an unknown offset. Stage 1 locates the
// offset where the rounded left position steps by one pixel; stage 2 sweeps the
// GAP-wide window around it.
const SEARCH_STEPS = 34;
const SWEEP_PROBES = 240;

type Stage =
  | {kind: 'search', lo: number, hi: number, step: number, loPx: ?number}
  | {kind: 'sweep'}
  | {kind: 'done'};

type Shortfall = {left: number, actualPx: number};

// The window sits immediately around the boundary, GAP wide in scaled units.
function sweepLeft(boundary: number, index: number): number {
  const span = (GAP * 1.6) / SCALE;
  const start = boundary - (GAP * 0.3) / SCALE;
  return start + (span * index) / (SWEEP_PROBES - 1);
}

function Playground(): React.Node {
  const probeRef = useRef<mixed>(null);
  const sweepRefs = useRef<Array<mixed>>([]);

  const [stage, setStage] = useState<Stage>({
    kind: 'search',
    lo: 0,
    hi: PERIOD_DP,
    step: 0,
    loPx: null,
  });
  const [boundary, setBoundary] = useState<?number>(null);
  const [report, setReport] = useState<?string>(null);

  const readProbe = useCallback((): ?{leftPx: number, widthPx: number} => {
    const node = probeRef.current;
    // $FlowFixMe[prop-missing] host instance
    if (node == null || typeof node.getBoundingClientRect !== 'function') {
      return null;
    }
    // $FlowFixMe[incompatible-use]
    const rect = node.getBoundingClientRect();
    return {
      leftPx: Math.round(rect.left * SCALE),
      widthPx: Math.round(rect.width * SCALE),
    };
  }, []);

  // Stage 1: binary search the one-pixel step in the rounded left position.
  useEffect(() => {
    if (stage.kind !== 'search') {
      return;
    }
    const timer = setTimeout(() => {
      const measured = readProbe();
      if (measured == null) {
        return;
      }
      if (stage.step === 0) {
        setStage({...stage, step: 1, loPx: measured.leftPx});
        return;
      }
      if (stage.step === 1) {
        setStage({...stage, step: 2});
        return;
      }
      if (stage.step >= SEARCH_STEPS) {
        setBoundary(stage.hi);
        setStage({kind: 'sweep'});
        return;
      }
      const mid = (stage.lo + stage.hi) / 2;
      if (measured.leftPx === stage.loPx) {
        setStage({...stage, lo: mid, step: stage.step + 1});
      } else {
        setStage({...stage, hi: mid, step: stage.step + 1});
      }
    }, 0);
    return () => clearTimeout(timer);
  }, [stage, readProbe]);

  const collectSweep = useCallback(() => {
    if (boundary == null) {
      return;
    }
    const narrow: Array<Shortfall> = [];
    let measured = 0;
    let wide = 0;
    sweepRefs.current.forEach((node, index) => {
      // $FlowFixMe[prop-missing] host instance
      if (node == null || typeof node.getBoundingClientRect !== 'function') {
        return;
      }
      // $FlowFixMe[incompatible-use]
      const actualPx = Math.round(node.getBoundingClientRect().width * SCALE);
      measured++;
      if (actualPx < TARGET_PX) {
        narrow.push({left: sweepLeft(boundary, index), actualPx});
      } else if (actualPx > TARGET_PX) {
        wide++;
      }
    });

    setReport(
      [
        `PixelRatio.get()  = ${SCALE}`,
        `text needs        = ${TARGET_PX} px  (width x scale = ${(WIDTH_DP * SCALE).toFixed(8)})`,
        `pixel boundary at = ${boundary.toFixed(8)} dp`,
        `probes            = ${measured}`,
        `laid out < ${TARGET_PX}px   = ${narrow.length}`,
        `laid out > ${TARGET_PX}px   = ${wide}`,
        '',
        narrow.length === 0
          ? `no text node was rounded below ${TARGET_PX} px`
          : narrow
              .slice(0, 6)
              .map(
                s =>
                  `  left ${s.left.toFixed(8)} dp -> ${s.actualPx} px, needs ${TARGET_PX}`,
              )
              .join('\n'),
      ].join('\n'),
    );
    console.log(
      `[pixelgrid] scale=${SCALE} needs=${TARGET_PX}px boundary=${boundary} probes=${measured} tooNarrow=${narrow.length} tooWide=${wide}`,
    );
    setStage({kind: 'done'});
  }, [boundary]);

  if (stage.kind === 'search') {
    const left = stage.step <= 1 ? stage.lo : stage.hi;
    return (
      <View style={styles.container}>
        <RNTesterText style={styles.title}>
          Yoga pixel-grid width rounding
        </RNTesterText>
        <RNTesterText style={styles.mono}>
          {`locating pixel boundary... step ${stage.step}/${SEARCH_STEPS}`}
        </RNTesterText>
        <View style={styles.probes}>
          <Text
            ref={node => {
              probeRef.current = node;
            }}
            style={{position: 'absolute', top: 0, left, width: WIDTH_DP}}>
            {' '}
          </Text>
        </View>
      </View>
    );
  }

  return (
    <View style={styles.container}>
      <RNTesterText style={styles.title}>
        Yoga pixel-grid width rounding
      </RNTesterText>
      <RNTesterText style={styles.mono}>
        {report ?? 'sweeping window...'}
      </RNTesterText>
      <View
        style={styles.probes}
        onLayout={() => {
          setTimeout(collectSweep, 0);
        }}>
        {Array.from({length: SWEEP_PROBES}, (_, index) => (
          <Text
            key={index}
            ref={node => {
              sweepRefs.current[index] = node;
            }}
            style={{
              position: 'absolute',
              top: 0,
              left: sweepLeft(boundary ?? 0, index),
              width: WIDTH_DP,
            }}>
            {' '}
          </Text>
        ))}
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {padding: 10},
  title: {fontWeight: 'bold', marginBottom: 8},
  mono: {fontSize: 12},
  probes: {height: 1, overflow: 'hidden'},
});

export default {
  title: 'Playground',
  name: 'playground',
  description: 'Test out new features and ideas.',
  render: (): React.Node => <Playground />,
} as RNTesterModuleExample;
```

</details>

**Other checks** - `yarn flow-check` 0 errors; ESLint and Prettier clean on the
new test; `clang-format` reports no replacements; the C++ API snapshot is
unaffected since no signature changed.

**Not verified** - iOS on a device, and the height dimension.
