### PR TITLE
Include errno in iOS bundle open/stat failure messages (#58383)

### DIFF
--- a/packages/react-native/React/Base/RCTJavaScriptLoader.mm
+++ b/packages/react-native/React/Base/RCTJavaScriptLoader.mm
@@ -7,6 +7,8 @@
 
 #import "RCTJavaScriptLoader.h"
 
+#import <errno.h>
+#import <string.h>
 #import <sys/stat.h>
 
 #import <cxxreact/JSBundleType.h>
@@ -138,12 +140,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   // modules into JSC as they're required.
   FILE *bundle = fopen(scriptURL.path.UTF8String, "r");
   if (!bundle) {
+    // Read errno before anything else can clobber it. Without it a missing bundle (ENOENT) is
+    // indistinguishable from one that exists but cannot be read (EACCES, EIO), which is the
+    // difference between a packaging bug and a transient filesystem failure.
+    const int openErrno = errno;
     if (error) {
       *error = [NSError
           errorWithDomain:RCTJavaScriptLoaderErrorDomain
                      code:RCTJavaScriptLoaderErrorFailedOpeningFile
                  userInfo:@{
-                   NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Error opening bundle %@", scriptURL.path]
+                   NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Error opening bundle %@ (errno %d: %s)",
+                                                                          scriptURL.path,
+                                                                          openErrno,
+                                                                          strerror(openErrno)],
+                   NSUnderlyingErrorKey : [NSError errorWithDomain:NSPOSIXErrorDomain code:openErrno userInfo:nil]
                  }];
     }
     return nil;
@@ -190,12 +200,17 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
   struct stat statInfo;
   if (stat(scriptURL.path.UTF8String, &statInfo) != 0) {
+    const int statErrno = errno;
     if (error) {
       *error = [NSError
           errorWithDomain:RCTJavaScriptLoaderErrorDomain
                      code:RCTJavaScriptLoaderErrorFailedStatingFile
                  userInfo:@{
-                   NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Error stating bundle %@", scriptURL.path]
+                   NSLocalizedDescriptionKey : [NSString stringWithFormat:@"Error stating bundle %@ (errno %d: %s)",
+                                                                          scriptURL.path,
+                                                                          statErrno,
+                                                                          strerror(statErrno)],
+                   NSUnderlyingErrorKey : [NSError errorWithDomain:NSPOSIXErrorDomain code:statErrno userInfo:nil]
                  }];
     }
     return nil;


### PR DESCRIPTION
Summary:

When `RCTJavaScriptLoader` fails to open or stat the JS bundle, the resulting
`NSError` carried only the bundle path. The `errno` set by the failing `fopen()` /
`stat()` was discarded, so a bundle that is absent (`ENOENT`) was indistinguishable
from one that exists but cannot be read (`EACCES`, `EIO`). Because
`RCTInstance handleBundleLoadingError:` turns every loader error into a fatal, this
is the only diagnostic information available after the fact — and there was none.

Capture `errno` immediately after the failing call (before any intervening call can
clobber it) and surface it in two ways: appended to the localized description as
`(errno <n>: <strerror>)`, which is what ends up in the crash report, and as an
`NSPOSIXErrorDomain` error under `NSUnderlyingErrorKey` for programmatic consumers.

Purely additive to error paths that already abort; no behavior change on success.

Changelog:
[iOS][Changed] - Include `errno` and its description in `RCTJavaScriptLoader` bundle open/stat errors

Differential Revision: D118952499
