### PR TITLE
[HIGH] Pin tmp to 0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "on-headers": "1.1.0",
     "compression": "1.8.1",
     "@microsoft/api-extractor/minimatch": "3.1.4",
+    "**/external-editor/tmp": "0.2.7",
     "lodash": "4.18.1",
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "^4.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7514,11 +7514,6 @@ ora@^5.4.1:
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 own-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
@@ -8848,12 +8843,10 @@ tinyglobby@^0.2.15:
     fdir "^6.5.0"
     picomatch "^4.0.3"
 
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@0.2.7, tmp@^0.0.33:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary

- resolve external-editor’s tmp dependency to 0.2.7
- remove the obsolete os-tmpdir transitive dependency
- keep the change scoped to the existing Inquirer toolchain

## Security impact

tmp 0.0.33 is affected by GHSA-ph9p-34f9-6g65, a high-severity path traversal through unsanitized prefix/postfix values, and GHSA-52f5-9888-hmc6, a symlink-based arbitrary temporary file/directory write. The targeted resolution is necessary because current external-editor still requests tmp ^0.0.33.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why tmp confirmed only 0.2.7
- yarn audit no longer reports tmp advisories
- temporary-file create/remove lifecycle check
- yarn build
- git diff --check