### PR TITLE
[MEDIUM] Pin uuid to 11.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "on-headers": "1.1.0",
     "compression": "1.8.1",
     "@microsoft/api-extractor/minimatch": "3.1.4",
+    "**/jest-junit/uuid": "11.1.1",
     "lodash": "4.18.1",
     "@xmldom/xmldom": "^0.8.13",
     "fast-xml-parser": "^4.5.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9194,10 +9194,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"


### PR DESCRIPTION
## Summary

- resolve jest-junit’s uuid dependency to 11.1.1
- keep the change scoped to the test-reporting toolchain
- verify that Jest still produces its JUnit report with the newer uuid API

## Security impact

uuid 8.3.2 is affected by GHSA-w5hq-g745-h8pq, which lacks bounds checks in namespace-based UUID generation when a caller supplies an output buffer. The targeted resolution is needed because jest-junit still requests the affected 8.x line.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why uuid confirmed only 11.1.1
- yarn audit no longer reports the uuid advisory
- Jest with the jest-junit reporter: 14 tests passed and a non-empty JUnit XML report was generated
- git diff --check