### PR TITLE
Restore `paperComponentName: 'RCTSwitch'` to fix `@testing-library/react-native` queries

### DIFF
--- a/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/components/switch/specs/SwitchNativeComponent.js
@@ -59,6 +59,10 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 });
 
 export default codegenNativeComponent<SwitchNativeProps>('Switch', {
+  // @testing-library/react-native (as of 13.3.3) only recognizes a host
+  // component named `RCTSwitch` as a switch, so renaming this breaks every
+  // `*ByRole('switch')` query and `toBeChecked()` assertion in Jest.
+  paperComponentName: 'RCTSwitch',
   excludedPlatforms: ['android'],
   interfaceOnly: true,
 }) as ComponentType;


### PR DESCRIPTION
Summary:
Restore `paperComponentName: 'RCTSwitch'` in `SwitchNativeComponent.js` and regenerate affected snapshots to fix test breakages introduced by D117877024.

`testing-library/react-native` 13.3.3 hardcodes `HOST_SWITCH_NAMES = ['RCTSwitch']`, so renaming the component to `Switch` broke `getByRole('switch')` queries and `toBeChecked()` assertions. This was the only xplat/js-wide breakage from that diff—only bare `<Switch>` renders without explicit `accessible` props failed, and only in `TWInternBoolSettingComponent-test.js`.

Add an inline comment documenting the `testing-library/react-native` constraint to prevent future regressions. The four other component renames in D117877024 have no RNTL special-casing and remain as landed.

Changelog: [iOS][Fixed] Restore `paperComponentName: 'RCTSwitch'` to fix `testing-library/react-native` queries

Differential Revision: D118743290


