### PR TITLE
Make Maestro keyboard dismissal Android-only

### DIFF
--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -14,7 +14,11 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: 'example_search'
 - inputText:
     text: 'Image.getSize'
-- hideKeyboard
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - hideKeyboard
 - tapOn:
     id: 'platform-test-results'
 - assertVisible: 'Results'


### PR DESCRIPTION
## Summary:

Run the RNTester Image flow keyboard dismissal only on Android.

Android needs this step because the keyboard obscures the platform test results control. On iOS, the keyboard can dismiss automatically before Maestro reaches `hideKeyboard`, causing the flow to fail with `Could not hide the keyboard`. This has occurred repeatedly in Maestro Cloud since #58272 landed; for example, [run 33517266090](https://github.com/react/react-native/actions/runs/33517266090/job/99902026553).

The flow passed in Maestro Cloud iOS while the dismissal was absent, and the existing platform condition syntax is already used by the neighboring Image flows.

## Changelog:

[INTERNAL] [FIXED] - Avoid dismissing an already-hidden keyboard in the iOS Maestro Image flow.

## Test Plan:

- `MAESTRO_CLI_NO_ANALYTICS=1 maestro check-syntax packages/rn-tester/.maestro/image.yml` — passed (`OK`)
- `./node_modules/.bin/prettier --check packages/rn-tester/.maestro/image.yml` — passed
- `git diff --check` — passed
- Confirmed the Android dismissal remains present behind `platform: Android`.