### PR TITLE
Cover reactperflogger with Stable API guards (#58382)

### DIFF
--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(reactperflogger OBJECT ${reactperflogger_SRC})
 target_include_directories(reactperflogger PUBLIC .)
 
 target_link_libraries(reactperflogger
+        react_cxxstableapi
         react_timing
         folly_runtime
 )

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -40,5 +40,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
+  s.dependency "React-cxxstableapi"
+
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "folly/json/dynamic.h"
 
 #include <functional>

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/BridgeNativeModulePerfLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/BridgeNativeModulePerfLogger.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <memory>
 #include "NativeModulePerfLogger.h"
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/FuseboxPerfettoDataSource.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/FuseboxPerfettoDataSource.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_PERFETTO
 
 #include <perfetto.h>

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_PERFETTO
 
 #include <perfetto.h>

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/NativeModulePerfLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/NativeModulePerfLogger.h
@@ -6,6 +6,9 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <cstdint>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_PERFETTO
 
 #include <perfetto.h>

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoCategories.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_PERFETTO
 
 #include <perfetto.h>

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <react/timing/primitives.h>
 #include <reactperflogger/ReactPerfettoCategories.h>
 


### PR DESCRIPTION
Summary:

Classifies `reactperflogger:reactperflogger` as a "for frameworks" target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get a warning if they include its headers directly, which they can acknowledge with `RN_ALLOW_FRAMEWORKS`; without that flag the guards are inert, so no existing build changes behaviour.

Changelog: [Internal]

Differential Revision: D119073018


