### PR TITLE
[iOS] Skip no-op ellipsis recolor in processTruncatedAttributedText

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -344,13 +344,31 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                            [layoutManager characterRangeForGlyphRange:truncatedRange
                                                                      actualGlyphRange:nil];
                                        if (characterRange.location > 0 && characterRange.length > 0) {
-                                         // Remove color attributes for truncated range
+                                         // Match the truncated range's color attributes to the character before
+                                         // the ellipsis. Skip the edit when the range already carries them:
+                                         // editing the storage invalidates the layout mid-draw and re-typesets
+                                         // the paragraph for nothing.
                                          for (NSAttributedStringKey key in
                                               @[ NSForegroundColorAttributeName, NSBackgroundColorAttributeName ]) {
-                                           [textStorage removeAttribute:key range:characterRange];
                                            id attribute = [textStorage attribute:key
                                                                          atIndex:characterRange.location - 1
                                                                   effectiveRange:nil];
+                                           __block BOOL rangeAlreadyMatches = YES;
+                                           [textStorage enumerateAttribute:key
+                                                                    inRange:characterRange
+                                                                    options:0
+                                                                 usingBlock:^(id value, NSRange range, BOOL *stopEnumerating) {
+                                                                   BOOL isEqual = value == attribute ||
+                                                                       (value != nil && attribute != nil && [value isEqual:attribute]);
+                                                                   if (!isEqual) {
+                                                                     rangeAlreadyMatches = NO;
+                                                                     *stopEnumerating = YES;
+                                                                   }
+                                                                 }];
+                                           if (rangeAlreadyMatches) {
+                                             continue;
+                                           }
+                                           [textStorage removeAttribute:key range:characterRange];
                                            if (attribute != nullptr) {
                                              [textStorage addAttribute:key value:attribute range:characterRange];
                                            }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -344,10 +344,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                                            [layoutManager characterRangeForGlyphRange:truncatedRange
                                                                      actualGlyphRange:nil];
                                        if (characterRange.location > 0 && characterRange.length > 0) {
-                                         // Match the truncated range's color attributes to the character before
-                                         // the ellipsis. Skip the edit when the range already carries them:
-                                         // editing the storage invalidates the layout mid-draw and re-typesets
-                                         // the paragraph for nothing.
+                                         // Remove color attributes for truncated range
                                          for (NSAttributedStringKey key in
                                               @[ NSForegroundColorAttributeName, NSBackgroundColorAttributeName ]) {
                                            id attribute = [textStorage attribute:key


### PR DESCRIPTION
## Summary:

`RCTTextLayoutManager processTruncatedAttributedText:` matches the truncated (ellipsis) range's color attributes to the character before it, so a truncated line's "…" doesn't carry a foreground/background color from the trimmed text (added in fcb6cdc / #39408). It does this by unconditionally removing and re-adding `NSForegroundColorAttributeName`/`NSBackgroundColorAttributeName` over the truncated range on **every draw**. That storage edit invalidates the layout TextKit just computed and re-typesets the paragraph inside `drawAttributedString:` — even when the attributes are already correct, which is the case for every single-color `<Text numberOfLines={...}>`.

This is expensive during continuous layout (e.g. resizing a split-view pane on iPad, where every visible row redraws per frame). On an iPad Pro (M5), Release build, ~20 ellipsized rows: an Instruments Time Profiler trace showed 72.8% of the paragraph draw-path cost inside this method's forced re-typeset (2.29s of a 3.15s draw path over the session). With the skip, observed p95 frame time during pane resizes dropped from 66ms to 42ms and worst frame from 100ms to 66ms, with identical rendering.

The change: before editing, check whether the truncated range already uniformly carries the attribute found at `characterRange.location - 1`, and skip the remove/add when it does. Multi-color truncated lines keep the existing recolor behavior, preserving #39408.

Related: #58101 defers the same edit out of the line-fragment enumeration to fix a crash with composed characters; this skip composes with that change (both reduce how often the storage is mutated mid-draw).

## Changelog:

[IOS] [FIXED] - Avoid re-typesetting truncated single-color Text on every draw by skipping the no-op ellipsis recolor

## Test Plan:

- Manual, iPad Pro (M5) + iPhone, Release: single-color and multi-color truncated `<Text numberOfLines={1}>` and multiline `numberOfLines={3}`, light/dark — rendering identical before/after; ellipsis color matching for multi-color text (the #39408 case) still applies.
- Instruments: with the skip, no `_fillLayoutHole...` re-typeset stacks under `-[RCTParagraphTextView drawRect:]` for single-color truncated text; unchanged behavior for multi-color text.
- Perf numbers above from a production RN 0.86 app (frame-time probe around a divider drag re-laying out ~20 ellipsized rows per frame).