### PR TITLE
Fix iOS Metro reload after initial bundle failure

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -13,6 +13,7 @@
 #import <React/RCTJavaScriptLoader.h>
 #import <ReactCommon/RCTHermesInstance.h>
 #import <ReactCommon/RCTInstance.h>
+#import <ReactCommon/RCTJSThreadManager.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
@@ -244,11 +245,22 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
 
   RCTInstance *instance = [self makeInstance];
   [self waitForExpectations:@[ loadStarted ] timeout:5.0];
+
+  dispatch_semaphore_t jsThreadBlocked = dispatch_semaphore_create(0);
+  dispatch_semaphore_t releaseJsThread = dispatch_semaphore_create(0);
+  RCTJSThreadManager *jsThreadManager = [instance valueForKey:@"jsThreadManager"];
+  [jsThreadManager dispatchToJSThread:^{
+    dispatch_semaphore_signal(jsThreadBlocked);
+    dispatch_semaphore_wait(releaseJsThread, DISPATCH_TIME_FOREVER);
+  }];
+  XCTAssertEqual(dispatch_semaphore_wait(jsThreadBlocked, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)), 0);
+
   [instance invalidate];
 
   loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
 
   XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
+  dispatch_semaphore_signal(releaseJsThread);
 }
 
 - (void)testBundleLoadAwaitsMainQueueModuleSetup

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -86,6 +86,32 @@ static void (^sOnInit)(void);
 
 @end
 
+@interface FakeDevSettings : FakeEagerModule
+- (void)setupHMRClientWithBundleURL:(NSURL *)bundleURL;
+@end
+
+@implementation FakeDevSettings
+
+static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
+
++ (NSString *)moduleName
+{
+  return @"DevSettings";
+}
+
+- (void)initialize
+{
+  @synchronized([FakeDevSettings initCounts]) {
+    [[FakeDevSettings initCounts] addObject:FakeDevSettingsInitialize];
+  }
+}
+
+- (void)setupHMRClientWithBundleURL:(__unused NSURL *)bundleURL
+{
+}
+
+@end
+
 @interface RCTInstanceTests : XCTestCase
 @end
 
@@ -108,8 +134,12 @@ static void (^sOnInit)(void);
   OCMStub([_mockTMMDelegate getModuleClassFromName:nullptr]).ignoringNonObjectArgs().andDo(^(NSInvocation *invocation) {
     const char *requestedName = nullptr;
     [invocation getArgument:&requestedName atIndex:2];
-    Class result =
-        (requestedName != nullptr && strcmp(requestedName, "FakeEagerModule") == 0) ? [FakeEagerModule class] : Nil;
+    Class result = Nil;
+    if (requestedName != nullptr && strcmp(requestedName, "FakeEagerModule") == 0) {
+      result = [FakeEagerModule class];
+    } else if (requestedName != nullptr && strcmp(requestedName, "DevSettings") == 0) {
+      result = [FakeDevSettings class];
+    }
     [invocation setReturnValue:&result];
   });
 }
@@ -170,6 +200,25 @@ static void (^sOnInit)(void);
       @"FakeEagerModule should have been constructed exactly once during eager setup");
 
   [instance invalidate];
+}
+
+- (void)testInitializesDevSettingsBeforeLoadingBundle
+{
+  OCMStub([_mockDelegate unstableModulesRequiringMainQueueSetup]).andReturn(@[]);
+
+  XCTestExpectation *loadStarted = [self expectationWithDescription:@"bundle load started"];
+  __block NSUInteger initializeCountAtBundleLoad = 0;
+  OCMStub([_mockDelegate loadBundleAtURL:[OCMArg any] onProgress:[OCMArg any] onComplete:[OCMArg any]])
+      .andDo(^(NSInvocation *_) {
+        initializeCountAtBundleLoad = [FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize];
+        [loadStarted fulfill];
+      });
+
+  RCTInstance *instance = [self makeInstance];
+  [self waitForExpectations:@[ loadStarted ] timeout:5.0];
+  [instance invalidate];
+
+  XCTAssertEqual(initializeCountAtBundleLoad, 1u);
 }
 
 - (void)testBundleLoadAwaitsMainQueueModuleSetup

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -18,10 +18,6 @@
 
 using namespace facebook::react;
 
-@interface RCTInstance (RCTInstanceTests)
-- (void)handleBundleLoadingError:(NSError *)error;
-@end
-
 @interface FakeEagerModule : NSObject <RCTBridgeModule, RCTTurboModule>
 @property (class, readonly) NSCountedSet<NSString *> *initCounts;
 @property (class, nullable) void (^onInit)(void);
@@ -225,14 +221,34 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
 
   XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
 
-  id instanceMock = OCMPartialMock(instance);
-  OCMStub([instanceMock handleBundleLoadingError:[OCMArg any]]);
   loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
 
   XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 1u);
 
-  [instanceMock stopMocking];
   [instance invalidate];
+}
+
+- (void)testDoesNotInitializeDevSettingsAfterInvalidation
+{
+  OCMStub([_mockDelegate unstableModulesRequiringMainQueueSetup]).andReturn(@[]);
+
+  XCTestExpectation *loadStarted = [self expectationWithDescription:@"bundle load started"];
+  __block RCTSourceLoadBlock loadComplete;
+  OCMStub([_mockDelegate loadBundleAtURL:[OCMArg any] onProgress:[OCMArg any] onComplete:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained RCTSourceLoadBlock completion;
+        [invocation getArgument:&completion atIndex:4];
+        loadComplete = [completion copy];
+        [loadStarted fulfill];
+      });
+
+  RCTInstance *instance = [self makeInstance];
+  [self waitForExpectations:@[ loadStarted ] timeout:5.0];
+  [instance invalidate];
+
+  loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
+
+  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
 }
 
 - (void)testBundleLoadAwaitsMainQueueModuleSetup

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -13,7 +13,6 @@
 #import <React/RCTJavaScriptLoader.h>
 #import <ReactCommon/RCTHermesInstance.h>
 #import <ReactCommon/RCTInstance.h>
-#import <ReactCommon/RCTJSThreadManager.h>
 #import <ReactCommon/RCTTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
@@ -87,32 +86,6 @@ static void (^sOnInit)(void);
 
 @end
 
-@interface FakeDevSettings : FakeEagerModule
-- (void)setupHMRClientWithBundleURL:(NSURL *)bundleURL;
-@end
-
-@implementation FakeDevSettings
-
-static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
-
-+ (NSString *)moduleName
-{
-  return @"DevSettings";
-}
-
-- (void)initialize
-{
-  @synchronized([FakeDevSettings initCounts]) {
-    [[FakeDevSettings initCounts] addObject:FakeDevSettingsInitialize];
-  }
-}
-
-- (void)setupHMRClientWithBundleURL:(__unused NSURL *)bundleURL
-{
-}
-
-@end
-
 @interface RCTInstanceTests : XCTestCase
 @end
 
@@ -135,12 +108,8 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
   OCMStub([_mockTMMDelegate getModuleClassFromName:nullptr]).ignoringNonObjectArgs().andDo(^(NSInvocation *invocation) {
     const char *requestedName = nullptr;
     [invocation getArgument:&requestedName atIndex:2];
-    Class result = Nil;
-    if (requestedName != nullptr && strcmp(requestedName, "FakeEagerModule") == 0) {
-      result = [FakeEagerModule class];
-    } else if (requestedName != nullptr && strcmp(requestedName, "DevSettings") == 0) {
-      result = [FakeDevSettings class];
-    }
+    Class result =
+        (requestedName != nullptr && strcmp(requestedName, "FakeEagerModule") == 0) ? [FakeEagerModule class] : Nil;
     [invocation setReturnValue:&result];
   });
 }
@@ -201,66 +170,6 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
       @"FakeEagerModule should have been constructed exactly once during eager setup");
 
   [instance invalidate];
-}
-
-- (void)testInitializesDevSettingsAfterBundleLoadFailure
-{
-  OCMStub([_mockDelegate unstableModulesRequiringMainQueueSetup]).andReturn(@[]);
-
-  XCTestExpectation *loadStarted = [self expectationWithDescription:@"bundle load started"];
-  __block RCTSourceLoadBlock loadComplete;
-  OCMStub([_mockDelegate loadBundleAtURL:[OCMArg any] onProgress:[OCMArg any] onComplete:[OCMArg any]])
-      .andDo(^(NSInvocation *invocation) {
-        __unsafe_unretained RCTSourceLoadBlock completion;
-        [invocation getArgument:&completion atIndex:4];
-        loadComplete = [completion copy];
-        [loadStarted fulfill];
-      });
-
-  RCTInstance *instance = [self makeInstance];
-  [self waitForExpectations:@[ loadStarted ] timeout:5.0];
-
-  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
-
-  loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
-
-  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 1u);
-
-  [instance invalidate];
-}
-
-- (void)testDoesNotInitializeDevSettingsAfterInvalidation
-{
-  OCMStub([_mockDelegate unstableModulesRequiringMainQueueSetup]).andReturn(@[]);
-
-  XCTestExpectation *loadStarted = [self expectationWithDescription:@"bundle load started"];
-  __block RCTSourceLoadBlock loadComplete;
-  OCMStub([_mockDelegate loadBundleAtURL:[OCMArg any] onProgress:[OCMArg any] onComplete:[OCMArg any]])
-      .andDo(^(NSInvocation *invocation) {
-        __unsafe_unretained RCTSourceLoadBlock completion;
-        [invocation getArgument:&completion atIndex:4];
-        loadComplete = [completion copy];
-        [loadStarted fulfill];
-      });
-
-  RCTInstance *instance = [self makeInstance];
-  [self waitForExpectations:@[ loadStarted ] timeout:5.0];
-
-  dispatch_semaphore_t jsThreadBlocked = dispatch_semaphore_create(0);
-  dispatch_semaphore_t releaseJsThread = dispatch_semaphore_create(0);
-  RCTJSThreadManager *jsThreadManager = [instance valueForKey:@"jsThreadManager"];
-  [jsThreadManager dispatchToJSThread:^{
-    dispatch_semaphore_signal(jsThreadBlocked);
-    dispatch_semaphore_wait(releaseJsThread, DISPATCH_TIME_FOREVER);
-  }];
-  XCTAssertEqual(dispatch_semaphore_wait(jsThreadBlocked, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC)), 0);
-
-  [instance invalidate];
-
-  loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
-
-  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
-  dispatch_semaphore_signal(releaseJsThread);
 }
 
 - (void)testBundleLoadAwaitsMainQueueModuleSetup

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -8,7 +8,6 @@
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
-#import <React/RCTAssert.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBundleManager.h>
 #import <React/RCTJavaScriptLoader.h>
@@ -18,6 +17,10 @@
 #import <ReactCommon/RCTTurboModuleManager.h>
 
 using namespace facebook::react;
+
+@interface RCTInstance (RCTInstanceTests)
+- (void)handleBundleLoadingError:(NSError *)error;
+@end
 
 @interface FakeEagerModule : NSObject <RCTBridgeModule, RCTTurboModule>
 @property (class, readonly) NSCountedSet<NSString *> *initCounts;
@@ -222,14 +225,13 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
 
   XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
 
-  RCTFatalHandler previousFatalHandler = RCTGetFatalHandler();
-  RCTSetFatalHandler(^(__unused NSError *error){
-  });
+  id instanceMock = OCMPartialMock(instance);
+  OCMStub([instanceMock handleBundleLoadingError:[OCMArg any]]);
   loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
-  RCTSetFatalHandler(previousFatalHandler);
 
   XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 1u);
 
+  [instanceMock stopMocking];
   [instance invalidate];
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTInstanceTests.mm
@@ -8,6 +8,7 @@
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
+#import <React/RCTAssert.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTBundleManager.h>
 #import <React/RCTJavaScriptLoader.h>
@@ -202,23 +203,34 @@ static NSString *const FakeDevSettingsInitialize = @"DevSettings.initialize";
   [instance invalidate];
 }
 
-- (void)testInitializesDevSettingsBeforeLoadingBundle
+- (void)testInitializesDevSettingsAfterBundleLoadFailure
 {
   OCMStub([_mockDelegate unstableModulesRequiringMainQueueSetup]).andReturn(@[]);
 
   XCTestExpectation *loadStarted = [self expectationWithDescription:@"bundle load started"];
-  __block NSUInteger initializeCountAtBundleLoad = 0;
+  __block RCTSourceLoadBlock loadComplete;
   OCMStub([_mockDelegate loadBundleAtURL:[OCMArg any] onProgress:[OCMArg any] onComplete:[OCMArg any]])
-      .andDo(^(NSInvocation *_) {
-        initializeCountAtBundleLoad = [FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize];
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained RCTSourceLoadBlock completion;
+        [invocation getArgument:&completion atIndex:4];
+        loadComplete = [completion copy];
         [loadStarted fulfill];
       });
 
   RCTInstance *instance = [self makeInstance];
   [self waitForExpectations:@[ loadStarted ] timeout:5.0];
-  [instance invalidate];
 
-  XCTAssertEqual(initializeCountAtBundleLoad, 1u);
+  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 0u);
+
+  RCTFatalHandler previousFatalHandler = RCTGetFatalHandler();
+  RCTSetFatalHandler(^(__unused NSError *error){
+  });
+  loadComplete([NSError errorWithDomain:@"RCTInstanceTests" code:1 userInfo:nil], nil);
+  RCTSetFatalHandler(previousFatalHandler);
+
+  XCTAssertEqual([FakeDevSettings.initCounts countForObject:FakeDevSettingsInitialize], 1u);
+
+  [instance invalidate];
 }
 
 - (void)testBundleLoadAwaitsMainQueueModuleSetup

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -543,6 +543,8 @@ __attribute__((deprecated(
   }
 #endif
 
+  RCTDevSettings *const devSettings = (RCTDevSettings *)[_turboModuleManager moduleForName:"DevSettings"];
+
   __weak __typeof(self) weakSelf = self;
   [_delegate loadBundleAtURL:sourceURL
       onProgress:^(RCTLoadingProgress *progressData) {
@@ -567,9 +569,6 @@ __attribute__((deprecated(
           [strongSelf handleBundleLoadingError:error];
           return;
         }
-        // DevSettings module is needed by _loadScriptFromSource's callback so prior initialization is required
-        RCTDevSettings *const devSettings =
-            (RCTDevSettings *)[strongSelf->_turboModuleManager moduleForName:"DevSettings"];
         [strongSelf _loadScriptFromSource:source];
         // Set up hot module reloading in Dev only.
         [strongSelf->_performanceLogger markStopForTag:RCTPLScriptDownload];

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -543,8 +543,6 @@ __attribute__((deprecated(
   }
 #endif
 
-  RCTDevSettings *const devSettings = (RCTDevSettings *)[_turboModuleManager moduleForName:"DevSettings"];
-
   __weak __typeof(self) weakSelf = self;
   [_delegate loadBundleAtURL:sourceURL
       onProgress:^(RCTLoadingProgress *progressData) {
@@ -565,6 +563,8 @@ __attribute__((deprecated(
           return;
         }
 
+        RCTDevSettings *const devSettings =
+            (RCTDevSettings *)[strongSelf->_turboModuleManager moduleForName:"DevSettings"];
         if (error) {
           [strongSelf handleBundleLoadingError:error];
           return;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -521,7 +521,6 @@ __attribute__((deprecated(
     return;
   }
 
-  [_turboModuleManager moduleForName:"DevSettings"];
   RCTRedBox *redBox = [_turboModuleManager moduleForName:"RedBox"];
 
   RCTExecuteOnMainQueue(^{
@@ -536,6 +535,9 @@ __attribute__((deprecated(
 
 - (void)_loadJSBundle:(NSURL *)sourceURL
 {
+  // Initialize DevSettings before the request so Metro can reload after an initial bundle failure.
+  [_turboModuleManager moduleForName:"DevSettings"];
+
 #if RCT_DEV_MENU && __has_include(<React/RCTDevLoadingViewProtocol.h>)
   {
     id<RCTDevLoadingViewProtocol> loadingView =

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -521,6 +521,7 @@ __attribute__((deprecated(
     return;
   }
 
+  [_turboModuleManager moduleForName:"DevSettings"];
   RCTRedBox *redBox = [_turboModuleManager moduleForName:"RedBox"];
 
   RCTExecuteOnMainQueue(^{
@@ -563,12 +564,12 @@ __attribute__((deprecated(
           return;
         }
 
-        RCTDevSettings *const devSettings =
-            (RCTDevSettings *)[strongSelf->_turboModuleManager moduleForName:"DevSettings"];
         if (error) {
           [strongSelf handleBundleLoadingError:error];
           return;
         }
+        RCTDevSettings *const devSettings =
+            (RCTDevSettings *)[strongSelf->_turboModuleManager moduleForName:"DevSettings"];
         [strongSelf _loadScriptFromSource:source];
         // Set up hot module reloading in Dev only.
         [strongSelf->_performanceLogger markStopForTag:RCTPLScriptDownload];

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -535,7 +535,8 @@ __attribute__((deprecated(
 
 - (void)_loadJSBundle:(NSURL *)sourceURL
 {
-  // Initialize DevSettings before the request so Metro can reload after an initial bundle failure.
+  // DevSettings is needed by _loadScriptFromSource's callback, so it must be initialized first. Doing it before
+  // the request, not after a successful load, also lets Metro reload when the initial bundle request fails.
   [_turboModuleManager moduleForName:"DevSettings"];
 
 #if RCT_DEV_MENU && __has_include(<React/RCTDevLoadingViewProtocol.h>)


### PR DESCRIPTION
## Summary:

If the first bundle request fails on bridgeless iOS, Metro reload does nothing — the app sits on the error screen and has to be killed and relaunched, even once the source is fixed. Android already handles this.

The cause is timing. `RCTInstance` resolves the `DevSettings` TurboModule only inside `_loadJSBundle`'s success callback, and `RCTDevSettings.initialize` is what registers the Metro `reload` message handler. No successful first load means no handler, so the app never becomes a Metro reload peer.

This resolves `DevSettings` at the top of `_loadJSBundle`, before the request is issued, so the handler is registered regardless of how that request turns out. The callback keeps its own resolution for the HMR setup that follows it.

## Changelog:

[IOS] [FIXED] - Allow Metro reload after an initial bundle-load failure.

## Test Plan:

On RNTester (iOS 26.5 simulator), launched with an unresolved import so the initial bundle fails, then restored the source and waited 10 seconds: the error stayed and Metro received no bundle request, confirming the app was not a reload peer. Sending `{version: 2, method: "reload"}` to Metro then made it request a corrected bundle and recover in place, native PID `95823` unchanged. A second consecutive reload also worked.

Same scenario on Android RNTester as the reference: it already receives the Metro command on the initial-error path, recovering with PID `14848` unchanged.
