### PR TITLE
[HIGH] Pin js-yaml to fixed releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,8 @@
     "fast-xml-parser": "^4.5.6",
     "yaml": "^2.8.3",
     "fast-uri": "^3.1.2",
-    "shell-quote": "1.9.0"
+    "shell-quote": "1.9.0",
+    "@istanbuljs/load-nyc-config/js-yaml": "3.15.1",
+    "markdownlint-cli2/js-yaml": "4.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6232,16 +6232,16 @@ joi@^17.2.1:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@4.1.0, js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
+  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
   dependencies:
     argparse "^2.0.1"
 
 js-yaml@^3.13.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
-  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
+  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"


### PR DESCRIPTION
## Summary

- pin the Istanbul 3.x consumer to js-yaml 3.15.1
- pin the Markdownlint 4.x consumer to js-yaml 4.3.1
- update both existing lockfile entries without changing their major versions

## Security impact

The existing 3.14.1 and 4.1.0 releases are affected by quadratic CPU denial-of-service issues in merge-key and ordered-map handling (GHSA-52cp-r559-cp3m, GHSA-5p4m-2wfm-xmqj, GHSA-h67p-54hq-rp68), plus prototype pollution in merge handling (GHSA-mh29-5h37-fv8m). The resolutions are needed because markdownlint-cli2 0.17.2 requests js-yaml 4.1.0 exactly while React Native still supports Node 20.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why js-yaml confirmed only 3.15.1 and 4.3.1
- yarn audit no longer reports js-yaml advisories
- yarn build
- yarn lint
- yarn lint-markdown: 40 files, 0 errors
- Babel preset and community CLI: 13 suites, 153 tests, 16 snapshots passed
- git diff --check