### PR TITLE
[HIGH] Bump image-size to 1.2.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5264,9 +5264,9 @@ ignore@^7.0.5:
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 image-size@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.1.1.tgz#ddd67d4dc340e52ac29ce5f546a09f4e29e840ac"
-  integrity sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.2.1.tgz#ee118aedfe666db1a6ee12bed5821cde3740276d"
+  integrity sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==
   dependencies:
     queue "6.0.2"
 


### PR DESCRIPTION
## Summary

- update Metro’s image-size lockfile entry from 1.1.1 to the fixed legacy release 1.2.1
- remain within the existing compatible 1.x range
- keep the change lockfile-only

## Security impact

This removes GHSA-m5qc-5hw7-8vg7, an infinite-loop denial of service while processing malformed image data.

Two newer high-severity parser advisories (GHSA-5p2g-fcmc-qvqq for JXL/HEIF and GHSA-w3rx-r6r6-pgpr for ICNS) still have no patched release through image-size 2.0.2. The image-size repository is archived, so this PR intentionally makes the available remediation without claiming to clear those unresolved advisories.

## Verification

- yarn install --frozen-lockfile --ignore-scripts
- yarn why image-size confirmed 1.2.1
- yarn audit no longer reports GHSA-m5qc-5hw7-8vg7
- yarn build
- community CLI asset handling: 4 suites, 18 tests passed
- git diff --check