### PR TITLE
fix(android): stop re-arming idle Choreographer frame callbacks at vsync rate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -299,6 +299,11 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
 
     preOperations.executeBatch(batchNumber, nodesManager)
     operations.executeBatch(batchNumber, nodesManager)
+
+    // Operations executed above may have started animations (e.g. startAnimatingNode); the
+    // frame callback disarms itself when no animations are active, so re-arm it here.
+    // didDispatchMountItems is UI-confined, like enqueueFrameCallback.
+    enqueueFrameCallback()
   }
 
   // For non-FabricUIManager only (no-op since Fabric is the only supported UIManager)
@@ -348,9 +353,11 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
             val nodesManager = nodesManager ?: return
             if (nodesManager.hasActiveAnimations()) {
               nodesManager.runUpdates(frameTimeNanos)
+              // Only keep the Choreographer armed while animations are actually running.
+              // didDispatchMountItems re-arms this callback when new animation operations
+              // (e.g. startAnimatingNode) execute.
+              enqueueFrameCallback()
             }
-
-            enqueueFrameCallback()
           } catch (ex: Exception) {
             throw RuntimeException(ex)
           }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1663,7 +1663,12 @@ public class FabricUIManager
         mIsMountingEnabled = false;
         throw ex;
       } finally {
-        schedule();
+        // Keep the Choreographer armed only while items remain pending; posting new items
+        // calls schedule() directly. An unconditional re-schedule here kept the Choreographer
+        // running at vsync rate while idle.
+        if (mMountItemDispatcher.hasPendingItems()) {
+          schedule();
+        }
       }
 
       if (ReactNativeFeatureFlags.useSharedAnimatedBackend() && mBinding != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.kt
@@ -34,6 +34,10 @@ internal class MountItemDispatcher(
   private val mountItems: Queue<MountItem> = ConcurrentLinkedQueue()
   private val preMountItems: Queue<MountItem> = ConcurrentLinkedQueue()
 
+  /** @return true if any mount items, pre-mount items or view commands are still pending */
+  fun hasPendingItems(): Boolean =
+      !viewCommandMountItems.isEmpty() || !mountItems.isEmpty() || !preMountItems.isEmpty()
+
   private var inDispatch: Boolean = false
   var batchedExecutionTime: Long = 0L
     private set

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
@@ -185,6 +185,14 @@ public open class JavaTimerManager(
     synchronized(timerGuard) {
       timers.add(timer)
       timerIdsToTimers.put(timerId, timer)
+      if (!frameCallbackPosted && !isPaused.get()) {
+        // Re-arm the timers frame callback lazily: it disarms itself whenever the queue drains.
+        reactChoreographer.postFrameCallback(
+            ReactChoreographer.CallbackType.TIMERS_EVENTS,
+            timerFrameCallback,
+        )
+        frameCallbackPosted = true
+      }
     }
   }
 
@@ -292,6 +300,7 @@ public open class JavaTimerManager(
         return
       }
       val frameTimeMillis = frameTimeNanos / 1000000
+      var shouldRepost: Boolean
       synchronized(timerGuard) {
         while (!timers.isEmpty() && timers.peek()!!.targetTime < frameTimeMillis) {
           var timer = timers.poll()
@@ -309,12 +318,20 @@ public open class JavaTimerManager(
             timerIdsToTimers.remove(timer.timerId)
           }
         }
+        shouldRepost = timers.isNotEmpty()
+        if (!shouldRepost) {
+          // The timer queue is empty: disarm instead of re-posting this callback at vsync rate.
+          // createTimer re-arms the callback when a new timer arrives.
+          frameCallbackPosted = false
+        }
       }
       timersToCall?.let { timers ->
         javaScriptTimerExecutor.callTimers(timers)
         timersToCall = null
       }
-      reactChoreographer.postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, this)
+      if (shouldRepost) {
+        reactChoreographer.postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, this)
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
@@ -147,10 +147,13 @@ internal class FabricEventDispatcher(
     override fun doFrame(frameTimeNanos: Long) {
       UiThreadUtil.assertOnUiThread()
 
+      // This callback is one-shot per schedule request (see maybeDispatchBatchedEvents): events
+      // are dispatched synchronously in dispatchEvent, so there is nothing to re-post here.
+      // Re-posting unconditionally kept the Choreographer armed at vsync rate while idle.
+      isFrameCallbackDispatchScheduled = false
+
       if (shouldStop) {
-        isFrameCallbackDispatchScheduled = false
-      } else {
-        dispatchBatchedEvents()
+        return
       }
 
       Systrace.beginSection(Systrace.TRACE_TAG_REACT, "BatchEventDispatchedListeners")


### PR DESCRIPTION
## Summary

Resolves #58367.

Four Android frame callbacks re-post themselves unconditionally at the end of their own `doFrame` (armed at host resume), keeping the main-thread Choreographer running at ~60fps while an app is **idle in the foreground with zero pending work and zero frames rendered**. Measured on a stock 0.86.3 template app: ~600 doFrames/10s at 0.2–2ms each, ~3.5–22.5% process CPU across API 28–36 devices, `Total frames rendered: 0` (full data in the issue).

This makes each pump re-arm only when it has work, re-arming lazily from its registration/posting path:

1. **`JavaTimerManager.TimerFrameCallback`** — re-post only while the timer queue is non-empty; `createTimer` re-arms when a new timer arrives (posting is thread-safe; `ReactChoreographer` documents any-thread use, and the flag dance stays under `timerGuard`).
2. **`FabricEventDispatcher.ScheduleDispatchFrameCallback`** — one-shot per schedule request. Events are dispatched synchronously in `dispatchEvent`; this callback only notifies `BatchEventDispatchedListener`s, so `doFrame` has nothing to re-post. `stop()` now simply skips listener notification (the stop/resume of the re-post chain is no longer needed).
3. **`NativeAnimatedModule.animatedFrameCallback`** — `enqueueFrameCallback()` moves inside the existing `hasActiveAnimations()` branch; `didDispatchMountItems` re-arms after operation batches execute (where `startAnimatingNode`-style operations flip `hasActiveAnimations()` true).
4. **`FabricUIManager.DispatchUIFrameCallback`** — the `finally { schedule(); }` re-schedules only while `MountItemDispatcher` still has pending items (new `hasPendingItems()`; all three queues checked). Posting new items already calls `schedule()` directly, and the pre-mount "wait until next frame" continuation case is covered because the items are still queued.

## Test plan

- [x] On-device validation with patched framework classes (stock 0.86.3 template, Release, OPPO Find X8 / Android 16): demand-gating #1/#2 keeps the app fully functional (timers fire, events dispatch) but the loop persists via #3/#4; gating all four → **0 doFrames at idle, ~0% CPU, app alive, rendering and interaction normal** — each pump was keeping only itself armed (one dropped re-post per pump collapses it permanently).
- [ ] RN CI unit tests (JavaTimerManager/NativeAnimated/Fabric suites) — particularly timers-on-idle semantics, headless-task timer arming, and animation start while disarmed.
- [ ] Manual: animation-heavy screen, `requestIdleCallback` usage, and `setInterval` behavior before/after.

Fresh template + `atrace`/`dumpsys gfxinfo` reproduction commands are in the linked issue.

## Impact

Every RN Android app currently burns main-thread CPU at vsync rate whenever its screen is visible but idle (measured up to ~22.5% of a core on a 2016 SoC, ~3.5% on a 2025 flagship). After this change idle RN apps are Choreographer-silent like native apps. No behavior change while work is pending — each callback keeps its exact per-frame dispatch whenever it has work.

## Changelog:

[Android] [Fixed] - Stop re-arming idle Choreographer frame callbacks at vsync rate — idle-foreground apps no longer burn main-thread CPU at ~60 doFrames/s with zero pending work (timers, event dispatch, native animations, mount dispatch each re-arm only when they have work).
