### PR TITLE
[HIGH] Bump flatted to 3.4.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,9 +4761,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.2.9:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
-  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.4.tgz#aeeca2a506303f0cee61c59e6c9f2a88d2f29fc6"
+  integrity sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==
 
 flora-colossus@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## Summary

- update the existing flatted lockfile entry from 3.3.1 to 3.4.4
- remain within the existing compatible 3.x range
- keep the fix lockfile-only

## Security impact

flatted 3.3.1 is affected by GHSA-25h7-pfq9-p65f, an unbounded-recursion denial of service during parse revival, and GHSA-rf6f-7fwh-wjgh, prototype pollution through parse. Version 3.4.4 includes both fixes.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why flatted confirmed 3.4.4
- yarn audit no longer reports flatted advisories
- yarn build
- yarn lint
- circular-reference stringify/parse compatibility check
- git diff --check