### PR TITLE
[HIGH] Bump ws to 7.5.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tinybench": "^4.1.0",
     "tinyglobby": "^0.2.15",
     "typescript": "^6.0.3",
-    "ws": "^7.5.10"
+    "ws": "^7.5.13"
   },
   "resolutions": {
     "react-is": "19.2.3",

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -40,7 +40,7 @@
     "nullthrows": "^1.1.1",
     "open": "^8.4.2",
     "serve-static": "^1.16.2",
-    "ws": "^7.5.10"
+    "ws": "^7.5.13"
   },
   "devDependencies": {
     "@react-native/debugger-shell": "0.87.0-main",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -178,7 +178,7 @@
     "stacktrace-parser": "^0.1.10",
     "tinyglobby": "^0.2.15",
     "whatwg-fetch": "^3.0.0",
-    "ws": "^7.5.10",
+    "ws": "^7.5.13",
     "yargs": "^17.6.2"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9426,10 +9426,10 @@ ws@^6.2.3:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7, ws@^7.5.10:
-  version "7.5.10"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
-  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+ws@^7, ws@^7.5.10, ws@^7.5.13:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
 
 xml@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary:

Bumps the direct ws dependency from 7.5.10 to 7.5.13 across the root workspace, React Native package, and dev middleware. This resolves GHSA-96hv-2xvq-fx4p / CVE-2026-48779, a high-severity memory-exhaustion denial of service reachable from WebSocket peers through many tiny fragments and data chunks.

The lockfile entry is consolidated so compatible transitive 7.x consumers, including Metro and react-devtools-core, also resolve to 7.5.13. The unrelated 6.x CLI dependency remains unchanged.

## Changelog:

[GENERAL] [SECURITY] - Update ws to a release that prevents memory exhaustion from tiny fragments.

## Test Plan:

- yarn install --frozen-lockfile --ignore-scripts
- yarn why ws confirms all compatible 7.x consumers resolve to 7.5.13
- yarn audit --groups dependencies no longer reports GHSA-96hv-2xvq-fx4p
- NODE_OPTIONS=--experimental-vm-modules yarn jest packages/dev-middleware --runInBand --silent
  - 11 suites passed
  - 135 tests passed
  - 1 snapshot passed
  - Jest retained a pre-existing open handle after reporting success, so the completed process was interrupted after the full result was printed
- git diff --check