### PR TITLE
[MEDIUM] Bump @xmldom/xmldom to 0.8.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "compression": "1.8.1",
     "@microsoft/api-extractor/minimatch": "3.1.4",
     "lodash": "4.18.1",
-    "@xmldom/xmldom": "^0.8.13",
+    "@xmldom/xmldom": "^0.8.15",
     "fast-xml-parser": "^4.5.6",
     "yaml": "^2.8.3",
     "fast-uri": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2539,10 +2539,10 @@
   resolved "https://registry.yarnpkg.com/@vscode/sudo-prompt/-/sudo-prompt-9.3.1.tgz#c562334bc6647733649fd42afc96c0eea8de3b65"
   integrity sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==
 
-"@xmldom/xmldom@^0.8.13", "@xmldom/xmldom@^0.8.8":
-  version "0.8.13"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
-  integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
+"@xmldom/xmldom@^0.8.15", "@xmldom/xmldom@^0.8.8":
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.15.tgz#71ebf80729e4e95221d519ac9b1e1eaea7784907"
+  integrity sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==
 
 accepts@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

- raise the existing @xmldom/xmldom resolution floor from 0.8.13 to 0.8.15
- lock the Electron packager dependency to the fixed 0.8.15 release
- remain within the existing 0.8.x line

## Security impact

Versions through 0.8.14 are affected by GHSA-6gmq-8vp8-gcm6, which permits XML fragment injection when an invalid EntityReference node name is serialized with well-formed output enabled.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why @xmldom/xmldom confirmed 0.8.15
- yarn audit no longer reports the xmldom advisory
- yarn build
- debugger-shell: 4 suites, 9 tests, 4 snapshots passed
- XML parse/serialize compatibility check
- Jest retained a pre-existing open handle after reporting success and was stopped after completion
- git diff --check