### PR TITLE
Preserve TextInput returnKeyType when changing multiline

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -43,6 +43,7 @@ void RCTCopyBackedTextInput(
   toTextInput.scrollEnabled = fromTextInput.scrollEnabled;
   toTextInput.secureTextEntry = fromTextInput.secureTextEntry;
   toTextInput.keyboardType = fromTextInput.keyboardType;
+  toTextInput.returnKeyType = fromTextInput.returnKeyType;
   toTextInput.textContentType = fromTextInput.textContentType;
   toTextInput.smartInsertDeleteType = fromTextInput.smartInsertDeleteType;
   toTextInput.passwordRules = fromTextInput.passwordRules;

--- a/packages/react-native/React/Tests/Text/RCTTextInputUtilsTest.mm
+++ b/packages/react-native/React/Tests/Text/RCTTextInputUtilsTest.mm
@@ -26,4 +26,15 @@
   XCTAssertEqualObjects(destination.tintColor, UIColor.redColor);
 }
 
+- (void)testCopyBackedTextInputPreservesReturnKeyType
+{
+  RCTUITextField *source = [RCTUITextField new];
+  RCTUITextView *destination = [RCTUITextView new];
+  source.returnKeyType = UIReturnKeyDone;
+
+  RCTCopyBackedTextInput(source, destination);
+
+  XCTAssertEqual(destination.returnKeyType, UIReturnKeyDone);
+}
+
 @end


### PR DESCRIPTION
## Summary:

`RCTCopyBackedTextInput` is called when a `TextInput` switches between
single-line and multiline and the Fabric component view swaps its backing
UIKit view (`RCTUITextField` <-> `RCTUITextView`). It copies the keyboard
traits across to the replacement view, but `returnKeyType` is not among them —
`keyboardType` is copied on the line directly above it.

Because the prop itself has not changed across the transition, the prop diff in
`RCTTextInputComponentView` sees `done` -> `done` and does not re-run the
setter. The replacement view therefore keeps its default Return key, so an
input declared `returnKeyType="done"` renders the newline key instead of Done
once it has flipped to multiline.

This is the same class of omission that was fixed for `tintColor` in #57748,
and the fix is the same shape: copy the property along with its neighbours.

Repro: a `TextInput` with a stable key and `returnKeyType="done"` whose
`multiline` prop goes `false` -> `true`. After the transition, focusing it shows
the default Return key. Fabric view recycling can produce the same backing-view
transition even for an input that is always multiline, which makes it
intermittent in real apps.

Verified against 0.86.3; the line is still missing on 0.87.1 and on `main`.

## Changelog:

[IOS] [FIXED] - Preserve TextInput returnKeyType when switching between single-line and multiline backing views.

## Test Plan:

Added `testCopyBackedTextInputPreservesReturnKeyType` to
`React/Tests/Text/RCTTextInputUtilsTest.mm`, alongside the existing
`testCopyBackedTextInputPreservesTintColor` added in #57748. It sets
`returnKeyType = UIReturnKeyDone` on an `RCTUITextField`, runs
`RCTCopyBackedTextInput` into an `RCTUITextView`, and asserts the value
survives. The test fails without the one-line change and passes with it.

Also confirmed in a production app: a multiline `TextInput` with
`returnKeyType="done"` intermittently displayed the newline key, and adding
this single line fixed it.
