### PR TITLE
Cover `react/renderer/mounting` with guards

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(react_renderer_mounting
         glog_init
         jsi
         jsinspector_tracing
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <chrono>
 #include <condition_variable>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/mounting/MountingTransaction.h>
 
 #pragma once

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingTransaction.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <react/renderer/telemetry/SurfaceTelemetry.h>
 #include <react/renderer/telemetry/TransactionTelemetry.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <shared_mutex>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/mounting/MountingCoordinator.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <shared_mutex>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRevision.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeRevision.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/MountingTransaction.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/Props.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <vector>
 
 #include <react/renderer/mounting/ShadowView.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/TelemetryController.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <functional>
 #include <mutex>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/Transform.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/ShadowViewNodePair.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/ShadowViewNodePair.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/mounting/ShadowView.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <deque>
 
 #include "CullingContext.h"

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/stubs/StubView.h>
 #include <react/renderer/mounting/stubs/StubViewTree.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/mounting/ShadowTree.h>
 


### PR DESCRIPTION
Summary:
Classifies `react/renderer/mounting:mounting` as a "for frameworks" target under the C++ stable API three-tier visibility model. Adds `#include <react/cxxstableapi/FrameworksGuard.h>` to the module's 15 non-test headers, and wires the guard dependency into BUCK and CMake. No CocoaPods change is needed: the module ships as a subspec of `React-Fabric`, whose parent spec already declares `React-cxxstableapi` and calls `mark_as_react_native_build`.

Consumers that opt into `RN_STRICT_API` now get a warning if they include these headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D118612708


