### PR TITLE
Cover react/renderer/css with Stable API guards

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -142,6 +142,7 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/core/", "react/renderer/core/"),
                       // react_renderer_css
                       Pair("../ReactCommon/react/renderer/css/", "react/renderer/css/"),
+                      Pair("../ReactCommon/react/renderer/css/React/", "React/"),
                       // react_debug
                       Pair("../ReactCommon/react/debug/", "react/debug/"),
                       Pair("../ReactCommon/react/debug/React/", "React/"),

--- a/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
@@ -14,10 +14,13 @@ file(GLOB react_renderer_css_SRC CONFIGURE_DEPENDS *.cpp)
 if("${react_renderer_css_SRC}" STREQUAL "")
   add_library(react_renderer_css INTERFACE)
 
-  target_include_directories(react_renderer_css INTERFACE ${REACT_COMMON_DIR})
+  target_include_directories(react_renderer_css INTERFACE
+        ${REACT_COMMON_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(react_renderer_css INTERFACE
         fast_float
         glog
+        react_cxxstableapi
         react_debug
         react_utils)
   target_compile_reactnative_options(react_renderer_css INTERFACE)
@@ -25,10 +28,13 @@ if("${react_renderer_css_SRC}" STREQUAL "")
 else()
   add_library(react_renderer_css OBJECT ${react_renderer_css_SRC})
 
-  target_include_directories(react_renderer_css PUBLIC ${REACT_COMMON_DIR})
+  target_include_directories(react_renderer_css PUBLIC
+        ${REACT_COMMON_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR})
   target_link_libraries(react_renderer_css
         fast_float
         glog
+        react_cxxstableapi
         react_debug
         react_utils)
   target_compile_reactnative_options(react_renderer_css PRIVATE)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSAngle.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSAngle.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSAngleUnit.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSAngleUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSAngleUnit.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cmath>
 #include <cstdint>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSBackgroundImage.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <variant>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSColorFunction.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/css/CSSDataType.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <any>
 #include <concepts>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <array>
 #include <optional>
 #include <variant>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFontVariant.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFontVariant.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/renderer/css/CSSDataType.h>
 #include <react/renderer/css/CSSKeyword.h>
 #include <react/renderer/css/CSSList.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cstdint>
 #include <optional>
 #include <string_view>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLength.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLength.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSDataType.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
@@ -6,6 +6,8 @@
  */
 
 #pragma once
+
+#include <react/cxxstableapi/UmbrellaGuard.h>
 #include <react/renderer/css/CSSCompoundDataType.h>
 #include <react/renderer/css/CSSLength.h>
 #include <react/renderer/css/CSSPercentage.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLengthUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLengthUnit.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cstdint>
 #include <optional>
 #include <string_view>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <type_traits>
 #include <variant>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSNamedColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSNamedColor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSNumber.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSNumber.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSDataType.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSPercentage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSPercentage.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSDataType.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <variant>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <tuple>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <concepts>
 #include <optional>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSToken.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSToken.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <string_view>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cmath>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <array>
 #include <optional>
 #include <variant>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <type_traits>
 #include <variant>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 #include <type_traits>
 #include <variant>

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <optional>
 
 #include <react/renderer/css/CSSDataType.h>

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -31,9 +31,8 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/renderer/css"
-  s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
@@ -44,6 +43,13 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-debug")
   add_dependency(s, "React-utils")
+  s.dependency "React-cxxstableapi"
+
+  s.subspec "cssUmbrella" do |ss|
+    ss.source_files        = "React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "."
+  end
 
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/css/React/CSS.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/React/CSS.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/css` module - public entry point.
+//
+//   #include <React/CSS.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/css/...>` includes; only
+// outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/renderer/css/CSSAngle.h>
+#include <react/renderer/css/CSSAngleUnit.h>
+#include <react/renderer/css/CSSBackgroundImage.h>
+#include <react/renderer/css/CSSColor.h>
+#include <react/renderer/css/CSSColorFunction.h>
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSFilter.h>
+#include <react/renderer/css/CSSFontVariant.h>
+#include <react/renderer/css/CSSHexColor.h>
+#include <react/renderer/css/CSSKeyword.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
+#include <react/renderer/css/CSSLengthUnit.h>
+#include <react/renderer/css/CSSList.h>
+#include <react/renderer/css/CSSNamedColor.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSRatio.h>
+#include <react/renderer/css/CSSShadow.h>
+#include <react/renderer/css/CSSSyntaxParser.h>
+#include <react/renderer/css/CSSToken.h>
+#include <react/renderer/css/CSSTokenizer.h>
+#include <react/renderer/css/CSSTransform.h>
+#include <react/renderer/css/CSSTransformOrigin.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/css/CSSZero.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -585,6 +585,23 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
   'Libraries/PushNotificationIOS/React-RCTPushNotification.podspec': {
     disabled: true,
   },
+  'ReactCommon/react/renderer/css/React-renderercss.podspec': {
+    name: 'React-renderercss',
+    headerPatterns: [],
+    headerDir: '',
+    subSpecs: [
+      {
+        name: 'css',
+        headerPatterns: ['*.h'],
+        headerDir: 'react/renderer/css',
+      },
+      {
+        name: 'cssUmbrella',
+        headerPatterns: ['React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
 };
 
 module.exports = {PodspecExceptions};


### PR DESCRIPTION
Summary:
Classify the renderer CSS module as part of React Native’s public C++ stable API. Consumers opting into strict API checks must use the new <React/CSS.h> umbrella, while React Native’s own sources can continue using fine-grained includes.

Changelog:
[Internal] - Add <React/CSS.h> as the public entry point for renderer CSS APIs

Reviewed By: cortinico

Differential Revision: D119072734
