### PR TITLE
Pin react peerDependency to the exact synced renderer version

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -143,7 +143,7 @@
   },
   "peerDependencies": {
     "@types/react": "^19.1.1",
-    "react": "^19.2.3"
+    "react": "19.2.3"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/scripts/monorepo-tests/__tests__/check-packages-test.js
+++ b/scripts/monorepo-tests/__tests__/check-packages-test.js
@@ -8,12 +8,17 @@
  * @format
  */
 
-import {PRIVATE_DIR, REPO_ROOT} from '../../shared/consts';
+import {
+  PRIVATE_DIR,
+  REACT_NATIVE_PACKAGE_DIR,
+  REPO_ROOT,
+} from '../../shared/consts';
 import {
   getPackages,
   getReactNativePackage,
   getWorkspaceRoot,
 } from '../../shared/monorepoUtils';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import {globSync} from 'tinyglobby';
 
@@ -26,6 +31,34 @@ describe('package manifests', () => {
   test('the react-native package must not declare devDependencies', async () => {
     const {packageJson} = await getReactNativePackage();
     expect(packageJson).not.toHaveProperty('devDependencies');
+  });
+
+  test('the react-native peer for react must exactly match the synced renderer version', async () => {
+    const {packageJson: rnPackageJson} = await getReactNativePackage();
+    const reactPeer = rnPackageJson.peerDependencies?.react;
+    expect(typeof reactPeer).toBe('string');
+
+    // The embedded renderer only supports the exact React version it was
+    // synced with (see #57079: a caret range lets package managers install a
+    // React that the renderer rejects at runtime), so the peer must be
+    // pinned to that exact version instead of a range.
+    expect(reactPeer).toMatch(/^\d+\.\d+\.\d+$/);
+
+    // The development pin in the workspace root must agree with the peer...
+    const {packageJson: rootPackageJson} = await getWorkspaceRoot();
+    expect(rootPackageJson.devDependencies?.react).toBe(reactPeer);
+
+    // ...as must the version embedded in the synced renderer bundle.
+    const rendererDev = await fs.readFile(
+      path.join(
+        REACT_NATIVE_PACKAGE_DIR,
+        'Libraries/Renderer/implementations/ReactFabric-dev.js',
+      ),
+      'utf-8',
+    );
+    const embeddedVersions = rendererDev.match(/version: "(\d+\.\d+\.\d+)"/g);
+    expect(embeddedVersions).toHaveLength(1);
+    expect(embeddedVersions?.[0]).toBe(`version: "${reactPeer}"`);
   });
 
   test('published packages must declare required fields', async () => {


### PR DESCRIPTION
## Summary:

Fixes #57079.

`react-native@0.85.3` declares `"react": "^19.2.3"` in `peerDependencies`, so package managers happily install e.g. `react@19.2.6` — but the embedded renderer only supports the exact React version it was synced with (the 0.85.x Paper bundle throws `Incompatible React versions` unless `React.version === "19.2.3"`, and the Fabric bundle still embeds a pinned `version: "19.2.3"`). Install succeeds, launch crashes.

This PR pins `packages/react-native/package.json` `peerDependencies.react` to the exact synced version (`19.2.3`, matching the workspace-root dev pin, the helloworld template, and the renderer bundle), restoring the pre-0.76 exact-pin practice (0.74.0 shipped `"react": "18.2.0"`). A mismatched React now surfaces as an install-time peer warning instead of a runtime crash. It also adds a monorepo consistency test so future React syncs cannot silently reintroduce the drift.

## Changelog:

[GENERAL] [FIXED] - Pin `react-native` peerDependency on `react` to the exact synced renderer version so installs reject React versions the renderer does not support (fixes #57079)

## Test Plan:

- `yarn jest scripts/monorepo-tests/__tests__/check-packages-test.js` — 6/6 pass, including the new `the react-native peer for react must exactly match the synced renderer version` test.
- Negative control: temporarily restored `^19.2.3` and re-ran the new test — it fails as expected; re-applied the fix and it passes.
- `yarn eslint --max-warnings 0 scripts/monorepo-tests/__tests__/check-packages-test.js` — clean.
- `prettier --check` on both changed files — clean.
- Verified against published tarballs: `npm view react-native@0.85.3 peerDependencies` shows the old `^19.2.3`, and the 0.85.3 tarball's `ReactNativeRenderer-dev.js` contains the exact `19.2.3` runtime check; semver simulation confirms `19.2.6` satisfies `^19.2.3` but not `19.2.3`.
- Could not run: native builds / RNTester bundling (no device toolchain in this environment); change is metadata + a Node-only test, no runtime code touched.