### PR TITLE
Fix Modal staying onscreen when dismissed while presenting a child controller

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -158,7 +158,13 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
                      animated:(BOOL)animated
                    completion:(void (^)(void))completion
 {
-  [modalViewController dismissViewControllerAnimated:animated completion:completion];
+  if (modalViewController.presentedViewController) {
+    // Dismissing a controller that is itself presenting only dismisses its child, so dismiss both.
+    UIViewController *presentingViewController = modalViewController.presentingViewController ?: modalViewController;
+    [presentingViewController dismissViewControllerAnimated:animated completion:completion];
+  } else {
+    [modalViewController dismissViewControllerAnimated:animated completion:completion];
+  }
 }
 
 - (void)ensurePresentedOnlyIfNeeded

--- a/packages/react-native/React/Tests/Mounting/RCTModalHostViewComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Mounting/RCTModalHostViewComponentViewTests.mm
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTModalHostViewComponentView.h>
+#import <XCTest/XCTest.h>
+
+#if TARGET_OS_IOS
+
+// Simulates a modal that is itself presenting a child, without a window or presentation animation.
+@interface RCTFakeModalViewController : UIViewController
+@property (nonatomic, strong) UIViewController *fakePresentedViewController;
+@property (nonatomic, weak) UIViewController *fakePresentingViewController;
+@property (nonatomic, assign) NSInteger dismissCallCount;
+@end
+
+@implementation RCTFakeModalViewController
+
+- (UIViewController *)presentedViewController
+{
+  return _fakePresentedViewController;
+}
+
+- (UIViewController *)presentingViewController
+{
+  return _fakePresentingViewController;
+}
+
+- (void)dismissViewControllerAnimated:(BOOL)animated completion:(void (^)(void))completion
+{
+  self.dismissCallCount++;
+  if (completion) {
+    completion();
+  }
+}
+
+@end
+
+@interface RCTModalHostViewComponentViewTests : XCTestCase
+@end
+
+@implementation RCTModalHostViewComponentViewTests
+
+// Dismissing a modal that is itself presenting a child (e.g. the "Undo Typing" alert) must
+// dismiss the whole stack through the presenting view controller, otherwise the modal is left
+// stuck onscreen (#58326).
+- (void)testDismissViewControllerDismissesWholeStackWhenChildIsPresented
+{
+  RCTModalHostViewComponentView *view = [[RCTModalHostViewComponentView alloc] initWithFrame:CGRectZero];
+
+  RCTFakeModalViewController *presentingViewController = [RCTFakeModalViewController new];
+  RCTFakeModalViewController *modalViewController = [RCTFakeModalViewController new];
+  RCTFakeModalViewController *presentedChildViewController = [RCTFakeModalViewController new];
+
+  modalViewController.fakePresentedViewController = presentedChildViewController;
+  modalViewController.fakePresentingViewController = presentingViewController;
+
+  __block BOOL completionCalled = NO;
+  [view dismissViewController:modalViewController
+                     animated:NO
+                   completion:^{
+                     completionCalled = YES;
+                   }];
+
+  XCTAssertEqual(presentingViewController.dismissCallCount, 1);
+  XCTAssertEqual(modalViewController.dismissCallCount, 0);
+  XCTAssertTrue(completionCalled);
+}
+
+- (void)testDismissViewControllerFallsBackToModalWhenPresentingViewControllerIsNil
+{
+  RCTModalHostViewComponentView *view = [[RCTModalHostViewComponentView alloc] initWithFrame:CGRectZero];
+
+  RCTFakeModalViewController *modalViewController = [RCTFakeModalViewController new];
+  modalViewController.fakePresentedViewController = [RCTFakeModalViewController new];
+  modalViewController.fakePresentingViewController = nil;
+
+  __block BOOL completionCalled = NO;
+  [view dismissViewController:modalViewController
+                     animated:NO
+                   completion:^{
+                     completionCalled = YES;
+                   }];
+
+  XCTAssertEqual(modalViewController.dismissCallCount, 1);
+  XCTAssertTrue(completionCalled);
+}
+
+- (void)testDismissViewControllerWithNoPresentedChildDismissesDirectly
+{
+  RCTModalHostViewComponentView *view = [[RCTModalHostViewComponentView alloc] initWithFrame:CGRectZero];
+
+  RCTFakeModalViewController *modalViewController = [RCTFakeModalViewController new];
+
+  __block BOOL completionCalled = NO;
+  [view dismissViewController:modalViewController
+                     animated:NO
+                   completion:^{
+                     completionCalled = YES;
+                   }];
+
+  XCTAssertEqual(modalViewController.dismissCallCount, 1);
+  XCTAssertTrue(completionCalled);
+}
+
+@end
+
+#endif


### PR DESCRIPTION
## Summary:

Dismissing a `Modal` on iOS/Fabric while it was presenting a child view controller (a system alert, an action sheet, the dev menu) left the modal itself stuck onscreen as an empty sheet. `RCTModalHostViewComponentView` dismissed the modal's view controller directly, but UIKit forwards `dismissViewControllerAnimated:` calls to the topmost presented child, so only the alert closed while React still thought the modal was gone.

Now the dismissal goes through the modal's `presentingViewController` whenever it has a presented child, closing the whole stack in one animation.

Fixes #58326

## Changelog:

[IOS] [FIXED] - Fix Modal staying onscreen when dismissed while presenting a child view controller

## Test Plan:

Added `RCTModalHostViewComponentViewTests.mm`: dismissing with a presented child redirects through `presentingViewController`, falls back to the modal itself when that's nil, and the no-child path still dismisses directly. Couldn't run against a simulator in this environment (no full Xcode/CocoaPods toolchain available here); traced the issue's repro steps against the new logic by hand.
