### PR TITLE
Cover `componentregistry` with Stable API guards (#58302)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -134,6 +134,7 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/componentregistry/",
                           "react/renderer/componentregistry/",
                       ),
+                      Pair("../ReactCommon/react/renderer/componentregistry/React/", "React/"),
                       // react_renderer_consistency
                       Pair(
                           "../ReactCommon/react/renderer/consistency/",

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -120,6 +120,12 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/componentregistry"
   end
 
+  s.subspec "componentregistryUmbrella" do |ss|
+    ss.source_files         = "react/renderer/componentregistry/React/*.h"
+    ss.header_dir           = ""
+    ss.header_mappings_dir  = "react/renderer/componentregistry"
+  end
+
   s.subspec "componentregistrynative" do |ss|
     ss.source_files         = podspec_sources("react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}", "react/renderer/componentregistry/native/**/*.{h}")
     ss.header_dir           = "react/renderer/componentregistry/native"

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -12,11 +12,13 @@ file(GLOB react_renderer_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_componentregistry OBJECT ${react_renderer_componentregistry_SRC})
 
 target_include_directories(react_renderer_componentregistry PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_componentregistry INTERFACE ${REACT_COMMON_DIR}/react/renderer/componentregistry)
 
 target_link_libraries(react_renderer_componentregistry
         folly_runtime
         glog_init
         jsi
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorFactory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 #include <react/renderer/core/ComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventDispatcher.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <shared_mutex>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <shared_mutex>
 #include <unordered_map>

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/React/ComponentRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/React/ComponentRegistry.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/componentregistry` module - public
+// entry point.
+//
+//   #include <React/ComponentRegistry.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/componentregistry/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
+#include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
+#include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
+#include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
+#include <react/renderer/componentregistry/componentNameByReactViewName.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/componentNameByReactViewName.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <string>
 
 namespace facebook::react {

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -88,6 +88,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
 
       {
+        name: 'componentregistryUmbrella',
+        headerPatterns: ['react/renderer/componentregistry/React/*.h'],
+        headerDir: 'React',
+      },
+
+      {
         name: 'componentregistrynative',
         headerPatterns: ['react/renderer/componentregistry/native/**/*.h'],
         headerDir: 'react/renderer/componentregistry/native',


### PR DESCRIPTION
Summary:

Classifies `react/renderer/componentregistry:componentregistry` as a public target under the C++ stable API three-tier visibility model and introduces the module umbrella `React/ComponentRegistry.h` as its public entry point.

This module has no podspec of its own - it ships as a subspec of `React-Fabric` - so the `componentregistryUmbrella` subspec and the matching `headers-config.js` entry are added to the parent pod. The umbrella re-exports all five of the module's headers.

The sibling `react/renderer/componentregistry/native:native` target is private under the same model.

The guards are inert unless a consumer defines `RN_STRICT_API`, so there is no behavior change.

Changelog:
[General][Added] - Add `<React/ComponentRegistry.h>` umbrella header as the public entry point for `react/renderer/componentregistry`

Differential Revision: D118612734


