### PR TITLE
Fix Maestro image flow keyboard handling

### DIFF
--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -14,6 +14,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: 'example_search'
 - inputText:
     text: 'Image.getSize'
+- hideKeyboard
 - tapOn:
     id: 'platform-test-results'
 - assertVisible: 'Results'


### PR DESCRIPTION
## Summary:

Restore the `hideKeyboard` step in the RNTester Image Maestro flow before tapping the platform test results.

The step was removed in #58166, after which the local Android release and debug jobs consistently failed `image.yml` across all three attempts. The failure artifact from [run 33481521624](https://github.com/react/react-native/actions/runs/33481521624/job/99784789650) shows the Gboard clipboard panel obscuring the lower results UI. The same flow passed in both configurations immediately before that removal.

This does not change the Maestro Cloud exclusions added in #58166. The earlier Cloud Android run with `hideKeyboard` present passed the `image` flow.

## Changelog:

[INTERNAL] [FIXED] - Restore keyboard dismissal in the RNTester Image Maestro flow.

## Test Plan:

- `maestro check-syntax packages/rn-tester/.maestro/image.yml` — passed (`OK`)
- `./node_modules/.bin/prettier --check packages/rn-tester/.maestro/image.yml` — passed
- `git diff --check` — passed
- Compared Android E2E runs before and after #58166: `image.yml` passed on both release and debug before the removal and failed all three attempts afterward.