### PR TITLE
Wait for Maestro template app startup

### DIFF
--- a/scripts/e2e/.maestro/start.yml
+++ b/scripts/e2e/.maestro/start.yml
@@ -1,4 +1,6 @@
 appId: ${APP_ID} # iOS: org.reactjs.native.example.RNTestProject  | Android: com.rntestproject
 ---
 - launchApp
-- assertVisible: 'Welcome to React Native'
+- extendedWaitUntil:
+    visible: 'Welcome to React Native'
+    timeout: 60000


### PR DESCRIPTION
## Summary:

Replace the immediate template-app startup assertion with `extendedWaitUntil` and a 60-second timeout.

The Android ARM64 debug app occasionally becomes accessibility-visible just after the existing assertion times out under native translation. This failed all three attempts in [run 33609361836](https://github.com/react/react-native/actions/runs/33609361836/job/100196578829) and [run 33540863593](https://github.com/react/react-native/actions/runs/33540863593/job/99984608541). In the captured failure artifact, both the screenshot and XML hierarchy contain `Welcome to React Native`, indicating a startup/accessibility timing race rather than an app failure.

Release runs remain fast because `extendedWaitUntil` returns as soon as the element is visible.

## Changelog:

[INTERNAL] [FIXED] - Wait for the template app to become visible in Maestro E2E tests.

## Test Plan:

- `MAESTRO_CLI_NO_ANALYTICS=1 maestro check-syntax scripts/e2e/.maestro/start.yml` — passed (`OK`)
- `./node_modules/.bin/prettier --check scripts/e2e/.maestro/start.yml` — passed
- `git diff --check` — passed
- Inspected the failing Android debug artifact: the expected text is present in both the final screenshot and accessibility hierarchy.