### PR TITLE
Emit tvOS focus events after focus updates

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1850,7 +1850,6 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (void)focus
 {
   UIView *viewToFocus = [self viewToFocus];
-  [viewToFocus becomeFirstResponder];
 
 #if TARGET_OS_TV
   RCTSurfaceHostingProxyRootView *rootView = [self containingRootView];
@@ -1861,6 +1860,8 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   rootView.reactPreferredFocusedView = viewToFocus;
   [rootView setNeedsFocusUpdate];
   [rootView updateFocusIfNeeded];
+#else
+  [viewToFocus becomeFirstResponder];
 #endif
 }
 


### PR DESCRIPTION
Summary:
On tvOS, the focus engine and UIKit first responder are related but distinct. The imperative focus path previously called `becomeFirstResponder` before requesting a focus-engine update. If tvOS rejected that candidate, React Native had already emitted `blur` for the currently focused view and `focus` for the candidate, leaving JavaScript event state out of sync with visual focus.

Request the tvOS focus update without changing first responder first. `didUpdateFocusInContext` remains the point that promotes the selected view to first responder and emits events. Successful focus updates retain their focus and blur events, rejected updates emit neither, and non-tvOS behavior is unchanged.

Changelog:
[iOS][Fixed] - Prevent unsuccessful tvOS focus requests from emitting stale focus events

Differential Revision: D119054149


