### PR TITLE
[MEDIUM] Bump @babel/runtime to 7.29.7

### DIFF
--- a/private/helloworld/package.json
+++ b/private/helloworld/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
-    "@babel/runtime": "^7.25.0",
+    "@babel/runtime": "^7.29.7",
     "@react-native/babel-preset": "0.87.0-main",
     "@react-native/core-cli-utils": "*",
     "@react-native/eslint-config": "0.87.0-main",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,12 +1043,10 @@
     pirates "^4.0.6"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.25.0", "@babel/runtime@^7.8.4":
-  version "7.26.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.9.tgz#aa4c6facc65b9cb3f87d75125ffd47781b475433"
-  integrity sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==
-  dependencies:
-    regenerator-runtime "^0.14.0"
+"@babel/runtime@^7.25.0", "@babel/runtime@^7.29.7", "@babel/runtime@^7.8.4":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
 
 "@babel/template@^7.25.9", "@babel/template@^7.27.2", "@babel/template@^7.28.6", "@babel/template@^7.3.3":
   version "7.28.6"


### PR DESCRIPTION
## Summary:

Bumps @babel/runtime from 7.26.9 to 7.29.7 and consolidates all compatible lockfile consumers on the fixed release. This resolves GHSA-968p-4wvh-cqc8 / CVE-2025-27789, where Babel-generated named-capture replacement helpers can exhibit quadratic complexity for crafted replacement strings.

The change is isolated to the HelloWorld dependency declaration and the shared lockfile. No application dependency is changed outside the React Native repository.

## Changelog:

[INTERNAL] [SECURITY] - Update @babel/runtime to remove quadratic named-capture replacement behavior.

## Test Plan:

- yarn install --frozen-lockfile --ignore-scripts
- yarn why @babel/runtime confirms all compatible consumers resolve to 7.29.7
- yarn audit --groups dependencies no longer reports GHSA-968p-4wvh-cqc8
- yarn workspace helloworld test --runInBand --silent
- yarn workspace helloworld lint
- git diff --check