### PR TITLE
Cover react/renderer/imagemanager with Stable API guards (#58307)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -36,6 +36,7 @@ react_native_android_selector(reactnativejni reactnativejni "")
 target_link_libraries(react_renderer_imagemanager
         folly_runtime
         ${mapbufferjni}
+        react_cxxstableapi
         react_debug
         react_renderer_core
         react_renderer_debug

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 
 #include <react/renderer/core/ReactPrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/imagemanager/ImageResponse.h>
 #include <react/renderer/imagemanager/ImageResponseObserver.h>
 #include <react/renderer/imagemanager/ImageResponseObserverCoordinator.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/imagemanager/ImageResponse.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/imagemanager/ImageResponse.h>
 #include <react/renderer/imagemanager/ImageResponseObserver.h>
 #include <react/utils/SharedFunction.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/Telemetry.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
 #include <react/utils/ContextContainer.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <utility>
 
 #include <react/renderer/graphics/Color.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -21,7 +21,11 @@ Pod::Spec.new do |s|
   header_search_paths = [
     "\"$(PODS_TARGET_SRCROOT)/../../../\"",
     "\"$(PODS_TARGET_SRCROOT)\"",
-  ].join(" ")
+  ]
+
+  if ENV['USE_FRAMEWORKS']
+    header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../../../..\"" # ReactCommon, for <react/cxxstableapi/...>
+  end
 
   s.name                   = "React-ImageManager"
   s.version                = version
@@ -38,12 +42,13 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig  = {
     "USE_HEADERMAP" => "NO",
-    "HEADER_SEARCH_PATHS" => header_search_paths,
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES",
   }
 
   s.dependency "React-Core/Default"
+  s.dependency "React-cxxstableapi"
 
   add_dependency(s, "React-Fabric")
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #import <UIKit/UIKit.h>
 
 #import "RCTImageManagerProtocol.h"

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManagerProtocol.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManagerProtocol.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #import <Foundation/Foundation.h>
 #import <react/renderer/core/ReactPrimitives.h>
 #import <react/renderer/imagemanager/ImageRequest.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #import <UIKit/UIKit.h>
 
 #import <React/RCTConvert.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #import <UIKit/UIKit.h>
 
 #import "RCTImageManagerProtocol.h"

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Summary:

Classifies `react/renderer/imagemanager:imagemanager` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

`React-Fabric` already depended on `React-cxxstableapi` from an earlier migration in the same pod, so the module's subspec needs no change.

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D118621752


