### PR TITLE
fix(image): preserve source headers with crossOrigin and referrerPolicy

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -89,7 +89,13 @@ export function getImageSourcesFromImageProps(imageProps: ImageProps):
     sources = [{uri: src, headers: headers, width, height}];
   } else if (source != null && source.uri && Object.keys(headers).length > 0) {
     const sourceHeaders = (source as ImageURISource).headers;
-    sources = [{...source, headers: {...sourceHeaders, ...headers}}];
+    sources = [
+      {
+        ...source,
+        headers:
+          sourceHeaders != null ? {...sourceHeaders, ...headers} : headers,
+      },
+    ];
   } else {
     sources = source;
   }

--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -12,6 +12,7 @@
 
 import type {ResolvedAssetSource} from './AssetSourceResolver';
 import type {ImageProps} from './ImageProps';
+import type {ImageURISource} from './ImageSource';
 
 import resolveAssetSource from './resolveAssetSource';
 
@@ -87,7 +88,8 @@ export function getImageSourcesFromImageProps(imageProps: ImageProps):
   } else if (src != null) {
     sources = [{uri: src, headers: headers, width, height}];
   } else if (source != null && source.uri && Object.keys(headers).length > 0) {
-    sources = [{...source, headers}];
+    const sourceHeaders = (source as ImageURISource).headers;
+    sources = [{...source, headers: {...sourceHeaders, ...headers}}];
   } else {
     sources = source;
   }

--- a/packages/react-native/Libraries/Image/__tests__/Image-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-itest.js
@@ -102,19 +102,28 @@ describe('<Image>', () => {
         );
       });
 
-      it('sets the "Access-Control-Allow-Credentials" header in "use-credentials" mode', () => {
+      it('adds the credentials header without replacing source headers', () => {
         const root = Fantom.createRoot();
 
         Fantom.runTask(() => {
           root.render(
-            <Image crossOrigin="use-credentials" source={LOGO_SOURCE} />,
+            <Image
+              crossOrigin="use-credentials"
+              source={{
+                ...LOGO_SOURCE,
+                headers: {Authorization: 'Bearer token'},
+              }}
+            />,
           );
         });
 
         expect(
           root.getRenderedOutput({props: ['source-header']}).toJSX(),
         ).toEqual(
-          <rn-image source-header-Access-Control-Allow-Credentials="true" />,
+          <rn-image
+            source-header-Access-Control-Allow-Credentials="true"
+            source-header-Authorization="Bearer token"
+          />,
         );
       });
     });


### PR DESCRIPTION
## Summary:

When `crossOrigin="use-credentials"` or `referrerPolicy` is used on an `Image`, `getImageSourcesFromImageProps` currently fully replaces `source.headers`, removing custom headers such as `Authorization`.

This fix merges the generated headers with the user-provided source headers instead (generated headers take precedence).

## Changelog:

[GENERAL] [FIXED] - Preserve Image source headers when using crossOrigin or referrerPolicy

## Test Plan:

Confirmed existing tests are unchanged & added a regression test