### PR TITLE
fix(babel-preset): preserve Platform.select initializers

### DIFF
--- a/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/inline-platform-plugin-test.js
@@ -483,6 +483,16 @@ describe('Platform.select', () => {
     expect(select('{ios: 1, ios: 2}')).toContain('const value=2');
   });
 
+  test('does not discard impure initializers', () => {
+    expectUnchanged(`
+      const value = require('react-native').Platform.select({
+        ios: first(),
+        android: android(),
+        ios: last(),
+      });
+    `);
+  });
+
   test('does not inline computed keys', () => {
     expect(select('{[key]: 1, default: 2}')).toContain('Platform.select');
   });

--- a/packages/react-native-babel-preset/src/inline-platform-plugin.js
+++ b/packages/react-native-babel-preset/src/inline-platform-plugin.js
@@ -520,13 +520,23 @@ module.exports = function inlinePlatformPlugin(
           return;
         }
 
-        path.replaceWith(
-          findProperty(spec, platform, () =>
-            findProperty(spec, 'native', () =>
-              findProperty(spec, 'default', () => t.identifier('undefined')),
-            ),
+        const replacement = findProperty(spec, platform, () =>
+          findProperty(spec, 'native', () =>
+            findProperty(spec, 'default', () => t.identifier('undefined')),
           ),
         );
+        // Inlining must not drop side effects from discarded property values.
+        if (
+          spec.properties.some(
+            property =>
+              t.isObjectProperty(property) &&
+              property.value !== replacement &&
+              !path.scope.isPure(property.value),
+          )
+        ) {
+          return;
+        }
+        path.replaceWith(replacement);
       },
     },
   };


### PR DESCRIPTION
## Summary:

The React Native Babel preset replaces `Platform.select({...})` with the selected property during production transforms. JavaScript evaluates every object property initializer before calling `Platform.select`, so this can silently remove side effects from non-selected properties.

For example:

```js
Platform.select({
  ios: selected(),
  android: discarded(),
});
```

JavaScript would run both side effects, `selected()` and `discarded()`. The plugin's current behavior removes `discarded` on iOS however.

This fix preserves both side effects by testing for purity.

## Changelog:

[GENERAL] [FIXED] - Preserve side effects from discarded Platform.select property initializers in the Babel preset.

## Test Plan:

Added a regression test and ran existing tests, linter and formatter.