### PR TITLE
fix(iOS) - Prevent SwiftUI based `filter` from insetting content by the safe area

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1746,7 +1746,13 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 
 - (BOOL)styleNeedsSwiftUIContainer
 {
-  if (!_props->filter.empty()) {
+  if (_props->filter.empty()) {
+    return NO;
+  }
+
+  // A filter must not affect layout, but UIHostingController insets its content by the safe area.
+  // To disable the insets we use `safeAreaRegions` which is only available in iOS 16.4 and tvOS 16.4.
+  if (@available(iOS 16.4, tvOS 16.4, *)) {
     for (const auto &primitive : _props->filter) {
       if (primitive.type == FilterType::Blur || primitive.type == FilterType::Grayscale ||
           primitive.type == FilterType::DropShadow || primitive.type == FilterType::Saturate ||
@@ -1755,6 +1761,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
       }
     }
   }
+
   return NO;
 }
 

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -14,8 +14,13 @@ import UIKit
 
   @objc public override init() {
     super.init()
-    hostingController = UIHostingController(rootView: SwiftUIContainerView(viewModel: containerViewModel))
-    guard let view = hostingController?.view else {
+    let controller = UIHostingController(rootView: SwiftUIContainerView(viewModel: containerViewModel))
+    if #available(iOS 16.4, tvOS 16.4, *) {
+      // Disable implicit safe area insets or else the view is shifted by the safe area insets
+      controller.safeAreaRegions = []
+    }
+    hostingController = controller
+    guard let view = controller.view else {
       return
     }
     view.backgroundColor = .clear

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -14,13 +14,12 @@ import UIKit
 
   @objc public override init() {
     super.init()
-    let controller = UIHostingController(rootView: SwiftUIContainerView(viewModel: containerViewModel))
+    hostingController = UIHostingController(rootView: SwiftUIContainerView(viewModel: containerViewModel))
     if #available(iOS 16.4, tvOS 16.4, *) {
       // Disable implicit safe area insets or else the view is shifted by the safe area insets
-      controller.safeAreaRegions = []
+      hostingController?.safeAreaRegions = []
     }
-    hostingController = controller
-    guard let view = controller.view else {
+    guard let view = hostingController?.view else {
       return
     }
     view.backgroundColor = .clear


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When a `filter` style is passed to a `View`, it can shift the `View` by safe area insets if it overlaps a safe area edge. Filter style should not affect layout. Also fixes - https://github.com/react/react-native/issues/57642


Unset [safeAreaRegions](https://developer.apple.com/documentation/swiftui/uihostingcontroller/safearearegions) on the hosting controller to opt out of implicit safe area insets. Below iOS 16.4 `safeAreaRegions` does not exist so it requires Obj-C swizzling hack as noted here - https://github.com/react/react-native/pull/57643. Hence, proper fix requires gating the filter feature to iOS 16.4. We can mention it in the documentation on release.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Fix views with a filter having their content offset by the safe area insets

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Set `releaseLevel` to canary.
- Render `<View style={{width: 100, height: 100, backgroundColor:"red", filter:[{blur: 10}]}} />` in RNTester, make sure it renders on top of the screen.
- View renders as expected on first mount.
- Change height or width, it will shift the view by safe area inset. It requires layout update because RCTMountingManager calls `finalizeUpdates` before calling `mountChildComponentView`, so on first mount the hosting view has no window and its safe area insets are zero. 


| Before | After |
| --- | --- |
| <img width="200" alt="Filtered content pushed down by the top safe area inset" src="https://github.com/user-attachments/assets/49905f7b-0a82-4958-91d2-e89c852e5a93" /> | <img width="200" alt="Filtered content aligned with the view bounds" src="https://github.com/user-attachments/assets/85848179-43fc-42f4-9271-1093413ad42d" /> |
| Content is offset down and shrunk by the top inset | Content fills the view |


cc - @jorge-cab 


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
