### PR TITLE
Forward declare ShadowTreeRevisionConsistencyManager (#58370)

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -20,6 +20,8 @@
 
 namespace facebook::react {
 
+class ShadowTreeRevisionConsistencyManager;
+
 class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Legacy(

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -19,6 +19,8 @@
 
 namespace facebook::react {
 
+class ShadowTreeRevisionConsistencyManager;
+
 class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Modern(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -11,6 +11,7 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/core/DynamicPropsUtilities.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
@@ -19,6 +20,7 @@
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/renderer/uimanager/UIManagerMountHook.h>
+#include <react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h>
 
 #include <glog/logging.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -16,7 +16,6 @@
 #include <shared_mutex>
 
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
-#include <react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/core/InstanceHandle.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/core/ShadowNode.h>
@@ -29,14 +28,15 @@
 #include <react/renderer/uimanager/UIManagerDelegate.h>
 #include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
 #include <react/renderer/uimanager/UIManagerViewTransitionDelegate.h>
-#include <react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h>
 #include <react/renderer/uimanager/consistency/ShadowTreeRevisionProvider.h>
 #include <react/renderer/uimanager/primitives.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
 
+class LazyShadowTreeRevisionConsistencyManager;
 class LeakChecker;
+class ShadowTreeRevisionConsistencyManager;
 class UIManagerBinding;
 class UIManagerCommitHook;
 class UIManagerMountHook;


### PR DESCRIPTION
Summary:

Stops the for-frameworks and public headers from pulling in the now-guarded private header `react/renderer/consistency/ShadowTreeRevisionConsistencyManager.h`.

It was included by `RuntimeScheduler.h` (and its two forks `RuntimeScheduler_Legacy.h` and `RuntimeScheduler_Modern.h`) and by the public `UIManager.h`, which makes the private guard a hard error for consumers under `RN_STRICT_API`. Every use is a pointer, so those headers now forward declare the type and the include moves to `UIManager.cpp`. `UIManager.h` also drops `LazyShadowTreeRevisionConsistencyManager.h`, which re-exposed the same header through inheritance.

Changelog: [Internal]

Differential Revision: D119054240


