### PR TITLE
Cover react/renderer/animationbackend with Stable API guards (#58304)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 
 #include <utility>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/graphics/Filter.h>
 #include "AnimatedProps.h"

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 #include <react/renderer/components/view/BaseViewProps.h>
 #include <react/renderer/core/ReactPrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsSerializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsSerializer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 #include "AnimatedProps.h"
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <ReactCommon/CallInvoker.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationChoreographer.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationChoreographer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>
 #include <react/timing/primitives.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/CMakeLists.txt
@@ -15,6 +15,7 @@ target_include_directories(react_renderer_animationbackend PUBLIC ${REACT_COMMON
 
 target_link_libraries(react_renderer_animationbackend
       react_codegen_rncore
+      react_cxxstableapi
       react_debug
       react_renderer_core
       react_renderer_graphics


### PR DESCRIPTION
Summary:

Classifies `react/renderer/animationbackend:animationbackend` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

`React-Fabric` already depended on `React-cxxstableapi` from an earlier migration in the same pod, so the module's subspec needs no change.

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D118616103


