### PR TITLE
[HIGH] Bump undici to 7.29.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9117,9 +9117,9 @@ undici@^6.23.0:
   integrity sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==
 
 undici@^7.24.4:
-  version "7.25.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-7.25.0.tgz#7d72fc429a0421769ca2966fd07cac875c85b781"
-  integrity sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.1.tgz#7741c6fc8b3e1a48e30323833642bfbe841443ad"
+  integrity sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

- update @electron/get’s undici 7.x lockfile entry from 7.25.0 to 7.29.1
- leave the unaffected React Native dev-middleware 6.x line unchanged
- remain within the existing compatible 7.x range

## Security impact

undici 7.25.0 is affected by multiple advisories fixed in 7.28.0/7.29.0, including cross-user cache disclosure, SOCKS5 cross-origin routing and TLS validation bypass, WebSocket denial of service, response desynchronization, and header/cookie injection (GHSA-4cwx-7wf7-3272, GHSA-hm92-r4w5-c3mj, GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, GHSA-8xcm-r25x-g524, GHSA-m8rv-5g2x-5cg5, and related 7.x advisories).

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why undici confirmed the affected line at 7.29.1
- yarn audit no longer reports undici advisories
- yarn build
- debugger-shell: 4 suites, 9 tests, 4 snapshots passed
- Jest retained a pre-existing open handle after reporting success and was stopped after completion
- git diff --check