### PR TITLE
Cover `react/renderer/telemetry` with guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(react_renderer_telemetry
         folly_runtime
         glog
         glog_init
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/SurfaceTelemetry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <vector>
 
 #include <react/renderer/telemetry/TransactionTelemetry.h>

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/TransactionTelemetry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <chrono>
 #include <cstdint>
 #include <functional>


### PR DESCRIPTION
Summary:
Classifies `react/renderer/telemetry:telemetry` as a "for frameworks" target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's 2 non-test headers, and wires the guard dependency into BUCK and CMake. No CocoaPods change is needed: the module ships as a subspec of `React-Fabric`, whose parent spec already declares `React-cxxstableapi` and calls `mark_as_react_native_build`.

Consumers that opt into `RN_STRICT_API` now get a warning if they include these headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D118612692


