### PR TITLE
[HIGH] Bump linkify-it to 5.0.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6412,9 +6412,9 @@ lines-and-columns@^1.1.6:
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
 linkify-it@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
-  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-5.0.2.tgz#d3be0a693af3da9df3883f1e346a0e97461a8c19"
+  integrity sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==
   dependencies:
     uc.micro "^2.0.0"
 


### PR DESCRIPTION
## Summary

- update the existing linkify-it lockfile entry from 5.0.0 to 5.0.2
- remain within the existing compatible 5.x range
- keep the fix lockfile-only

## Security impact

linkify-it 5.0.0 is affected by GHSA-22p9-wv53-3rq4 and GHSA-v245-v573-v5vm. Both allow attacker-controlled text, including mailto input, to cause quadratic scanning and CPU denial of service. Version 5.0.2 contains both fixes.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why linkify-it confirmed 5.0.2
- yarn audit no longer reports linkify-it advisories
- yarn lint-markdown: 39 files, 0 errors
- URL and mailto matching compatibility check
- git diff --check