### PR TITLE
Run SPM-generated shell scripts under bash, not /bin/sh

### DIFF
--- a/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
@@ -151,6 +151,31 @@ describe('scheme pre-action', () => {
       updated,
     );
   });
+
+  // Xcode always runs a scheme pre-action's scriptText under the shell named
+  // by shellToInvoke (default /bin/sh), independent of a
+  // PBXShellScriptBuildPhase's own shellPath — the sync script needs bash
+  // (`set -o pipefail`), so pin it here too.
+  it('pins shellToInvoke to bash on a freshly generated scheme', () => {
+    const result = generateXcscheme('MyApp', 'TARGET_UUID', 'MyApp', 'SCRIPT');
+    expect(result).toContain('shellToInvoke = "/bin/bash"');
+  });
+
+  it('adds shellToInvoke to a scheme injected before this attribute existed', () => {
+    // Simulates a scheme written by an older RN version — no shellToInvoke.
+    const legacy = generateXcscheme(
+      'MyApp',
+      'TARGET_UUID',
+      'MyApp',
+      'SCRIPT',
+    ).replace('\n               shellToInvoke = "/bin/bash">', '>');
+    expect(legacy).not.toContain('shellToInvoke');
+    const updated = addPreActionToScheme(legacy, 'TARGET_UUID', 'SCRIPT');
+    expect(updated).toContain('shellToInvoke = "/bin/bash"');
+    expect(addPreActionToScheme(updated, 'TARGET_UUID', 'SCRIPT')).toBe(
+      updated,
+    );
+  });
 });
 
 describe('sync scripts', () => {

--- a/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/generate-spm-xcodeproj-test.js
@@ -176,6 +176,31 @@ describe('scheme pre-action', () => {
       updated,
     );
   });
+
+  it('refreshes shellToInvoke when it appears before scriptText', () => {
+    const reordered = generateXcscheme(
+      'MyApp',
+      'TARGET_UUID',
+      'MyApp',
+      'SCRIPT',
+    ).replace(
+      'scriptText = "SCRIPT"\n               shellToInvoke = "/bin/bash">',
+      'shellToInvoke = "/bin/bash"\n               scriptText = "SCRIPT">',
+    );
+    const updated = addPreActionToScheme(reordered, 'TARGET_UUID', 'SCRIPT');
+    expect(updated.match(/shellToInvoke/g)).toHaveLength(1);
+  });
+
+  it('refreshes shellToInvoke with no spaces around the equals sign', () => {
+    const unspaced = generateXcscheme(
+      'MyApp',
+      'TARGET_UUID',
+      'MyApp',
+      'SCRIPT',
+    ).replace('shellToInvoke = "/bin/bash"', 'shellToInvoke="/bin/bash"');
+    const updated = addPreActionToScheme(unspaced, 'TARGET_UUID', 'SCRIPT');
+    expect(updated.match(/shellToInvoke/g)).toHaveLength(1);
+  });
 });
 
 describe('sync scripts', () => {

--- a/packages/react-native/scripts/spm/__tests__/inject-spm-xcodeproj-test.js
+++ b/packages/react-native/scripts/spm/__tests__/inject-spm-xcodeproj-test.js
@@ -297,6 +297,35 @@ describe('injectSpmIntoPbxproj — Tier 2 (build settings + phase)', () => {
     expect(syncIdx).toBeLessThan(sourcesIdx);
   });
 
+  it('runs every injected shell-script build phase under bash, not /bin/sh', () => {
+    // Their bodies start with `set -euo pipefail`, which a non-bash /bin/sh
+    // (e.g. dash) rejects at runtime.
+    const {text} = inject(PLAIN);
+    const phaseCount = text.match(/isa = PBXShellScriptBuildPhase;/g)?.length;
+    const bashCount = text.match(/shellPath = \/bin\/bash;/g)?.length;
+    expect(phaseCount).toBeGreaterThan(0);
+    expect(bashCount).toBe(phaseCount);
+  });
+
+  it('upgrades an already-injected phase from /bin/sh to bash on re-run', () => {
+    // A project injected before this fix recorded `shellPath = /bin/sh;` on
+    // the Sync SPM Autolinking phase. Re-running inject (e.g. `spm update`)
+    // must refresh it in place, not just apply bash to newly-created phases.
+    const {text: firstText} = inject(PLAIN);
+    const downgraded = firstText.replace(
+      /shellPath = \/bin\/bash;/g,
+      'shellPath = /bin/sh;',
+    );
+    const {text: secondText} = inject(downgraded);
+    expect(secondText).not.toContain('shellPath = /bin/sh;');
+    const phaseCount = secondText.match(
+      /isa = PBXShellScriptBuildPhase;/g,
+    )?.length;
+    expect(secondText.match(/shellPath = \/bin\/bash;/g)?.length).toBe(
+      phaseCount,
+    );
+  });
+
   it.each([
     [
       '"$(inherited)"',

--- a/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
+++ b/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
@@ -319,7 +319,11 @@ function shellScriptPhase(
       outputFileListPaths: empty,
       outputPaths: pathList(options.outputPaths),
       runOnlyForDeploymentPostprocessing: '0',
-      shellPath: '/bin/sh',
+      // React Native's own bodies here start with `set -euo pipefail`, which
+      // /bin/sh rejects on a host where it isn't bash (e.g. dash's `set -o
+      // pipefail: Illegal option`). Run every phase under bash, including
+      // plugin-contributed ones, so a plugin's body can rely on it too.
+      shellPath: '/bin/bash',
       shellScript: quoteIfNeeded(script),
     },
   };
@@ -899,7 +903,8 @@ function generateXcscheme(
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Sync SPM Autolinking"
-               scriptText = "${escapedSync}">
+               scriptText = "${escapedSync}"
+               shellToInvoke = "/bin/bash">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -1361,27 +1366,29 @@ function injectSpmIntoPbxproj(
   //    bundles JS via its own phase.
   const syncScript = buildSyncAutolinkingScript(reactNativePath);
   const syncPhaseUuid = mkUuid('PBXShellScriptBuildPhase', 'SyncAutolinking');
+  const syncEntry = shellScriptPhase(
+    syncPhaseUuid,
+    'Sync SPM Autolinking',
+    syncScript,
+  );
   if (!text.includes(syncPhaseUuid)) {
     text = insertObjectsIntoSection(
       text,
       'PBXShellScriptBuildPhase',
-      serializeEntry(
-        shellScriptPhase(syncPhaseUuid, 'Sync SPM Autolinking', syncScript),
-      ),
+      serializeEntry(syncEntry),
     );
   } else {
-    // Already injected on a prior run — the phase object owns its
-    // shellScript, so refresh it in place (same quoting used at creation) in
-    // case the generated script changed since. Byte-identical when it
-    // didn't; field order and every other byte of the phase are untouched.
-    const existingPhase = findObjectByUuid(text, syncPhaseUuid);
-    if (existingPhase != null) {
-      text = setScalarField(
-        text,
-        existingPhase,
-        'shellScript',
-        quoteIfNeeded(syncScript),
-      );
+    // Already injected on a prior run — the phase object owns these fields,
+    // so refresh them in place (same quoting used at creation) in case the
+    // generated script changed, or a project injected before shellPath moved
+    // to bash (see shellScriptPhase) still has the stale value. Byte-identical
+    // when neither did; field order and every other byte of the phase are
+    // untouched.
+    for (const key of ['shellScript', 'shellPath']) {
+      const current = findObjectByUuid(text, syncPhaseUuid);
+      if (current != null) {
+        text = setScalarField(text, current, key, syncEntry.fields[key]);
+      }
     }
   }
   injectedUuids.push(syncPhaseUuid);
@@ -1429,7 +1436,12 @@ function injectSpmIntoPbxproj(
   } else {
     const existingPhase = findObjectByUuid(text, embedPhaseUuid);
     if (existingPhase != null) {
-      for (const key of ['shellScript', 'inputPaths', 'outputPaths']) {
+      for (const key of [
+        'shellScript',
+        'inputPaths',
+        'outputPaths',
+        'shellPath',
+      ]) {
         const current = findObjectByUuid(text, embedPhaseUuid);
         if (current != null) {
           text = setScalarField(text, current, key, embedEntry.fields[key]);
@@ -1606,6 +1618,7 @@ function injectSpmIntoPbxproj(
           'shellScript',
           'inputPaths',
           'outputPaths',
+          'shellPath',
         ]) {
           const current = findObjectByUuid(text, uuid);
           if (current != null) {
@@ -1876,11 +1889,33 @@ function addPreActionToScheme(
     // value itself never contains one — the next `"` is always the closing
     // delimiter.
     const valueEnd = xml.indexOf('"', valueStart);
-    return (
+    let xmlWithScript =
       xml.slice(0, valueStart) +
       escapeXmlAttribute(syncScript) +
-      xml.slice(valueEnd)
-    );
+      xml.slice(valueEnd);
+
+    // Xcode always runs a scheme pre-action's scriptText under the shell this
+    // attribute names (default /bin/sh), independent of a
+    // PBXShellScriptBuildPhase's own shellPath (see shellScriptPhase) — pin
+    // it to bash too. `>` can't appear unescaped inside either attribute
+    // value, so it reliably closes the ActionContent open tag.
+    const contentCloseIdx = xmlWithScript.indexOf('>', stIdx);
+    const shellToInvokeMarker = 'shellToInvoke = "';
+    const stiIdx = xmlWithScript.indexOf(shellToInvokeMarker, valueStart);
+    if (stiIdx >= 0 && stiIdx < contentCloseIdx) {
+      const stiValueStart = stiIdx + shellToInvokeMarker.length;
+      const stiValueEnd = xmlWithScript.indexOf('"', stiValueStart);
+      xmlWithScript =
+        xmlWithScript.slice(0, stiValueStart) +
+        '/bin/bash' +
+        xmlWithScript.slice(stiValueEnd);
+    } else {
+      xmlWithScript =
+        xmlWithScript.slice(0, contentCloseIdx) +
+        '\n               shellToInvoke = "/bin/bash"' +
+        xmlWithScript.slice(contentCloseIdx);
+    }
+    return xmlWithScript;
   }
   const refMatch = xml.match(
     new RegExp(
@@ -1907,7 +1942,8 @@ function addPreActionToScheme(
     `            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">\n` +
     `            <ActionContent\n` +
     `               title = "Sync SPM Autolinking"\n` +
-    `               scriptText = "${escapeXmlAttribute(syncScript)}">\n` +
+    `               scriptText = "${escapeXmlAttribute(syncScript)}"\n` +
+    `               shellToInvoke = "/bin/bash">\n` +
     `               <EnvironmentBuildable>\n` +
     `                  ${cleanRef}\n` +
     `               </EnvironmentBuildable>\n` +

--- a/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
+++ b/packages/react-native/scripts/spm/generate-spm-xcodeproj.js
@@ -1898,12 +1898,19 @@ function addPreActionToScheme(
     // attribute names (default /bin/sh), independent of a
     // PBXShellScriptBuildPhase's own shellPath (see shellScriptPhase) — pin
     // it to bash too. `>` can't appear unescaped inside either attribute
-    // value, so it reliably closes the ActionContent open tag.
+    // value, so it reliably closes the ActionContent open tag. Search the
+    // whole open tag (not just after scriptText) and allow any spacing
+    // around `=`, since attribute order and formatting aren't guaranteed.
+    const contentOpenIdx = xmlWithScript.lastIndexOf(
+      '<ActionContent',
+      titleIdx,
+    );
     const contentCloseIdx = xmlWithScript.indexOf('>', stIdx);
-    const shellToInvokeMarker = 'shellToInvoke = "';
-    const stiIdx = xmlWithScript.indexOf(shellToInvokeMarker, valueStart);
-    if (stiIdx >= 0 && stiIdx < contentCloseIdx) {
-      const stiValueStart = stiIdx + shellToInvokeMarker.length;
+    const openTag = xmlWithScript.slice(contentOpenIdx, contentCloseIdx);
+    const stiMatch = openTag.match(/shellToInvoke\s*=\s*"/);
+    if (stiMatch != null) {
+      const stiValueStart =
+        contentOpenIdx + stiMatch.index + stiMatch[0].length;
       const stiValueEnd = xmlWithScript.indexOf('"', stiValueStart);
       xmlWithScript =
         xmlWithScript.slice(0, stiValueStart) +


### PR DESCRIPTION
## Summary:

SPM setup scripts start with `set -euo pipefail`, but every one of them runs under `/bin/sh`. On a machine where `/bin/sh` isn't bash (e.g. dash), that fails immediately with `set: Illegal option -o pipefail`, so no SwiftPM build gets past the first build phase.

Two spots in `generate-spm-xcodeproj.js`:

- `shellScriptPhase` hardcodes `shellPath: '/bin/sh'` for every `PBXShellScriptBuildPhase` it builds (Sync SPM Autolinking, Embed React Native Flavored Frameworks, plugin-contributed phases), while their bodies are bash-only. Now sets `shellPath: '/bin/bash'`, and refreshes it on an already-injected project too.
- The "Sync SPM Autolinking" scheme pre-action runs the same kind of script, but a scheme pre-action ignores a build phase's `shellPath` entirely — Xcode reads the shell from the `ActionContent`'s own `shellToInvoke` attribute instead (default `/bin/sh`). Now sets `shellToInvoke = "/bin/bash"` on both scheme creation and when adding/refreshing the pre-action on an existing scheme.

Fixes #58359

## Changelog:

[IOS] [FIXED] - SwiftPM: run generated build scripts under bash instead of /bin/sh, so they don't break on a host where /bin/sh isn't bash

## Test Plan:

`yarn test packages/react-native/scripts/spm` — 838 passed, including new cases for the refreshed `shellPath`/`shellToInvoke` on a project injected before this fix, and a scheme injected before the attribute existed.