### PR TITLE
Forward-declare private-target types in RuntimeScheduler.h (#58271)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -11,16 +11,18 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsi/hermes-interfaces.h>
-#include <react/performance/timeline/PerformanceEntryReporter.h>
-#include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/SchedulerPriorityUtils.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <react/timing/primitives.h>
+#include <cstdint>
 #include "RuntimeSchedulerEventTimingDelegate.h"
 #include "RuntimeSchedulerIntersectionObserverDelegate.h"
 #include "RuntimeSchedulerResizeObserverDelegate.h"
 
 namespace facebook::react {
+
+class PerformanceEntryReporter;
+class ShadowTreeRevisionConsistencyManager;
 
 using RuntimeSchedulerRenderingUpdate = std::function<void()>;
 using SurfaceId = int32_t;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -12,7 +12,6 @@
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <atomic>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -10,6 +10,7 @@
 #include <ReactCommon/RuntimeExecutorSyncUIThreadUtils.h>
 #include <cxxreact/TraceSection.h>
 #include <jsinspector-modern/tracing/EventLoopReporter.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
 #include <react/utils/OnScopeExit.h>

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -10,7 +10,6 @@
 #include <react/cxxstableapi/FrameworksGuard.h>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/runtimescheduler/Task.h>
 #include <atomic>

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -18,6 +18,7 @@
 #include <jsi/instrumentation.h>
 #include <jsinspector-modern/HostTarget.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #include <react/runtime/JSRuntimeBindings.h>


### PR DESCRIPTION
Summary:

Replaces `PerformanceEntryReporter` and `ShadowTreeRevisionConsistencyManager` with forward declarations and removes the now redundant `ShadowTreeRevisionConsistencyManager` include from the forked headers.

Changelog:
[General][Changed] - `RuntimeScheduler.h` no longer transitively includes `PerformanceEntryReporter.h` or `ShadowTreeRevisionConsistencyManager.h`; include them directly where the complete types are needed

Differential Revision: D117838094


