### PR TITLE
fix(text): avoid mutating accessibilityState

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -134,7 +134,7 @@ const TextImpl: component(
     if (_accessibilityState == null) {
       _accessibilityState = {disabled};
     } else {
-      _accessibilityState.disabled = _disabled;
+      _accessibilityState = {..._accessibilityState, disabled: _disabled};
     }
   }
 

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -592,6 +592,30 @@ describe('<Text>', () => {
       });
     });
 
+    describe('accessibilityState', () => {
+      it('does not mutate the prop when disabled overrides it', () => {
+        const accessibilityState = {disabled: false};
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(
+            <Text disabled accessibilityState={accessibilityState}>
+              {TEST_TEXT}
+            </Text>,
+          );
+        });
+
+        expect(accessibilityState).toEqual({disabled: false});
+        expect(
+          root.getRenderedOutput({props: ['accessibilityState']}).toJSX(),
+        ).toEqual(
+          <rn-paragraph accessibilityState="{disabled:true,selected:false,checked:None,busy:false,expanded:null}">
+            {TEST_TEXT}
+          </rn-paragraph>,
+        );
+      });
+    });
+
     describe('aria-hidden', () => {
       it('is is passed as importantForAccessibility', () => {
         const root = Fantom.createRoot();

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -11,7 +11,7 @@
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
-import type {AccessibilityProps} from 'react-native';
+import type {AccessibilityProps, AccessibilityState} from 'react-native';
 
 import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
@@ -594,7 +594,7 @@ describe('<Text>', () => {
 
     describe('accessibilityState', () => {
       it('does not mutate the prop when disabled overrides it', () => {
-        const accessibilityState = {disabled: false};
+        const accessibilityState: AccessibilityState = {disabled: false};
         const root = Fantom.createRoot();
 
         Fantom.runTask(() => {


### PR DESCRIPTION
## Summary:

When `accessibilityState.disabled` conflicts with an explicit `disabled` prop, the `Text` component currently updates `accessibilityState` in place. This mutates an object owned by the caller, which can cause issues when other code uses that same object.

This fix creates a new object instead, while retaining existing behavior (giving priority to the explicit prop).

## Changelog:

[GENERAL] [FIXED] - Prevent Text from mutating the accessibilityState prop

## Test Plan:

Unchanged tests pass + added a regression test