### PR TITLE
Remove RCTInstance runtime diagnostic flags getter/setter

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -19,14 +19,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * A utility to enable diagnostics mode at runtime. Useful for test runs.
- * The flags are comma-separated string tokens, or an empty string when
- * nothing is enabled.
- */
-RCT_EXTERN NSString *RCTInstanceRuntimeDiagnosticFlags(void);
-RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
-
 @class RCTBundleManager;
 @class RCTInstance;
 @class RCTJSThreadManager;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -59,20 +59,6 @@
 using namespace facebook;
 using namespace facebook::react;
 
-static NSString *sRuntimeDiagnosticFlags = nil;
-NSString *RCTInstanceRuntimeDiagnosticFlags(void)
-{
-  return sRuntimeDiagnosticFlags ? [sRuntimeDiagnosticFlags copy] : [NSString new];
-}
-
-void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
-{
-  if (!flags) {
-    return;
-  }
-  sRuntimeDiagnosticFlags = [flags copy];
-}
-
 __attribute__((deprecated(
     "RCTBridgelessDisplayLinkModuleHolder is part of the legacy architecture and will be removed in a future React Native release.")))
 @interface RCTBridgelessDisplayLinkModuleHolder : NSObject<RCTDisplayLinkModuleHolder>
@@ -438,9 +424,7 @@ __attribute__((deprecated(
   _displayLink = [RCTDisplayLink new];
 
   auto &inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
-  ReactInstance::JSRuntimeFlags options = {
-      .isProfiling = inspectorFlags.getIsProfilingBuild(),
-      .runtimeDiagnosticFlags = [RCTInstanceRuntimeDiagnosticFlags() UTF8String]};
+  ReactInstance::JSRuntimeFlags options = {.isProfiling = inspectorFlags.getIsProfilingBuild()};
   _reactInstance->initializeRuntime(options, [=](jsi::Runtime &runtime) {
     __strong __typeof(self) strongSelf = weakSelf;
     if (!strongSelf) {


### PR DESCRIPTION
Summary:
Removes the `RCTInstanceRuntimeDiagnosticFlags` getter and `RCTInstanceSetRuntimeDiagnosticFlags` setter (and the backing static) from the bridgeless `RCTInstance` runtime, on both the iOS and macOS platform copies.

The setter had no callers anywhere, so the getter always returned an empty string and the `RN$DiagnosticFlags` JS global was never defined. The `ReactInstance::JSRuntimeFlags::runtimeDiagnosticFlags` field already defaults to an empty string, so the `initializeRuntime` call site now relies on that default with no change in runtime behavior.

Changelog:
[iOS][Removed] - Remove `RCTInstanceSetRuntimeDiagnosticFlags` and `RCTInstanceRuntimeDiagnosticFlags`

Differential Revision: D119072229
