### PR TITLE
Fix Android text mis-measurement when using fontVariationSettings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTypefaceUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTypefaceUtils.kt
@@ -179,6 +179,10 @@ public object ReactTypefaceUtils {
     }
 
     try {
+      // Paint skips unchanged settings even after setTypeface, so clear them first.
+      if (paint.fontVariationSettings != null) {
+        paint.setFontVariationSettings(null)
+      }
       paint.setFontVariationSettings(fontVariationSettings)
     } catch (exception: IllegalArgumentException) {
       // Paint instances are reused, so explicitly clear axes from a previous layout.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -689,6 +689,10 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     val newTypeface = applyStyles(typeface, fontStyle, fontWeight, fontFamily, context.assets)
     typeface = newTypeface
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      // TextView skips unchanged settings even after a typeface change, so clear them first.
+      if (fontVariationSettings != null) {
+        super.setFontVariationSettings(null)
+      }
       super.setFontVariationSettings(parsedFontVariationSettings)
     }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerFontWeightAdjustmentTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerFontWeightAdjustmentTest.kt
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -125,6 +126,55 @@ class TextLayoutManagerFontWeightAdjustmentTest {
     verify(paint).setFontVariationSettings("'wght' 700")
     verify(paint).setFontVariationSettings(invalidSettings)
     verify(paint).setFontVariationSettings(null)
+  }
+
+  @Test
+  fun `reused paint re-applies unchanged font variation settings to a new typeface`() {
+    val paint = mock<Paint>()
+    whenever(paint.fontVariationSettings).thenReturn("'wght' 600")
+
+    ReactTypefaceUtils.applyFontVariationSettings(paint, "'wght' 600")
+
+    inOrder(paint) {
+      verify(paint).setFontVariationSettings(null)
+      verify(paint).setFontVariationSettings("'wght' 600")
+    }
+  }
+
+  @Test
+  fun `fresh paint applies font variation settings without clearing first`() {
+    val paint = mock<Paint>()
+    whenever(paint.fontVariationSettings).thenReturn(null)
+
+    ReactTypefaceUtils.applyFontVariationSettings(paint, "'wght' 600")
+
+    verify(paint).setFontVariationSettings("'wght' 600")
+    verify(paint, never()).setFontVariationSettings(null)
+  }
+
+  @Test
+  fun `scratch text paint re-applies font variation settings on repeated measurement`() {
+    val paint = mock<TextPaint>()
+    whenever(paint.fontVariationSettings).thenReturn("'wght' 600")
+    val textAttributes =
+        TextAttributeProps.fromReadableMap(
+            ReactStylesDiffMap(
+                JavaOnlyMap.of("fontWeight", "600", "fontVariationSettings", "'wght' 600"),
+            ),
+        )
+
+    TextLayoutManager.updateTextPaint(
+        paint,
+        textAttributes,
+        RuntimeEnvironment.getApplication().assets,
+        0,
+    )
+
+    inOrder(paint) {
+      verify(paint).setTypeface(any())
+      verify(paint).setFontVariationSettings(null)
+      verify(paint).setFontVariationSettings("'wght' 600")
+    }
   }
 
   private companion object {


### PR DESCRIPTION
## Summary:

`fontVariationSettings` (#57804, #57805) is applied with `Paint.setFontVariationSettings` after `Paint.setTypeface`. Android's `Paint.setFontVariationSettings` returns early when the requested settings string equals the value the paint already holds, and `Paint.setTypeface` does not clear that stored string. On the legacy variation path, the variation instance lives on the typeface, so once `setTypeface` replaces the typeface the axes are gone, but the paint still reports the old settings and the second `setFontVariationSettings` call is a no-op.

With a variable font whose default instance is lighter than the requested `wght`, Yoga receives regular-width metrics while semibold glyphs are drawn, so `numberOfLines={1}` text is ellipsized ("Get Start...") and wrapped text breaks in different places than it renders.

This change clears the paint's settings before re-applying them in `ReactTypefaceUtils.applyFontVariationSettings` and in `ReactEditText.maybeUpdateTypeface`, so the axes are always rebuilt on the current typeface. Paints without previous settings are unaffected.

## Changelog:

[ANDROID] [FIXED] - Fix text measured with the wrong width when `fontVariationSettings` are re-applied to a reused `Paint`

## Test Plan:

Ran test suite, validated the fix in my patched react-native instance that backports variable fonts support.