### PR TITLE
Forward declare NativeModulePerfLogger in TurboModulePerfLogger.h (#58381)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.cpp
@@ -7,6 +7,8 @@
 
 #include "TurboModulePerfLogger.h"
 
+#include <reactperflogger/NativeModulePerfLogger.h>
+
 namespace facebook::react::TurboModulePerfLogger {
 
 std::unique_ptr<NativeModulePerfLogger> g_perfLogger = nullptr;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModulePerfLogger.h
@@ -7,8 +7,12 @@
 
 #pragma once
 
-#include <reactperflogger/NativeModulePerfLogger.h>
+#include <cstdint>
 #include <memory>
+
+namespace facebook::react {
+class NativeModulePerfLogger;
+} // namespace facebook::react
 
 namespace facebook::react::TurboModulePerfLogger {
 void enableLogging(std::unique_ptr<NativeModulePerfLogger> &&logger);


### PR DESCRIPTION
Summary:

Under the C++ Stable API RFC, `react/nativemodule/core:core` is public while `reactperflogger:reactperflogger` is classified as "private". `TurboModulePerfLogger.h` is an exported header of the public target and includes `reactperflogger/NativeModulePerfLogger.h`, so it transitively exposes a private header to consumers.

`NativeModulePerfLogger` is only named as a `std::unique_ptr<NativeModulePerfLogger>&&` parameter in a declaration, so a forward declaration is sufficient and the include moves to the implementation file. `<cstdint>` is now included explicitly, since it was previously pulled in transitively.

This also makes the header consistent with the build config: `reactperflogger` is already a non-exported dep of `react/nativemodule/core:core`, so no BUCK change is needed.

Changelog: [Internal]

Differential Revision: D116901579


