### PR TITLE
Cover jsinspector-modern with Stable API guards (#58309)

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(jsinspector
         glog
         jsinspector_network
         jsinspector_tracing
+        react_cxxstableapi
         react_featureflags
         runtimeexecutor
         reactperflogger

--- a/packages/react-native/ReactCommon/jsinspector-modern/ConsoleMessage.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ConsoleMessage.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "StackTrace.h"
 
 #include <vector>

--- a/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTask.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTask.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTaskContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTaskContext.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "StackTrace.h"
 
 #include <folly/dynamic.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTaskOrchestrator.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ConsoleTaskOrchestrator.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <stack>

--- a/packages/react-native/ReactCommon/jsinspector-modern/EmulationAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/EmulationAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "HostTarget.h"
 #include "InspectorInterfaces.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/EnumArray.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/EnumArray.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <array>
 #include <limits>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "UniqueMonostate.h"
 
 #include <optional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContextManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <cinttypes>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "SessionState.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 #include "RuntimeTarget.h"
 #include "SessionState.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "HostTarget.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostCommand.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostCommand.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 namespace facebook::react::jsinspector_modern {
 
 enum class HostCommand {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "ExecutionContextManager.h"
 #include "HostCommand.h"
 #include "InspectorInterfaces.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "HostAgent.h"
 #include "HostTarget.h"
 #include "InstanceTarget.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 
 #include "cdp/CdpJson.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <mutex>
 #include <optional>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <folly/dynamic.h>
 
 #include <functional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "WebSocketInterfaces.h"
 
 #include <chrono>

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 #include "InspectorPackagerConnection.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorUtilities.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 
 // Utilities that are useful when integrating with InspectorInterfaces.h but

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "RuntimeTarget.h"
 #include "SessionState.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "ExecutionContextManager.h"
 #include "RuntimeTarget.h"
 #include "ScopedExecutor.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 #include "ScopedExecutor.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/PerfMonitorV2.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/PerfMonitorV2.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <optional>
 #include <string>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -54,6 +54,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-perflogger", version
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-oscompat")
   add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
   if use_hermes()

--- a/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ReactCdp.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsinspector-modern/ExecutionContext.h>
 #include <jsinspector-modern/FallbackRuntimeTargetDelegate.h>
 #include <jsinspector-modern/HostTarget.h>

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "InspectorInterfaces.h"
 #include "RuntimeAgentDelegate.h"
 #include "RuntimeTarget.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgentDelegate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsinspector-modern/cdp/CdpJson.h>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "ConsoleMessage.h"
 #include "EnumArray.h"
 #include "ExecutionContext.h"

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetGlobalStateObserver.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetGlobalStateObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <jsi/jsi.h>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ScopedExecutor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/utils/OnScopeExit.h>
 #include <cassert>
 #include <functional>

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "ExecutionContext.h"
 #include "RuntimeAgent.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/StackTrace.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/StackTrace.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "HostTarget.h"
 #include "InspectorInterfaces.h"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/UniqueMonostate.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <functional>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <stdexcept>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/WeakList.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WeakList.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <list>
 #include <memory>
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <optional>
 #include <string>
 #include <string_view>


### PR DESCRIPTION
Summary:

Classifies `jsinspector-modern:jsinspector` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D118629799
