### PR TITLE
fix(android): keep ReactTextView line breaking advance-based on Android 15+ so the last line is not clipped

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -24,6 +24,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.core.view.AccessibilityDelegateCompat;
@@ -46,10 +47,12 @@ import com.facebook.react.uimanager.style.BorderRadiusProp;
 import com.facebook.react.uimanager.style.BorderStyle;
 import com.facebook.react.uimanager.style.LogicalEdge;
 import com.facebook.react.uimanager.style.Overflow;
+import com.facebook.react.util.AndroidVersion;
 import com.facebook.react.views.text.internal.span.CanvasEffectSpan;
 import com.facebook.react.views.text.internal.span.ReactFragmentIndexSpan;
 import com.facebook.react.views.text.internal.span.ReactTagSpan;
 import com.facebook.yoga.YogaMeasureMode;
+import java.lang.reflect.Method;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactTextView extends AppCompatTextView implements ReactCompoundView {
@@ -59,6 +62,10 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   // https://github.com/aosp-mirror/platform_frameworks_base/blob/master/core/java/android/widget/TextView.java#L854
   private static final int DEFAULT_GRAVITY = Gravity.TOP | Gravity.START;
+
+  // TextView.setUseBoundsForWidth (API 35+). Looked up reflectively because some internal targets
+  // compile against an SDK older than 35 (see AndroidVersion).
+  private static final @Nullable Method SET_USE_BOUNDS_FOR_WIDTH = resolveSetUseBoundsForWidth();
 
   private int mNumberOfLines;
   private @Nullable TextUtils.TruncateAt mEllipsizeLocation;
@@ -76,7 +83,40 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
   public ReactTextView(Context context) {
     super(context);
+    matchLineBreakingToMeasurement();
     initView();
+  }
+
+  private static @Nullable Method resolveSetUseBoundsForWidth() {
+    if (Build.VERSION.SDK_INT < AndroidVersion.VERSION_CODE_VANILLA_ICE_CREAM) {
+      return null;
+    }
+    try {
+      return TextView.class.getMethod("setUseBoundsForWidth", boolean.class);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Keeps this view's line breaking on the same basis as TextLayoutManager's measurement.
+   *
+   * <p>On Android 15+ a TextView in an app targeting API 35+ breaks lines on glyph bounds
+   * (TextView#USE_BOUNDS_FOR_WIDTH), while TextLayoutManager measures with a StaticLayout that
+   * breaks on glyph advances. For a font whose ink overhangs its advance, a line that fit at
+   * measure time can wrap at draw time; the extra line lands outside the measured height and is
+   * never seen. Drawing with advance-based breaking makes the painted line count match the
+   * measured one.
+   */
+  private void matchLineBreakingToMeasurement() {
+    if (SET_USE_BOUNDS_FOR_WIDTH == null) {
+      return;
+    }
+    try {
+      SET_USE_BOUNDS_FOR_WIDTH.invoke(this, false);
+    } catch (ReflectiveOperationException e) {
+      FLog.w(ReactConstants.TAG, "Could not disable useBoundsForWidth on ReactTextView", e);
+    }
   }
 
   /**
@@ -151,6 +191,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NONE);
+    matchLineBreakingToMeasurement();
     updateView(); // call after changing ellipsizeLocation in particular
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
@@ -27,6 +27,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class ReactTextViewTest {
@@ -84,6 +85,28 @@ class ReactTextViewTest {
     val fontSizeWhenShort = largestAbsoluteSizeSpan(text)
 
     assertThat(fontSizeWhenShort).isLessThan(fontSizeWhenTall)
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun breaksLinesOnAdvancesLikeMeasurementOnApi35() {
+    // TextLayoutManager measures with an advance-based StaticLayout; on API 35+ a TextView in an
+    // app targeting 35+ defaults to bounds-based breaking, which can wrap one more line at draw
+    // than at measure and clip it. The view must opt out so both agree.
+    val view = ReactTextView(RuntimeEnvironment.getApplication())
+
+    assertThat(view.useBoundsForWidth).isFalse()
+  }
+
+  @Test
+  @Config(sdk = [35])
+  fun recyclingRestoresAdvanceBasedLineBreaking() {
+    val view = ReactTextView(RuntimeEnvironment.getApplication())
+    view.useBoundsForWidth = true
+
+    view.recycleView()
+
+    assertThat(view.useBoundsForWidth).isFalse()
   }
 
   private fun layoutAndDraw(view: TestReactTextView, width: Int, height: Int) {

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1443,6 +1443,51 @@ const examples = [
     },
   },
   {
+    title: 'Android 15+ glyph overhang (last line must not disappear)',
+    name: 'androidGlyphOverhangLineBreaking',
+    render(): React.Node {
+      // Android's generic `cursive` family (Dancing Script) has glyphs whose
+      // ink extends past their advance. In a shrink-wrapping container the view
+      // is measured on advances; if the drawn TextView breaks lines on bounds
+      // instead, the trailing colored "f" wraps to a line outside the measured
+      // height and is never painted. Every row must show its green "f".
+      const rows = [
+        'Enjoy your',
+        'Enjoy your coffee',
+        'Enjoy your coffee, my',
+        'Enjoy your morning coffee, my friend',
+      ];
+      return (
+        <View>
+          {rows.map(text => (
+            <View key={text} style={{flexDirection: 'row', gap: 8}}>
+              <View style={styles.overhangBubble}>
+                <Text
+                  allowFontScaling={false}
+                  style={{fontFamily: 'cursive', fontSize: 18, lineHeight: 27}}>
+                  {text}
+                  <Text style={{color: 'green'}}> f</Text>
+                </Text>
+              </View>
+              <View style={styles.overhangBubble}>
+                <Text
+                  allowFontScaling={false}
+                  style={{fontSize: 18, lineHeight: 27}}>
+                  {text}
+                  <Text style={{color: 'green'}}> f</Text>
+                </Text>
+              </View>
+            </View>
+          ))}
+          <RNTesterText style={{marginTop: 8}}>
+            Left: cursive (overhangs). Right: default font (control). A missing
+            green f on the left is the bug.
+          </RNTesterText>
+        </View>
+      );
+    },
+  },
+  {
     title: 'Text metrics legend',
     name: 'textMetricLegend',
     render(): React.Node {
@@ -1846,6 +1891,15 @@ const examples = [
 ];
 
 const styles = StyleSheet.create({
+  overhangBubble: {
+    alignSelf: 'flex-start',
+    maxWidth: '48%',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    padding: 8,
+    marginBottom: 8,
+  },
   backgroundColorText: {
     left: 5,
     backgroundColor: 'rgba(100, 100, 100, 0.3)',


### PR DESCRIPTION
## Summary

On Android 15+ (API 35), an app that targets API 35+ gets bounds-based line breaking in every `TextView` by default — the platform compat change `TextView#USE_BOUNDS_FOR_WIDTH`:

```java
// frameworks/base/core/java/android/widget/TextView.java
@ChangeId
@EnabledSince(targetSdkVersion = VERSION_CODES.VANILLA_ICE_CREAM)
public static final long USE_BOUNDS_FOR_WIDTH = 63938206;
…
if (!hasUseBoundForWidthValue) {
    mUseBoundsForWidth = CompatChanges.isChangeEnabled(USE_BOUNDS_FOR_WIDTH);
}
```

React Native measures `<Text>` in `TextLayoutManager` with a `StaticLayout` that breaks lines on glyph **advances** (`buildLayout` never sets `setUseBoundsForWidth`). With `enablePreparedTextLayout` off (the default), the pixels on screen come from `ReactTextView`'s own `TextView` layout — `ReactTextView.setText()` hands the Spannable to `TextView` and `onDraw()` defers to `super.onDraw()`. That layout breaks lines on glyph **bounds**.

So measurement and painting disagree on where lines break. For any font whose ink overhangs its advance (script/cursive fonts, several OEM system fonts, emoji fallbacks), a line that fits at measure time can wrap at draw time. The extra line lands outside the Yoga-measured height and is simply never seen: **the last word of a `<Text>` disappears**, while the view is sized as if it were there.

This is the mechanism behind #56402 / #53286 (and the shape of #57957: content-sized parent, last line gone). It is independent of `lineHeight`, and it affects both shrink-wrapped single-line text and width-constrained wrapped paragraphs.

## The fix

Opt `ReactTextView` out of bounds-based breaking so the drawn layout uses the same advance-based line breaking as measurement. Applied in the constructor and again in `recycleView()` so recycled views cannot drift. The call is resolved reflectively, following the existing `setUseBoundsForWidth` pattern in `TextLayoutManager`, because some internal targets compile against an SDK older than 35 (see `AndroidVersion`).

This keeps the final layout on the advance-based behavior React Native has always had — the same principle #57117 states for the layouts it builds — but applies it where the pixels actually come from. It is complementary to #57117: that PR widens the *desired* width for `AT_MOST`/`UNDEFINED` measurement, which does not reach a width-constrained paragraph whose lines are re-broken by the `TextView` at draw time; this change makes both paths agree regardless of constraint mode.

Trade-off: React Native forgoes Android 15's automatic reservation of overhang space at the edges of a line (glyph ink may be clipped at the view edge as it was before Android 15). That is the pre-existing behavior on every prior Android version, and strictly better than losing whole words. A follow-up could make *measurement* bounds-aware instead (platform parity), but that changes wrapping app-wide and was the direction of the reverted #54721/#54871.

Fixes #56402
Related: #53286, #57957, #57117, #56864

## Changelog:

[ANDROID] [FIXED] - Text: the last line no longer disappears on Android 15+ when a font's glyphs overhang their advance (ReactTextView now breaks lines on advances, matching measurement)

## Test Plan

### Deterministic repro (stock emulator, no custom font)

API 35/36 AVD, app targeting API 35+. Android's generic `cursive` family (Dancing Script) overhangs heavily. Inside a shrink-wrapping container:

```tsx
<View style={{ alignSelf: 'flex-start' }}>
  <Text style={{ fontFamily: 'cursive', fontSize: 18, lineHeight: 27 }} allowFontScaling={false}>
    Enjoy your coffee<Text style={{ color: 'green' }}> f</Text>
  </Text>
</View>
```

**Before:** the green `f` is not painted. The view is sized for it (measure), but the `TextView` breaks the line on bounds, wraps the `f` to a second line, and that line is outside the measured height. Which strings trip it depends on where the bounds-based break falls relative to the advance-based one — in the rn-tester example below two of the four cursive rows lose the `f` — while a control row with a non-overhanging font (Roboto) always keeps it.

**After:** the `f` is painted on the first line.

**Before** (rn-tester `Text` example, API 36 emulator — the cursive column loses its `f` on two of the four rows; the default-font control column keeps every one):

![before](https://raw.githubusercontent.com/idoyana/react-native/pr-assets/android-text-line-breaking/before-cursive-api36.png)

**After** (same example, this branch):

![after](https://raw.githubusercontent.com/idoyana/react-native/pr-assets/android-text-line-breaking/after-cursive-api36.png)

### rn-tester

`Text` → **"Android 15+ glyph overhang (last line must not disappear)"** — the rows above, cursive on the left with a default-font control on the right. Every row must show its green `f`.

### Unit tests

`ReactTextViewTest`:
- `breaksLinesOnAdvancesLikeMeasurementOnApi35` — a freshly constructed `ReactTextView` reports `useBoundsForWidth == false` on API 35.
- `recyclingRestoresAdvanceBasedLineBreaking` — after `useBoundsForWidth = true`, `recycleView()` restores `false`.

Below API 35 the reflective lookup returns null and the view is untouched.

### Origin

Reported in production by a user on a Samsung SM-A566B (Android 16, One UI system font): trailing words vanished from chat messages while the message bubble was sized for the full text. Pinning a bundled font (Alef) in the app made it stop — consistent with the mechanism above — and the same symptom then reproduced on an AOSP emulator with the `cursive` family as shown here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
