### PR TITLE
[HIGH] Bump fast-uri to 3.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "^4.5.6",
     "yaml": "^2.8.3",
-    "fast-uri": "^3.1.2",
+    "fast-uri": "^3.1.6",
     "shell-quote": "1.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4630,10 +4630,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1, fast-uri@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
-  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
+fast-uri@^3.0.1, fast-uri@^3.1.6:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fast-xml-parser@^4.5.6, fast-xml-parser@^5.3.6:
   version "4.5.6"


### PR DESCRIPTION
## Summary

- raise the existing fast-uri resolution floor from 3.1.2 to 3.1.6
- lock the compatible 3.x dependency to the current 3.1.7 release
- keep the change scoped to fast-uri

## Security impact

fast-uri 3.1.2 is affected by six high-severity URL parsing and host-confusion advisories: GHSA-5jgf-p345-68v8, GHSA-7p8r-x3mc-p8w7, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp, and GHSA-v2hh-gcrm-f6hx. Version 3.1.7 contains all fixes while remaining within the existing 3.x dependency line.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why fast-uri confirmed 3.1.7
- yarn audit no longer reports fast-uri advisories
- yarn build
- yarn build-types --validate
- JS API tooling: 22 suites, 153 tests, 131 snapshots passed
- git diff --check