### PR TITLE
Enable Kotlin warnings as errors (#58390)

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuPackage.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/PopupMenuPackage.kt
@@ -26,7 +26,7 @@ public class PopupMenuPackage() : BaseReactPackage(), ViewManagerOnDemandReactPa
     return null
   }
 
-  protected override fun getViewManagers(reactContext: ReactApplicationContext): List<ModuleSpec> {
+  override fun getViewManagers(reactContext: ReactApplicationContext): List<ModuleSpec> {
     return viewManagersMap.values.toList()
   }
 

--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
@@ -25,7 +25,7 @@ public class ReactPopupMenuContainer(context: Context) : FrameLayout(context) {
   public fun showPopupMenu() {
     val view = getChildAt(0)
     val popupMenu = PopupMenu(context, view)
-    var menu = popupMenu.menu
+    val menu = popupMenu.menu
     val items = menuItems
     if (items != null) {
       for (i in 0 until items.size()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -38,6 +38,7 @@ public abstract class ReactActivity extends AppCompatActivity
         }
       };
 
+  @SuppressWarnings("this-escape")
   protected ReactActivity() {
     mDelegate = createReactActivityDelegate();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -175,7 +175,10 @@ public class ReactInstanceManager {
   private final @Nullable JSExceptionHandler mJSExceptionHandler;
   private final @Nullable UIManagerProvider mUIManagerProvider;
   private final @Nullable ReactPackageTurboModuleManagerDelegate.Builder mTMMDelegateBuilder;
+
+  @SuppressWarnings("rawtypes")
   private List<ViewManager> mViewManagers;
+
   private boolean mUseFallbackBundle = true;
   private volatile boolean mInstanceManagerInvalidated = false;
 
@@ -777,7 +780,7 @@ public class ReactInstanceManager {
       mCurrentActivity = null;
     }
 
-    ResourceDrawableIdHelper.getInstance().clear();
+    ResourceDrawableIdHelper.clear();
 
     mHasStartedDestroying = false;
     synchronized (mHasStartedDestroyingLock) {
@@ -940,6 +943,7 @@ public class ReactInstanceManager {
   }
 
   /** Uses configured {@link ReactPackage} instances to create all view managers. */
+  @SuppressWarnings("rawtypes")
   public List<ViewManager> getOrCreateViewManagers(
       ReactApplicationContext catalystApplicationContext) {
     ReactMarker.logMarker(CREATE_VIEW_MANAGERS_START);
@@ -964,6 +968,7 @@ public class ReactInstanceManager {
     }
   }
 
+  @SuppressWarnings("rawtypes")
   public @Nullable ViewManager createViewManager(String viewManagerName) {
     ReactApplicationContext context;
     synchronized (mReactContextLock) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -117,16 +117,19 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private int mLastOffsetY = Integer.MIN_VALUE;
   private final AtomicInteger mState = new AtomicInteger(STATE_STOPPED);
 
+  @SuppressWarnings("this-escape")
   public ReactRootView(Context context) {
     super(context);
     init();
   }
 
+  @SuppressWarnings("this-escape")
   public ReactRootView(Context context, AttributeSet attrs) {
     super(context, attrs);
     init();
   }
 
+  @SuppressWarnings("this-escape")
   public ReactRootView(Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
     init();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
@@ -36,7 +36,7 @@ public abstract class AnimatedNode {
     child.onAttachedToNode(this)
   }
 
-  internal fun removeChild(child: AnimatedNode): Unit {
+  internal fun removeChild(child: AnimatedNode) {
     val currentChildren = children ?: return
     child.onDetachedFromNode(this)
     currentChildren.remove(child)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -903,9 +903,9 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
     addUnbatchedOperation(
         object : UIThreadOperation() {
           override fun execute(animatedNodesManager: NativeAnimatedNodesManager) {
-            val reactApplicationContext = reactApplicationContextIfActiveOrWarn
+            // Retained for warning side-effect
+            getReactApplicationContextIfActiveOrWarn()
 
-            var viewTag = -1
             var i = 0
             while (i < opBufferSize) {
               val command = BatchExecutionOpCodes.fromId(opsAndArgs.getInt(i++))
@@ -996,7 +996,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
 
                 BatchExecutionOpCodes.OP_CODE_DISCONNECT_ANIMATED_NODE_FROM_VIEW -> {
                   val animatedNodeTag = opsAndArgs.getInt(i++)
-                  viewTag = opsAndArgs.getInt(i++)
+                  val viewTag = opsAndArgs.getInt(i++)
                   animatedNodesManager.disconnectAnimatedNodeFromView(animatedNodeTag, viewTag)
                 }
 
@@ -1014,7 +1014,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
                     )
 
                 BatchExecutionOpCodes.OP_CODE_REMOVE_ANIMATED_EVENT_FROM_VIEW -> {
-                  viewTag = opsAndArgs.getInt(i++)
+                  val viewTag = opsAndArgs.getInt(i++)
                   animatedNodesManager.removeAnimatedEventFromView(
                       viewTag,
                       checkNotNull(opsAndArgs.getString(i++)),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ShakeDetector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ShakeDetector.kt
@@ -34,7 +34,7 @@ constructor(private val shakeListener: ShakeListener, private val minNumShakes: 
   private var lastShakeTimestamp: Long = 0
 
   /** Start listening for shakes. */
-  public fun start(manager: SensorManager): Unit {
+  public fun start(manager: SensorManager) {
     val accelerometer = manager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER) ?: return
     sensorManager = manager
     lastTimestamp = -1
@@ -44,7 +44,7 @@ constructor(private val shakeListener: ShakeListener, private val minNumShakes: 
   }
 
   /** Stop listening for shakes. */
-  public fun stop(): Unit {
+  public fun stop() {
     sensorManager?.unregisterListener(this)
     sensorManager = null
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
@@ -22,7 +22,7 @@ public interface SurfaceDelegate {
    *
    * @param appKey
    */
-  public fun createContentView(appKey: String): Unit
+  public fun createContentView(appKey: String)
 
   /**
    * Check if the content view is created and ready to be shown
@@ -32,13 +32,13 @@ public interface SurfaceDelegate {
   public fun isContentViewReady(): Boolean
 
   /** Destroy the React content view to avoid memory leak */
-  public fun destroyContentView(): Unit
+  public fun destroyContentView()
 
   /** Show the surface containing the React content view */
-  public fun show(): Unit
+  public fun show()
 
   /** Hide the surface containing the React content view */
-  public fun hide(): Unit
+  public fun hide()
 
   /** Check if the surface is currently showing */
   public fun isShowing(): Boolean

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.kt
@@ -83,7 +83,7 @@ public class ReactFontManager {
    *
    * ReactFontManager.getInstance().addCustomFont(this, "Srisakdi", R.font.srisakdi);
    */
-  public fun addCustomFont(context: Context, fontFamily: String, fontId: Int): Unit {
+  public fun addCustomFont(context: Context, fontFamily: String, fontId: Int) {
     addCustomFont(fontFamily, ResourcesCompat.getFont(context, fontId))
   }
 
@@ -91,7 +91,7 @@ public class ReactFontManager {
    * Equivalent method to {@see addCustomFont(Context, String, int)} which accepts a Typeface
    * object.
    */
-  public fun addCustomFont(fontFamily: String, font: Typeface?): Unit {
+  public fun addCustomFont(fontFamily: String, font: Typeface?) {
     if (font != null) {
       customTypefaceCache[fontFamily] = font
     }
@@ -105,7 +105,7 @@ public class ReactFontManager {
    * @see [Typeface.ITALIC]
    * @see [Typeface.BOLD_ITALIC]
    */
-  public fun setTypeface(fontFamilyName: String, style: Int, typeface: Typeface?): Unit {
+  public fun setTypeface(fontFamilyName: String, style: Int, typeface: Typeface?) {
     if (typeface != null) {
       fontCache.getOrPut(fontFamilyName) { AssetFontFamily() }.setTypefaceForStyle(style, typeface)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
@@ -27,7 +27,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
    * Sets the result. If another thread has called [get], they will immediately receive the value.
    * set or setException must only be called once.
    */
-  fun set(result: T?): Unit {
+  fun set(result: T?) {
     checkNotSet()
     this.result = result
     readyLatch.countDown()
@@ -37,7 +37,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
    * Sets the exception. If another thread has called [get], they will immediately receive the
    * exception. set or setException must only be called once.
    */
-  fun setException(exception: Exception): Unit {
+  fun setException(exception: Exception) {
     checkNotSet()
     this.exception = exception
     readyLatch.countDown()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/TracingStateListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/TracingStateListener.kt
@@ -11,5 +11,5 @@ import com.facebook.proguard.annotations.DoNotStripAny
 
 @DoNotStripAny
 internal fun interface TracingStateListener {
-  public fun onStateChanged(state: TracingState, screenshotsEnabled: Boolean)
+  fun onStateChanged(state: TracingState, screenshotsEnabled: Boolean)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.devsupport.interfaces
 
-internal enum class DebuggerFrontendPanelName(public val internalName: String) {
+internal enum class DebuggerFrontendPanelName(val internalName: String) {
   CONSOLE("console"),
   MEMORY("heap-profiler"),
   NETWORK("network"),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorDevHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorDevHelper.kt
@@ -14,11 +14,11 @@ import android.app.Activity
  * hooks used to implement the V2 Perf Monitor overlay (experimental).
  */
 internal interface PerfMonitorDevHelper {
-  public val currentActivity: Activity?
+  val currentActivity: Activity?
 
   /**
    * The inspector target object. Matches the lifetime of the ReactHost. May be null if modern JS
    * debugging is disabled.
    */
-  public val inspectorTarget: PerfMonitorInspectorTarget?
+  val inspectorTarget: PerfMonitorInspectorTarget?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorEventDispatcher.kt
@@ -8,5 +8,5 @@
 package com.facebook.react.devsupport.perfmonitor
 
 internal interface PerfMonitorEventDispatcher {
-  public fun addPerfMonitorListener(listener: PerfMonitorUpdateListener)
+  fun addPerfMonitorListener(listener: PerfMonitorUpdateListener)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
@@ -15,17 +15,17 @@ import com.facebook.react.devsupport.inspector.TracingState
  */
 internal interface PerfMonitorInspectorTargetBinding {
   /** Get the current CDP or background performance tracing state. */
-  public fun getTracingState(): TracingState
+  fun getTracingState(): TracingState
 
   /**
    * Attempt to pause the current background performance trace, and open in DevTools. Returns true
    * if there is an active session that can display the trace, false otherwise.
    */
-  public fun pauseAndAnalyzeBackgroundTrace(): Boolean
+  fun pauseAndAnalyzeBackgroundTrace(): Boolean
 
   /** Attempt to start a new background performance trace. */
-  public fun resumeBackgroundTrace()
+  fun resumeBackgroundTrace()
 
   /** Attempt to stop the current performance trace. */
-  public fun stopBackgroundTrace()
+  fun stopBackgroundTrace()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.kt
@@ -100,13 +100,13 @@ public class DevToolsReactPerfLogger : FabricMarkerListener {
     }
   }
 
-  public fun addDevToolsReactPerfLoggerListener(listener: DevToolsReactPerfLoggerListener): Unit {
+  public fun addDevToolsReactPerfLoggerListener(listener: DevToolsReactPerfLoggerListener) {
     devToolsReactPerfLoggerListeners.add(listener)
   }
 
   public fun removeDevToolsReactPerfLoggerListener(
       listener: DevToolsReactPerfLoggerListener,
-  ): Unit {
+  ) {
     devToolsReactPerfLoggerListeners.remove(listener)
   }
 
@@ -135,8 +135,8 @@ public class DevToolsReactPerfLogger : FabricMarkerListener {
       commitPoint.addPoint(name, FabricCommitPointData(timestamp, counter))
 
       if (
-          (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END ||
-              name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_END) && timestamp > 0
+          ((name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END) ||
+              (name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_END)) && (timestamp > 0)
       ) {
         onFabricCommitEnd(commitPoint)
         fabricCommitMarkers.remove(instanceKey)
@@ -151,29 +151,35 @@ public class DevToolsReactPerfLogger : FabricMarkerListener {
   }
 
   private companion object {
-    @JvmField internal val streamingCommitStats: LongStreamingStats = LongStreamingStats()
-
-    @JvmField internal val streamingLayoutStats: LongStreamingStats = LongStreamingStats()
-
-    @JvmField internal val streamingDiffStats: LongStreamingStats = LongStreamingStats()
-
-    @JvmField internal val streamingTransactionEndStats: LongStreamingStats = LongStreamingStats()
-
-    @JvmField internal val streamingBatchExecutionStats: LongStreamingStats = LongStreamingStats()
+    @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
+    @JvmField
+    internal val streamingCommitStats: LongStreamingStats = LongStreamingStats()
+    @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
+    @JvmField
+    internal val streamingLayoutStats: LongStreamingStats = LongStreamingStats()
+    @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
+    @JvmField
+    internal val streamingDiffStats: LongStreamingStats = LongStreamingStats()
+    @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
+    @JvmField
+    internal val streamingTransactionEndStats: LongStreamingStats = LongStreamingStats()
+    @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
+    @JvmField
+    internal val streamingBatchExecutionStats: LongStreamingStats = LongStreamingStats()
 
     private fun isFabricCommitMarker(name: ReactMarkerConstants): Boolean =
-        name == ReactMarkerConstants.FABRIC_COMMIT_START ||
-            name == ReactMarkerConstants.FABRIC_COMMIT_END ||
-            name == ReactMarkerConstants.FABRIC_FINISH_TRANSACTION_START ||
-            name == ReactMarkerConstants.FABRIC_FINISH_TRANSACTION_END ||
-            name == ReactMarkerConstants.FABRIC_DIFF_START ||
-            name == ReactMarkerConstants.FABRIC_DIFF_END ||
-            name == ReactMarkerConstants.FABRIC_LAYOUT_START ||
-            name == ReactMarkerConstants.FABRIC_LAYOUT_END ||
-            name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_START ||
-            name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END ||
-            name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_START ||
-            name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_END ||
-            name == ReactMarkerConstants.FABRIC_LAYOUT_AFFECTED_NODES
+        (name == ReactMarkerConstants.FABRIC_COMMIT_START) ||
+            (name == ReactMarkerConstants.FABRIC_COMMIT_END) ||
+            (name == ReactMarkerConstants.FABRIC_FINISH_TRANSACTION_START) ||
+            (name == ReactMarkerConstants.FABRIC_FINISH_TRANSACTION_END) ||
+            (name == ReactMarkerConstants.FABRIC_DIFF_START) ||
+            (name == ReactMarkerConstants.FABRIC_DIFF_END) ||
+            (name == ReactMarkerConstants.FABRIC_LAYOUT_START) ||
+            (name == ReactMarkerConstants.FABRIC_LAYOUT_END) ||
+            (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_START) ||
+            (name == ReactMarkerConstants.FABRIC_BATCH_EXECUTION_END) ||
+            (name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_START) ||
+            (name == ReactMarkerConstants.FABRIC_UPDATE_UI_MAIN_THREAD_END) ||
+            (name == ReactMarkerConstants.FABRIC_LAYOUT_AFFECTED_NODES)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -242,6 +242,7 @@ public class FabricUIManager
   // It's initialized only when addUIBlock or prependUIBlock is called the first time.
   @Nullable private InteropUIBlockListener mInteropUIBlockListener;
 
+  @SuppressWarnings("this-escape")
   public FabricUIManager(
       ReactApplicationContext reactContext,
       ViewManagerRegistry viewManagerRegistry,
@@ -551,7 +552,7 @@ public class FabricUIManager
       ReadableMapBuffer paragraphAttributes,
       float width,
       float height) {
-    ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
+    ViewManager<?, ?> textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
 
     return (NativeArray)
         TextLayoutManager.measureLines(
@@ -641,7 +642,7 @@ public class FabricUIManager
       float maxHeight,
       @Nullable float[] attachmentsPositions) {
 
-    ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
+    ViewManager<?, ?> textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
 
     return TextLayoutManager.measureText(
         mReactApplicationContext.getAssets(),
@@ -669,7 +670,7 @@ public class FabricUIManager
       float maxWidth,
       float minHeight,
       float maxHeight) {
-    ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
+    ViewManager<?, ?> textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
 
     return TextLayoutManager.createPreparedLayout(
         mReactApplicationContext.getAssets(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
@@ -33,9 +33,9 @@ internal class StateWrapperImpl private constructor() : HybridClassBase(), Refer
 
   private external fun getStateDataReferenceImpl(): Any?
 
-  public external fun updateStateImpl(map: NativeMap)
+  external fun updateStateImpl(map: NativeMap)
 
-  public override val stateDataMapBuffer: ReadableMapBuffer?
+  override val stateDataMapBuffer: ReadableMapBuffer?
     get() {
       if (!isValid) {
         FLog.e(TAG, "Race between StateWrapperImpl destruction and getState")
@@ -44,7 +44,7 @@ internal class StateWrapperImpl private constructor() : HybridClassBase(), Refer
       return getStateMapBufferDataImpl()
     }
 
-  public override val stateData: ReadableNativeMap?
+  override val stateData: ReadableNativeMap?
     get() {
       if (!isValid) {
         FLog.e(TAG, "Race between StateWrapperImpl destruction and getState")
@@ -53,7 +53,7 @@ internal class StateWrapperImpl private constructor() : HybridClassBase(), Refer
       return getStateDataImpl()
     }
 
-  public override val stateDataReference: Any?
+  override val stateDataReference: Any?
     get() {
       if (!isValid) {
         FLog.e(TAG, "Race between StateWrapperImpl destruction and getState")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.kt
@@ -119,7 +119,7 @@ internal constructor(
   private val tagToSynchronousMountProps = SparseArrayCompat<MutableMap<String, Any>>()
 
   @AnyThread
-  public fun attachRootView(rootView: View, themedReactContext: ThemedReactContext): Unit {
+  public fun attachRootView(rootView: View, themedReactContext: ThemedReactContext) {
     this.context = themedReactContext
 
     if (isStopped) {
@@ -201,7 +201,7 @@ internal constructor(
 
   @UiThread
   @ThreadConfined(ThreadConfined.UI)
-  internal fun scheduleMountItemOnViewAttach(item: MountItem): Unit {
+  internal fun scheduleMountItemOnViewAttach(item: MountItem) {
     onViewAttachMountItems.add(item)
   }
 
@@ -229,7 +229,7 @@ internal constructor(
    * garbage collection will take care of destroying it and all descendents.
    */
   @AnyThread
-  public fun stopSurface(): Unit {
+  public fun stopSurface() {
     FLog.e(TAG, "Stopping surface [$surfaceId]")
     if (isStopped) {
       return
@@ -294,7 +294,7 @@ internal constructor(
   }
 
   @UiThread
-  public fun addViewAt(parentTag: Int, tag: Int, index: Int): Unit {
+  public fun addViewAt(parentTag: Int, tag: Int, index: Int) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -396,7 +396,7 @@ internal constructor(
   }
 
   @UiThread
-  public fun removeViewAt(tag: Int, parentTag: Int, index: Int): Unit {
+  public fun removeViewAt(tag: Int, parentTag: Int, index: Int) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -537,7 +537,7 @@ internal constructor(
       stateWrapper: StateWrapper?,
       eventEmitterWrapper: EventEmitterWrapper?,
       isLayoutable: Boolean,
-  ): Unit {
+  ) {
     if (isStopped) {
       return
     }
@@ -582,7 +582,7 @@ internal constructor(
       stateWrapper: StateWrapper?,
       eventEmitterWrapper: EventEmitterWrapper?,
       isLayoutable: Boolean,
-  ): Unit {
+  ) {
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT,
         "SurfaceMountingManager::createViewUnsafe($componentName)",
@@ -616,7 +616,7 @@ internal constructor(
     }
   }
 
-  public fun storeSynchronousMountPropsOverride(reactTag: Int, props: ReadableMap): Unit {
+  public fun storeSynchronousMountPropsOverride(reactTag: Int, props: ReadableMap) {
     if (ReactNativeFeatureFlags.overrideBySynchronousMountPropsAtMountingAndroid()) {
       val propsMap = getAnimatedPropsMap(props)
       val synchronousMountProps = tagToSynchronousMountProps[reactTag] ?: mutableMapOf()
@@ -630,11 +630,11 @@ internal constructor(
     }
   }
 
-  public fun updatePropsSynchronously(reactTag: Int, props: ReadableMap): Unit {
+  public fun updatePropsSynchronously(reactTag: Int, props: ReadableMap) {
     updateProps(reactTag, props, true)
   }
 
-  public fun updateProps(reactTag: Int, props: ReadableMap): Unit {
+  public fun updateProps(reactTag: Int, props: ReadableMap) {
     updateProps(reactTag, props, false)
   }
 
@@ -690,7 +690,7 @@ internal constructor(
       surfaceId: Int,
       componentName: String,
       params: MapBuffer?,
-  ): Unit {
+  ) {
     if (isStopped) {
       return
     }
@@ -700,7 +700,7 @@ internal constructor(
   }
 
   @Deprecated("")
-  public fun receiveCommand(reactTag: Int, commandId: Int, commandArgs: ReadableArray?): Unit {
+  public fun receiveCommand(reactTag: Int, commandId: Int, commandArgs: ReadableArray?) {
     if (isStopped) {
       return
     }
@@ -729,7 +729,7 @@ internal constructor(
     @Suppress("DEPRECATION") viewManager.receiveCommand(view, commandId, commandArgs)
   }
 
-  public fun receiveCommand(reactTag: Int, commandId: String, commandArgs: ReadableArray?): Unit {
+  public fun receiveCommand(reactTag: Int, commandId: String, commandArgs: ReadableArray?) {
     if (isStopped) {
       return
     }
@@ -758,7 +758,7 @@ internal constructor(
     viewManager.receiveCommand(view, commandId, commandArgs)
   }
 
-  public fun sendAccessibilityEvent(reactTag: Int, eventType: Int): Unit {
+  public fun sendAccessibilityEvent(reactTag: Int, eventType: Int) {
     if (isStopped) {
       return
     }
@@ -788,7 +788,7 @@ internal constructor(
       height: Int,
       displayType: Int,
       layoutDirection: Int,
-  ): Unit {
+  ) {
     if (isStopped) {
       return
     }
@@ -867,7 +867,7 @@ internal constructor(
   }
 
   @UiThread
-  public fun updatePadding(reactTag: Int, left: Int, top: Int, right: Int, bottom: Int): Unit {
+  public fun updatePadding(reactTag: Int, left: Int, top: Int, right: Int, bottom: Int) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -901,7 +901,7 @@ internal constructor(
       overflowInsetTop: Int,
       overflowInsetRight: Int,
       overflowInsetBottom: Int,
-  ): Unit {
+  ) {
     if (isStopped) {
       return
     }
@@ -935,7 +935,7 @@ internal constructor(
   }
 
   @UiThread
-  public fun updateState(reactTag: Int, stateWrapper: StateWrapper?): Unit {
+  public fun updateState(reactTag: Int, stateWrapper: StateWrapper?) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -969,7 +969,7 @@ internal constructor(
 
   /** We update the event emitter from the main thread when the view is mounted. */
   @UiThread
-  internal fun updateEventEmitter(reactTag: Int, eventEmitter: EventEmitterWrapper): Unit {
+  internal fun updateEventEmitter(reactTag: Int, eventEmitter: EventEmitterWrapper) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -1001,7 +1001,7 @@ internal constructor(
       reactTag: Int,
       initialReactTag: Int,
       blockNativeResponder: Boolean,
-  ): Unit {
+  ) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -1062,7 +1062,7 @@ internal constructor(
   }
 
   @UiThread
-  public fun deleteView(reactTag: Int): Unit {
+  public fun deleteView(reactTag: Int) {
     UiThreadUtil.assertOnUiThread()
     if (isStopped) {
       return
@@ -1109,7 +1109,7 @@ internal constructor(
       props: ReadableMap,
       stateWrapper: StateWrapper?,
       isLayoutable: Boolean,
-  ): Unit {
+  ) {
     UiThreadUtil.assertOnUiThread()
 
     if (isStopped) {
@@ -1151,7 +1151,7 @@ internal constructor(
     view.background = bitmap.toDrawable(view.resources)
   }
 
-  public fun printSurfaceState(): Unit {
+  public fun printSurfaceState() {
     FLog.e(TAG, "Views created for surface $surfaceId:")
     registryLock.read {
       tagToViewState.forEachValue { viewState ->
@@ -1219,11 +1219,11 @@ internal constructor(
     }
   }
 
-  public fun markActiveTouchForTag(reactTag: Int): Unit {
+  public fun markActiveTouchForTag(reactTag: Int) {
     viewsWithActiveTouches.add(reactTag)
   }
 
-  public fun sweepActiveTouchForTag(reactTag: Int): Unit {
+  public fun sweepActiveTouchForTag(reactTag: Int) {
     viewsWithActiveTouches.remove(reactTag)
     if (viewsToDeleteAfterTouchFinishes.contains(reactTag)) {
       viewsToDeleteAfterTouchFinishes.remove(reactTag)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.kt
@@ -177,7 +177,7 @@ internal object TurboModuleInteropUtils {
 
     if (
         returnClass == Boolean::class.javaObjectType ||
-            returnClass == Integer::class.javaObjectType ||
+            returnClass == Int::class.javaObjectType ||
             returnClass == Double::class.javaObjectType ||
             returnClass == Float::class.javaObjectType ||
             returnClass == String::class.java ||

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
@@ -41,7 +41,7 @@ public class TurboModuleManager(
   private val legacyModuleProvider: ModuleProvider
 
   // Prevents the creation of new TurboModules once cleanup as been initiated.
-  private val moduleCleanupLock = Object()
+  private val moduleCleanupLock = Any()
 
   @GuardedBy("moduleCleanupLock") private var moduleCleanupStarted = false
 
@@ -234,7 +234,7 @@ public class TurboModuleManager(
       TurboModulePerfLogger.moduleCreateSetUpEnd(moduleName, moduleHolder.moduleId)
       synchronized(moduleHolder) {
         moduleHolder.endCreatingModule()
-        (moduleHolder as Object).notifyAll()
+        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") (moduleHolder as Object).notifyAll()
       }
 
       return nativeModule
@@ -245,7 +245,7 @@ public class TurboModuleManager(
       while (moduleHolder.isCreatingModule) {
         try {
           // Wait until TurboModule is created and initialized
-          (moduleHolder as Object).wait()
+          @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") (moduleHolder as Object).wait()
         } catch (e: InterruptedException) {
           wasInterrupted = true
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
@@ -31,6 +31,7 @@ internal class AppStateModule(reactContext: ReactApplicationContext) :
         else APP_STATE_BACKGROUND
   }
 
+  @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
   public override fun getTypedExportedConstants(): Map<String, Any> =
       mapOf(INITIAL_STATE to appState)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
@@ -294,7 +294,7 @@ public open class JavaTimerManager(
       val frameTimeMillis = frameTimeNanos / 1000000
       synchronized(timerGuard) {
         while (!timers.isEmpty() && timers.peek()!!.targetTime < frameTimeMillis) {
-          var timer = timers.poll()
+          val timer = timers.poll()
           if (timer == null) {
             break
           }
@@ -352,7 +352,7 @@ public open class JavaTimerManager(
       if (FRAME_DURATION_MS - frameTimeElapsed.toFloat() < IDLE_CALLBACK_FRAME_DEADLINE_MS) {
         return
       }
-      var sendIdleEvents: Boolean
+      val sendIdleEvents: Boolean
       synchronized(idleCallbackGuard) { sendIdleEvents = this@JavaTimerManager.sendIdleEvents }
       if (sendIdleEvents) {
         javaScriptTimerExecutor.callIdleCallbacks(absoluteFrameStartTime.toDouble())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/SourceCodeModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/SourceCodeModule.kt
@@ -18,7 +18,7 @@ import com.facebook.react.module.annotations.ReactModule
 @ReactModule(name = NativeSourceCodeSpec.NAME)
 public class SourceCodeModule(reactContext: ReactApplicationContext) :
     NativeSourceCodeSpec(reactContext) {
-  protected override fun getTypedExportedConstants(): Map<String, Any> = mapOf(
+  override fun getTypedExportedConstants(): Map<String, Any> = mapOf(
       "scriptURL" to
           Assertions.assertNotNull<String>(
               reactApplicationContext.getSourceURL(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -102,6 +102,7 @@ internal class DeviceInfoModule(reactContext: ReactApplicationContext) :
         putDouble("densityDpi", displayMetrics.densityDpi.toDouble())
       }
 
+  @Suppress("REDUNDANT_VISIBILITY_MODIFIER")
   public override fun getTypedExportedConstants(): Map<String, Any> {
     val displayMetrics = getDisplayMetricsWritableMap()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -65,30 +65,30 @@ public class NetworkingModule(
    */
   internal interface UriHandler {
     /** Returns if the handler should be used for an URI. */
-    public fun supports(uri: Uri, responseType: String): Boolean
+    fun supports(uri: Uri, responseType: String): Boolean
 
     /**
      * Fetch the URI and return a tuple containing the JS body payload and the raw response body.
      */
-    @Throws(IOException::class) public fun fetch(uri: Uri): Pair<WritableMap, ByteArray>
+    @Throws(IOException::class) fun fetch(uri: Uri): Pair<WritableMap, ByteArray>
   }
 
   /** Allows adding custom handling to build the [RequestBody] from the JS body payload. */
   internal interface RequestBodyHandler {
     /** Returns if the handler should be used for a JS body payload. */
-    public fun supports(map: ReadableMap): Boolean
+    fun supports(map: ReadableMap): Boolean
 
     /** Returns the [RequestBody] for the JS body payload. */
-    public fun toRequestBody(map: ReadableMap, contentType: String?): RequestBody?
+    fun toRequestBody(map: ReadableMap, contentType: String?): RequestBody?
   }
 
   /** Allows adding custom handling to build the JS body payload from the [ResponseBody]. */
   internal interface ResponseHandler {
     /** Returns if the handler should be used for a response type. */
-    public fun supports(responseType: String): Boolean
+    fun supports(responseType: String): Boolean
 
     /** Returns the JS body payload for the [ResponseBody]. */
-    @Throws(IOException::class) public fun toResponseData(data: ByteArray): WritableMap
+    @Throws(IOException::class) fun toResponseData(data: ByteArray): WritableMap
   }
 
   private val client: OkHttpClient

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
@@ -42,8 +42,8 @@ public class AndroidInfoModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getTypedExportedConstants(): Map<String, Any?> {
-    val constants = mutableMapOf<String, Any?>()
+  override fun getTypedExportedConstants(): Map<String, Any> {
+    val constants = mutableMapOf<String, Any>()
     constants["Version"] = Build.VERSION.SDK_INT
     constants["Release"] = Build.VERSION.RELEASE
     constants["Serial"] = Build.SERIAL

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
@@ -20,7 +20,7 @@ import com.facebook.react.module.annotations.ReactModule
 internal class ToastModule(reactContext: ReactApplicationContext) :
     NativeToastAndroidSpec(reactContext) {
 
-  override fun getTypedExportedConstants(): Map<String, Any> = mutableMapOf(
+  override fun getTypedExportedConstants(): Map<String, Any> = mapOf(
       DURATION_SHORT_KEY to Toast.LENGTH_SHORT,
       DURATION_LONG_KEY to Toast.LENGTH_LONG,
       GRAVITY_TOP_KEY to (Gravity.TOP or Gravity.CENTER_HORIZONTAL),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
@@ -204,7 +204,7 @@ internal constructor(
 
   internal companion object {
     @JvmStatic
-    public fun createWithView(
+    fun createWithView(
         context: Context,
         moduleName: String,
         initialProps: Bundle?,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
  * @param <TResult> The type of the result of the task.
  */
 public class Task<TResult> : TaskInterface<TResult> {
-  private val lock = Object()
+  @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN") private val lock = Object()
   private var complete = false
   private var cancelled = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -63,7 +63,7 @@ public object BackgroundStyleApplicator {
    * @param color The color to set, or null to remove the background color
    */
   @JvmStatic
-  public fun setBackgroundColor(view: View, @ColorInt color: Int?): Unit {
+  public fun setBackgroundColor(view: View, @ColorInt color: Int?) {
     // No color to set, and no color already set
     if (
         (color == null || color == Color.TRANSPARENT) &&
@@ -85,12 +85,12 @@ public object BackgroundStyleApplicator {
   public fun setBackgroundImage(
       view: View,
       backgroundImageLayers: List<BackgroundImageLayer>?,
-  ): Unit {
+  ) {
     ensureBackgroundImageDrawable(view).backgroundImageLayers = backgroundImageLayers
   }
 
   @JvmStatic
-  internal fun setBackgroundSize(view: View, backgroundSizes: List<BackgroundSize>?): Unit {
+  internal fun setBackgroundSize(view: View, backgroundSizes: List<BackgroundSize>?) {
     ensureBackgroundImageDrawable(view).backgroundSize = backgroundSizes
   }
 
@@ -98,12 +98,12 @@ public object BackgroundStyleApplicator {
   internal fun setBackgroundPosition(
       view: View,
       backgroundPositions: List<BackgroundPosition>?,
-  ): Unit {
+  ) {
     ensureBackgroundImageDrawable(view).backgroundPosition = backgroundPositions
   }
 
   @JvmStatic
-  internal fun setBackgroundRepeat(view: View, backgroundRepeats: List<BackgroundRepeat>?): Unit {
+  internal fun setBackgroundRepeat(view: View, backgroundRepeats: List<BackgroundRepeat>?) {
     ensureBackgroundImageDrawable(view).backgroundRepeat = backgroundRepeats
   }
 
@@ -127,7 +127,7 @@ public object BackgroundStyleApplicator {
    * @param width The border width in DIPs, or null to remove
    */
   @JvmStatic
-  public fun setBorderWidth(view: View, edge: LogicalEdge, width: Float?): Unit {
+  public fun setBorderWidth(view: View, edge: LogicalEdge, width: Float?) {
     val composite = ensureCompositeBackgroundDrawable(view)
     composite.borderInsets = composite.borderInsets ?: BorderInsets()
     composite.borderInsets?.setBorderWidth(edge, width)
@@ -176,7 +176,7 @@ public object BackgroundStyleApplicator {
    * @param color The border color, or null to remove
    */
   @JvmStatic
-  public fun setBorderColor(view: View, edge: LogicalEdge, @ColorInt color: Int?): Unit {
+  public fun setBorderColor(view: View, edge: LogicalEdge, @ColorInt color: Int?) {
     ensureBorderDrawable(view).setBorderColor(edge, color)
   }
 
@@ -205,7 +205,7 @@ public object BackgroundStyleApplicator {
       view: View,
       corner: BorderRadiusProp,
       radius: LengthPercentage?,
-  ): Unit {
+  ) {
     val compositeBackgroundDrawable = ensureCompositeBackgroundDrawable(view)
     compositeBackgroundDrawable.borderRadius =
         compositeBackgroundDrawable.borderRadius ?: BorderRadiusStyle()
@@ -305,7 +305,7 @@ public object BackgroundStyleApplicator {
    * @param outlineOffset The outline offset in DIPs
    */
   @JvmStatic
-  public fun setOutlineOffset(view: View, outlineOffset: Float): Unit {
+  public fun setOutlineOffset(view: View, outlineOffset: Float) {
     val outline = ensureOutlineDrawable(view)
     outline.outlineOffset = outlineOffset.dpToPx()
   }
@@ -325,7 +325,7 @@ public object BackgroundStyleApplicator {
    * @param outlineStyle The outline style (solid, dashed, dotted), or null to remove
    */
   @JvmStatic
-  public fun setOutlineStyle(view: View, outlineStyle: OutlineStyle?): Unit {
+  public fun setOutlineStyle(view: View, outlineStyle: OutlineStyle?) {
     val outline = ensureOutlineDrawable(view)
     if (outlineStyle != null) {
       outline.outlineStyle = outlineStyle
@@ -368,8 +368,8 @@ public object BackgroundStyleApplicator {
    */
   @JvmStatic
   public fun setBoxShadow(view: View, shadows: List<BoxShadow>) {
-    var innerShadows = mutableListOf<InsetBoxShadowDrawable>()
-    var outerShadows = mutableListOf<OutsetBoxShadowDrawable>()
+    val innerShadows = mutableListOf<InsetBoxShadowDrawable>()
+    val outerShadows = mutableListOf<OutsetBoxShadowDrawable>()
 
     val compositeBackgroundDrawable = ensureCompositeBackgroundDrawable(view)
     val borderInsets = compositeBackgroundDrawable.borderInsets

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -218,7 +218,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       ReadableArray transformOrigin = (ReadableArray) v.getTag(R.id.transform_origin);
       ReadableArray transforms = (ReadableArray) v.getTag(R.id.transform);
       if (transforms != null || transformOrigin != null) {
-        setTransformProperty((T) v, transforms, transformOrigin);
+        @SuppressWarnings("unchecked")
+        T typedView = (T) v;
+        setTransformProperty(typedView, transforms, transformOrigin);
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
@@ -399,7 +399,7 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
       return TOP_ACCESSIBILITY_ACTION_EVENT
     }
 
-    public override fun getEventData(): WritableMap? {
+    override fun getEventData(): WritableMap? {
       return accessibilityEventData
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -102,6 +102,7 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   private Integer mWidthMeasureSpec;
   private Integer mHeightMeasureSpec;
 
+  @SuppressWarnings("this-escape")
   public ReactShadowNodeImpl() {
     mDefaultPadding = new Spacing(0f);
     if (!isVirtual()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReferenceStateWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReferenceStateWrapper.kt
@@ -9,5 +9,5 @@ package com.facebook.react.uimanager
 
 internal interface ReferenceStateWrapper : StateWrapper {
   /** Returns state data backed by JNI reference. The underlying object should not be modified. */
-  public val stateDataReference: Any?
+  val stateDataReference: Any?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TransformHelper.kt
@@ -26,7 +26,7 @@ public object TransformHelper {
       }
 
   internal fun convertToRadians(transformMap: ReadableMap, key: String): Double {
-    var value: Double
+    val value: Double
     var inRadians = true
     if (transformMap.getType(key) == ReadableType.String) {
       var stringValue = transformMap.getString(key)!!

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
@@ -24,8 +24,8 @@ import java.util.Objects
     level = DeprecationLevel.WARNING,
 )
 internal class ViewAtIndex(
-    @Suppress("NoHungarianNotation") @JvmField public val mTag: Int,
-    @Suppress("NoHungarianNotation") @JvmField public val mIndex: Int,
+    @Suppress("NoHungarianNotation") @JvmField val mTag: Int,
+    @Suppress("NoHungarianNotation") @JvmField val mIndex: Int,
 ) {
 
   override fun equals(other: Any?): Boolean {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -41,7 +41,7 @@ import java.util.Stack;
  * and size for the corresponding native view.
  */
 @ReactPropertyHolder
-public abstract class ViewManager<T extends View, C extends ReactShadowNode>
+public abstract class ViewManager<T extends View, C extends ReactShadowNode<?>>
     extends BaseJavaModule {
 
   private static final String TAG = "ViewManager";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagersPropertyCache.kt
@@ -413,9 +413,9 @@ internal object ViewManagersPropertyCache {
         Double::class.javaPrimitiveType ->
             DoublePropSetter(annotation, method, annotation.defaultDouble)
         String::class.java -> StringPropSetter(annotation, method)
-        java.lang.Boolean::class.java -> BoxedBooleanPropSetter(annotation, method)
-        java.lang.Float::class.java -> BoxedFloatPropSetter(annotation, method)
-        java.lang.Integer::class.java ->
+        Boolean::class.javaObjectType -> BoxedBooleanPropSetter(annotation, method)
+        Float::class.javaObjectType -> BoxedFloatPropSetter(annotation, method)
+        Int::class.javaObjectType ->
             if ("Color" == annotation.customType) {
               BoxedColorPropSetter(annotation, method)
             } else {
@@ -459,7 +459,7 @@ internal object ViewManagersPropertyCache {
           for (i in names.indices) {
             props[names[i]] = DoublePropSetter(annotation, method, i, annotation.defaultDouble)
           }
-      java.lang.Integer::class.java ->
+      Int::class.javaObjectType ->
           for (i in names.indices) {
             props[names[i]] =
                 if ("Color" == annotation.customType) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/BlurEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/BlurEvent.kt
@@ -17,7 +17,7 @@ internal class BlurEvent(surfaceId: Int, viewId: Int) : Event<BlurEvent>(surface
 
   override fun canCoalesce(): Boolean = false
 
-  protected override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply { putInt("target", viewTag) }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ContentSizeChangeEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ContentSizeChangeEvent.kt
@@ -29,7 +29,7 @@ public class ContentSizeChangeEvent(
 
   public override fun getEventName(): String = "topContentSizeChange"
 
-  protected override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     val res = Arguments.createMap()
     res.putDouble("width", toDIPFromPixel(width.toFloat()).toDouble())
     res.putDouble("height", toDIPFromPixel(height.toFloat()).toDouble())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FocusEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FocusEvent.kt
@@ -17,7 +17,7 @@ internal class FocusEvent(surfaceId: Int, viewId: Int) : Event<FocusEvent>(surfa
 
   override fun canCoalesce(): Boolean = false
 
-  protected override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply { putInt("target", viewTag) }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
@@ -18,7 +18,7 @@ import com.facebook.systrace.Systrace
  * [android.view.MotionEvent].
  */
 internal object TouchesHelper {
-  @JvmField @Deprecated("Not used in New Architecture") public val TARGET_KEY: String = "target"
+  @JvmField @Deprecated("Not used in New Architecture") val TARGET_KEY: String = "target"
 
   private const val TARGET_SURFACE_KEY = "targetSurface"
   private const val CHANGED_TOUCHES_KEY = "changedTouches"
@@ -98,7 +98,7 @@ internal object TouchesHelper {
       val type = event.getTouchEventType()
       val motionEvent = event.getMotionEvent()
       var touches = createPointersArray(event)
-      var changedTouches: Array<WritableMap?>? = null
+      val changedTouches: Array<WritableMap?>?
 
       when (type) {
         TouchEventType.START -> {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundPosition.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundPosition.kt
@@ -23,12 +23,12 @@ import com.facebook.react.uimanager.LengthPercentage
  * @property bottom Offset from the bottom edge, or null if not specified
  */
 internal class BackgroundPosition(
-    public val top: LengthPercentage?,
-    public val left: LengthPercentage?,
-    public val right: LengthPercentage?,
-    public val bottom: LengthPercentage?,
+    val top: LengthPercentage?,
+    val left: LengthPercentage?,
+    val right: LengthPercentage?,
+    val bottom: LengthPercentage?,
 ) {
-  public companion object {
+  companion object {
     /**
      * Parses a ReadableMap into a BackgroundPosition.
      *
@@ -38,7 +38,7 @@ internal class BackgroundPosition(
      * @param backgroundPositionMap The map containing position values
      * @return A BackgroundPosition instance, or null if the map is null
      */
-    public fun parse(backgroundPositionMap: ReadableMap?): BackgroundPosition? {
+    fun parse(backgroundPositionMap: ReadableMap?): BackgroundPosition? {
       if (backgroundPositionMap == null) return null
 
       val top =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundRepeat.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundRepeat.kt
@@ -36,10 +36,10 @@ internal enum class BackgroundRepeatKeyword {
  * @property y The repeat behavior for the vertical axis
  */
 internal class BackgroundRepeat(
-    public val x: BackgroundRepeatKeyword,
-    public val y: BackgroundRepeatKeyword,
+    val x: BackgroundRepeatKeyword,
+    val y: BackgroundRepeatKeyword,
 ) {
-  public companion object {
+  companion object {
     /**
      * Parses a ReadableMap into a BackgroundRepeat.
      *
@@ -49,7 +49,7 @@ internal class BackgroundRepeat(
      * @param backgroundRepeatMap The map containing repeat values
      * @return A BackgroundRepeat instance, or null if the map is null
      */
-    public fun parse(backgroundRepeatMap: ReadableMap?): BackgroundRepeat? {
+    fun parse(backgroundRepeatMap: ReadableMap?): BackgroundRepeat? {
       if (backgroundRepeatMap == null) return null
 
       val x = parseRepeatStyle(backgroundRepeatMap, "x") ?: BackgroundRepeatKeyword.Repeat

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundSize.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BackgroundSize.kt
@@ -23,24 +23,24 @@ import com.facebook.react.uimanager.LengthPercentage
  * @property y The vertical size component, or null for "auto"
  */
 internal class BackgroundSizeLengthPercentage(
-    public val x: LengthPercentage?,
-    public val y: LengthPercentage?,
+    val x: LengthPercentage?,
+    val y: LengthPercentage?,
 ) {
   /**
    * Checks if the horizontal dimension is set to auto.
    *
    * @return true if x is null (auto), false otherwise
    */
-  public fun isXAuto(): Boolean = x == null
+  fun isXAuto(): Boolean = x == null
 
   /**
    * Checks if the vertical dimension is set to auto.
    *
    * @return true if y is null (auto), false otherwise
    */
-  public fun isYAuto(): Boolean = y == null
+  fun isYAuto(): Boolean = y == null
 
-  public companion object {
+  companion object {
     /**
      * Parses a ReadableMap into a BackgroundSizeLengthPercentage.
      *
@@ -50,7 +50,7 @@ internal class BackgroundSizeLengthPercentage(
      * @param backgroundSizeMap The map containing x and y size values
      * @return A BackgroundSizeLengthPercentage instance, or null if the map is null
      */
-    public fun parse(backgroundSizeMap: ReadableMap?): BackgroundSizeLengthPercentage? {
+    fun parse(backgroundSizeMap: ReadableMap?): BackgroundSizeLengthPercentage? {
       if (backgroundSizeMap == null) return null
 
       val x =
@@ -121,10 +121,10 @@ internal sealed class BackgroundSize {
    *
    * @property lengthPercentage The parsed size values for x and y dimensions
    */
-  public class LengthPercentageAuto(public val lengthPercentage: BackgroundSizeLengthPercentage) :
+  class LengthPercentageAuto(val lengthPercentage: BackgroundSizeLengthPercentage) :
       BackgroundSize()
 
-  public companion object {
+  companion object {
     /**
      * Parses a Dynamic value into a BackgroundSize.
      *
@@ -133,7 +133,7 @@ internal sealed class BackgroundSize {
      * @param backgroundSizeValue The dynamic value to parse
      * @return A BackgroundSize instance, or null if parsing fails
      */
-    public fun parse(backgroundSizeValue: Dynamic?): BackgroundSize? {
+    fun parse(backgroundSizeValue: Dynamic?): BackgroundSize? {
       if (backgroundSizeValue == null) return null
 
       return when (backgroundSizeValue.type) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -30,7 +30,7 @@ internal class DebuggingOverlayManager :
 
   override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
-  override fun highlightTraceUpdates(view: DebuggingOverlay, updates: ReadableArray): Unit {
+  override fun highlightTraceUpdates(view: DebuggingOverlay, updates: ReadableArray) {
     val formattedTraceUpdates = mutableListOf<TraceUpdate>()
 
     var successfullyParsedPayload = true
@@ -83,7 +83,7 @@ internal class DebuggingOverlayManager :
     }
   }
 
-  override fun highlightElements(view: DebuggingOverlay, elements: ReadableArray): Unit {
+  override fun highlightElements(view: DebuggingOverlay, elements: ReadableArray) {
     val elementsRectangles = mutableListOf<RectF>()
 
     var successfullyParsedPayload = true
@@ -120,7 +120,7 @@ internal class DebuggingOverlayManager :
     }
   }
 
-  override fun clearElementsHighlights(view: DebuggingOverlay): Unit {
+  override fun clearElementsHighlights(view: DebuggingOverlay) {
     view.clearElementsHighlights()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -164,7 +164,7 @@ public class ReactDrawerLayoutManager :
       view: ReactDrawerLayout,
       commandId: Int,
       args: ReadableArray?,
-  ): Unit {
+  ) {
     when (commandId) {
       OPEN_DRAWER -> view.openDrawer()
       CLOSE_DRAWER -> view.closeDrawer()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
@@ -90,7 +90,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     HasChildPressedStateDelay {
 
   private companion object {
-    private val DEBUG_MODE = false && ReactBuildConfig.DEBUG
+    private val DEBUG_MODE = ReactBuildConfig.DEBUG && false
     private val TAG = ReactHorizontalScrollView::class.java.simpleName
 
     private const val NO_SCROLL_POSITION = Int.MIN_VALUE

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<497c1f334f6b3325e032e09947f6fce4>>
+ * @generated SignedSource<<2f9a2ea0c223b08d9d1ea4517fd9671b>>
  */
 
 /**
@@ -112,19 +112,19 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
   override var lastScrollDispatchTime: Long = 0L
   override var hasChildPressedStateDelay: Boolean? = null
 
-  public open var pointerEvents: PointerEvents = PointerEvents.AUTO
+  open var pointerEvents: PointerEvents = PointerEvents.AUTO
     set(value) {
       field = value
       ImportantForInteractionHelper.setImportantForInteraction(this, value, _overflow)
     }
 
-  public open var fadingEdgeLengthStart: Int = 0
+  open var fadingEdgeLengthStart: Int = 0
     set(value) {
       field = value
       invalidate()
     }
 
-  public open var fadingEdgeLengthEnd: Int = 0
+  open var fadingEdgeLengthEnd: Int = 0
     set(value) {
       field = value
       invalidate()
@@ -322,58 +322,58 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     }
   }
 
-  public open fun setDisableIntervalMomentum(disableIntervalMomentum: Boolean) {
+  open fun setDisableIntervalMomentum(disableIntervalMomentum: Boolean) {
     this.disableIntervalMomentum = disableIntervalMomentum
   }
 
-  public open fun setSendMomentumEvents(sendMomentumEvents: Boolean) {
+  open fun setSendMomentumEvents(sendMomentumEvents: Boolean) {
     this.sendMomentumEvents = sendMomentumEvents
   }
 
-  public open fun setScrollPerfTag(scrollPerfTag: String?) {
+  open fun setScrollPerfTag(scrollPerfTag: String?) {
     this.scrollPerfTag = scrollPerfTag
   }
 
-  public open fun setPagingEnabled(pagingEnabled: Boolean) {
+  open fun setPagingEnabled(pagingEnabled: Boolean) {
     this.pagingEnabled = pagingEnabled
   }
 
-  public open fun setScrollsChildToFocus(scrollsChildToFocus: Boolean) {
+  open fun setScrollsChildToFocus(scrollsChildToFocus: Boolean) {
     this.scrollsChildToFocus = scrollsChildToFocus
   }
 
-  public open fun setDecelerationRate(decelerationRate: Float) {
+  open fun setDecelerationRate(decelerationRate: Float) {
     reactScrollViewScrollState.decelerationRate = decelerationRate
     scroller?.setFriction(1.0f - decelerationRate)
   }
 
-  public open fun abortAnimation() {
+  open fun abortAnimation() {
     if (scroller != null && !scroller.isFinished) {
       scroller.abortAnimation()
     }
   }
 
-  public open fun setSnapInterval(snapInterval: Int) {
+  open fun setSnapInterval(snapInterval: Int) {
     this.snapInterval = snapInterval
   }
 
-  public open fun setSnapOffsets(snapOffsets: List<Int>?) {
+  open fun setSnapOffsets(snapOffsets: List<Int>?) {
     this.snapOffsets = snapOffsets
   }
 
-  public open fun setSnapToStart(snapToStart: Boolean) {
+  open fun setSnapToStart(snapToStart: Boolean) {
     this.snapToStart = snapToStart
   }
 
-  public open fun setSnapToEnd(snapToEnd: Boolean) {
+  open fun setSnapToEnd(snapToEnd: Boolean) {
     this.snapToEnd = snapToEnd
   }
 
-  public open fun setSnapToAlignment(snapToAlignment: Int) {
+  open fun setSnapToAlignment(snapToAlignment: Int) {
     this.snapToAlignment = snapToAlignment
   }
 
-  public open fun flashScrollIndicators() {
+  open fun flashScrollIndicators() {
     awakenScrollBars()
   }
 
@@ -387,7 +387,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     return fadingEdgeLengthEnd / max
   }
 
-  public open fun setOverflow(overflow: String?) {
+  open fun setOverflow(overflow: String?) {
     _overflow =
         if (overflow == null) {
           Overflow.SCROLL
@@ -774,7 +774,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     super.draw(canvas)
   }
 
-  public override fun onDraw(canvas: Canvas) {
+  override fun onDraw(canvas: Canvas) {
     if (_overflow != Overflow.VISIBLE) {
       BackgroundStyleApplicator.clipToPaddingBox(this, canvas)
     }
@@ -1073,7 +1073,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
 
   private fun getSnapInterval(): Int = if (snapInterval != 0) snapInterval else height
 
-  public open fun setEndFillColor(color: Int) {
+  open fun setEndFillColor(color: Int) {
     if (color != endFillColor) {
       endFillColor = color
       endBackground = ColorDrawable(endFillColor)
@@ -1114,7 +1114,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     contentView = null
   }
 
-  public open fun setContentOffset(value: ReadableMap?) {
+  open fun setContentOffset(value: ReadableMap?) {
     if (currentContentOffset == null || currentContentOffset != value) {
       currentContentOffset = value
       if (value != null) {
@@ -1226,7 +1226,7 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     BackgroundStyleApplicator.setBackgroundColor(this, color)
   }
 
-  public open fun setBorderWidth(position: Int, width: Float) {
+  open fun setBorderWidth(position: Int, width: Float) {
     BackgroundStyleApplicator.setBorderWidth(
         this,
         LogicalEdge.entries[position],
@@ -1234,22 +1234,22 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     )
   }
 
-  public open fun setBorderColor(position: Int, color: Int?) {
+  open fun setBorderColor(position: Int, color: Int?) {
     BackgroundStyleApplicator.setBorderColor(this, LogicalEdge.entries[position], color)
   }
 
-  public open fun setBorderRadius(borderRadius: Float) {
+  open fun setBorderRadius(borderRadius: Float) {
     setBorderRadius(borderRadius, BorderRadiusProp.BORDER_RADIUS.ordinal)
   }
 
-  public open fun setBorderRadius(borderRadius: Float, position: Int) {
+  open fun setBorderRadius(borderRadius: Float, position: Int) {
     val radius =
         if (borderRadius.isNaN()) null
         else LengthPercentage(PixelUtil.toDIPFromPixel(borderRadius), LengthPercentageType.POINT)
     BackgroundStyleApplicator.setBorderRadius(this, BorderRadiusProp.entries[position], radius)
   }
 
-  public open fun setBorderStyle(style: String?) {
+  open fun setBorderStyle(style: String?) {
     BackgroundStyleApplicator.setBorderStyle(
         this,
         if (style == null) null else BorderStyle.fromString(style),
@@ -1269,11 +1269,11 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
    * that you are **not** overriding the NestedScrollView content view to pass in a `translateY` style.
    * `translateY` must never be set from ReactJS while using this feature!
    */
-  public open fun setScrollAwayPaddingEnabledUnstable(topPadding: Int, bottomPadding: Int) {
+  open fun setScrollAwayPaddingEnabledUnstable(topPadding: Int, bottomPadding: Int) {
     setScrollAwayPaddingEnabledUnstable(topPadding, bottomPadding, true)
   }
 
-  public open fun setScrollAwayPaddingEnabledUnstable(
+  open fun setScrollAwayPaddingEnabledUnstable(
       topPadding: Int,
       bottomPadding: Int,
       updateState: Boolean,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollViewManager.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1ea0f64fa8acd99b50c7ef54da014b3e>>
+ * @generated SignedSource<<cc2b79daa48993203e35cb663b733ccc>>
  */
 
 /**
@@ -85,11 +85,11 @@ constructor(private val fpsListener: FpsListener? = null) :
 
   override fun getName(): String = REACT_CLASS
 
-  public override fun createViewInstance(context: ThemedReactContext): ReactNestedScrollView =
+  override fun createViewInstance(context: ThemedReactContext): ReactNestedScrollView =
       ReactNestedScrollView(context, fpsListener)
 
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
-  public fun setScrollEnabled(view: ReactNestedScrollView, value: Boolean) {
+  fun setScrollEnabled(view: ReactNestedScrollView, value: Boolean) {
     view.scrollEnabled = value
 
     // Set focusable to match whether scroll is enabled. This improves keyboarding
@@ -98,34 +98,34 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = "showsVerticalScrollIndicator", defaultBoolean = true)
-  public fun setShowsVerticalScrollIndicator(view: ReactNestedScrollView, value: Boolean) {
+  fun setShowsVerticalScrollIndicator(view: ReactNestedScrollView, value: Boolean) {
     view.isVerticalScrollBarEnabled = value
   }
 
   @ReactProp(name = "decelerationRate")
-  public fun setDecelerationRate(view: ReactNestedScrollView, decelerationRate: Float) {
+  fun setDecelerationRate(view: ReactNestedScrollView, decelerationRate: Float) {
     view.setDecelerationRate(decelerationRate)
   }
 
   @ReactProp(name = "disableIntervalMomentum")
-  public fun setDisableIntervalMomentum(view: ReactNestedScrollView, disableIntervalMomentum: Boolean) {
+  fun setDisableIntervalMomentum(view: ReactNestedScrollView, disableIntervalMomentum: Boolean) {
     view.setDisableIntervalMomentum(disableIntervalMomentum)
   }
 
   @ReactProp(name = "scrollsChildToFocus", defaultBoolean = true)
-  public fun setScrollsChildToFocus(view: ReactNestedScrollView, scrollsChildToFocus: Boolean) {
+  fun setScrollsChildToFocus(view: ReactNestedScrollView, scrollsChildToFocus: Boolean) {
     view.setScrollsChildToFocus(scrollsChildToFocus)
   }
 
   @ReactProp(name = "snapToInterval")
-  public fun setSnapToInterval(view: ReactNestedScrollView, snapToInterval: Float) {
+  fun setSnapToInterval(view: ReactNestedScrollView, snapToInterval: Float) {
     // snapToInterval needs to be exposed as a float because of the Javascript interface.
     val density = getDisplayMetricDensity()
     view.setSnapInterval((snapToInterval * density).toInt())
   }
 
   @ReactProp(name = "snapToOffsets")
-  public fun setSnapToOffsets(view: ReactNestedScrollView, snapToOffsets: ReadableArray?) {
+  fun setSnapToOffsets(view: ReactNestedScrollView, snapToOffsets: ReadableArray?) {
     if (snapToOffsets == null || snapToOffsets.size() == 0) {
       view.setSnapOffsets(null)
       return
@@ -140,22 +140,22 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = "snapToAlignment")
-  public fun setSnapToAlignment(view: ReactNestedScrollView, alignment: String?) {
+  fun setSnapToAlignment(view: ReactNestedScrollView, alignment: String?) {
     view.setSnapToAlignment(parseSnapToAlignment(alignment))
   }
 
   @ReactProp(name = "snapToStart")
-  public fun setSnapToStart(view: ReactNestedScrollView, snapToStart: Boolean) {
+  fun setSnapToStart(view: ReactNestedScrollView, snapToStart: Boolean) {
     view.setSnapToStart(snapToStart)
   }
 
   @ReactProp(name = "snapToEnd")
-  public fun setSnapToEnd(view: ReactNestedScrollView, snapToEnd: Boolean) {
+  fun setSnapToEnd(view: ReactNestedScrollView, snapToEnd: Boolean) {
     view.setSnapToEnd(snapToEnd)
   }
 
   @ReactProp(name = ReactClippingViewGroupHelper.PROP_REMOVE_CLIPPED_SUBVIEWS)
-  public fun setRemoveClippedSubviews(view: ReactNestedScrollView, removeClippedSubviews: Boolean) {
+  fun setRemoveClippedSubviews(view: ReactNestedScrollView, removeClippedSubviews: Boolean) {
     view.removeClippedSubviews = removeClippedSubviews
   }
 
@@ -168,7 +168,7 @@ constructor(private val fpsListener: FpsListener? = null) :
    * @param sendMomentumEvents
    */
   @ReactProp(name = "sendMomentumEvents")
-  public fun setSendMomentumEvents(view: ReactNestedScrollView, sendMomentumEvents: Boolean) {
+  fun setSendMomentumEvents(view: ReactNestedScrollView, sendMomentumEvents: Boolean) {
     view.setSendMomentumEvents(sendMomentumEvents)
   }
 
@@ -180,12 +180,12 @@ constructor(private val fpsListener: FpsListener? = null) :
    * @param scrollPerfTag
    */
   @ReactProp(name = "scrollPerfTag")
-  public fun setScrollPerfTag(view: ReactNestedScrollView, scrollPerfTag: String?) {
+  fun setScrollPerfTag(view: ReactNestedScrollView, scrollPerfTag: String?) {
     view.setScrollPerfTag(scrollPerfTag)
   }
 
   @ReactProp(name = "pagingEnabled")
-  public fun setPagingEnabled(view: ReactNestedScrollView, pagingEnabled: Boolean) {
+  fun setPagingEnabled(view: ReactNestedScrollView, pagingEnabled: Boolean) {
     view.setPagingEnabled(pagingEnabled)
   }
 
@@ -197,18 +197,18 @@ constructor(private val fpsListener: FpsListener? = null) :
    * @param color
    */
   @ReactProp(name = "endFillColor", defaultInt = Color.TRANSPARENT, customType = "Color")
-  public fun setBottomFillColor(view: ReactNestedScrollView, color: Int) {
+  fun setBottomFillColor(view: ReactNestedScrollView, color: Int) {
     view.setEndFillColor(color)
   }
 
   /** Controls overScroll behaviour */
   @ReactProp(name = "overScrollMode")
-  public open fun setOverScrollMode(view: ReactNestedScrollView, value: String?) {
+  open fun setOverScrollMode(view: ReactNestedScrollView, value: String?) {
     view.overScrollMode = parseOverScrollMode(value)
   }
 
   @ReactProp(name = "nestedScrollEnabled")
-  public fun setNestedScrollEnabled(view: ReactNestedScrollView?, value: Boolean) {
+  fun setNestedScrollEnabled(view: ReactNestedScrollView?, value: Boolean) {
     if (view != null) {
       ViewCompat.setNestedScrollingEnabled(view, value)
     }
@@ -257,7 +257,7 @@ constructor(private val fpsListener: FpsListener? = null) :
           ],
       defaultFloat = Float.NaN,
   )
-  public fun setBorderRadius(view: ReactNestedScrollView?, index: Int, borderRadius: Float) {
+  fun setBorderRadius(view: ReactNestedScrollView?, index: Int, borderRadius: Float) {
     if (view != null) {
       val radius =
           if (borderRadius.isNaN()) null
@@ -267,7 +267,7 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = "borderStyle")
-  public fun setBorderStyle(view: ReactNestedScrollView?, borderStyle: String?) {
+  fun setBorderStyle(view: ReactNestedScrollView?, borderStyle: String?) {
     if (view != null) {
       val parsedBorderStyle = if (borderStyle == null) null else fromString(borderStyle)
       setBorderStyle(view, parsedBorderStyle)
@@ -285,7 +285,7 @@ constructor(private val fpsListener: FpsListener? = null) :
           ],
       defaultFloat = Float.NaN,
   )
-  public fun setBorderWidth(view: ReactNestedScrollView?, index: Int, width: Float) {
+  fun setBorderWidth(view: ReactNestedScrollView?, index: Int, width: Float) {
     if (view != null) {
       setBorderWidth(view, LogicalEdge.entries[index], width)
     }
@@ -303,14 +303,14 @@ constructor(private val fpsListener: FpsListener? = null) :
       customType = "Color",
   )
   @Suppress("UNUSED_PARAMETER")
-  public fun setBorderColor(view: ReactNestedScrollView?, index: Int, color: Int?) {
+  fun setBorderColor(view: ReactNestedScrollView?, index: Int, color: Int?) {
     if (view != null) {
       setBorderColor(view, LogicalEdge.ALL, color)
     }
   }
 
   @ReactProp(name = "overflow")
-  public fun setOverflow(view: ReactNestedScrollView, overflow: String?) {
+  fun setOverflow(view: ReactNestedScrollView, overflow: String?) {
     view.setOverflow(overflow)
   }
 
@@ -335,12 +335,12 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = "persistentScrollbar")
-  public fun setPersistentScrollbar(view: ReactNestedScrollView, value: Boolean) {
+  fun setPersistentScrollbar(view: ReactNestedScrollView, value: Boolean) {
     view.isScrollbarFadingEnabled = !value
   }
 
   @ReactProp(name = "fadingEdgeLength")
-  public fun setFadingEdgeLength(view: ReactNestedScrollView, value: Dynamic) {
+  fun setFadingEdgeLength(view: ReactNestedScrollView, value: Dynamic) {
     when (value.type) {
       ReadableType.Number -> {
         view.fadingEdgeLengthStart = value.asInt()
@@ -376,12 +376,12 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = "contentOffset", customType = "Point")
-  public fun setContentOffset(view: ReactNestedScrollView, value: ReadableMap?) {
+  fun setContentOffset(view: ReactNestedScrollView, value: ReadableMap?) {
     view.setContentOffset(value)
   }
 
   @ReactProp(name = "maintainVisibleContentPosition")
-  public fun setMaintainVisibleContentPosition(view: ReactNestedScrollView, value: ReadableMap?) {
+  fun setMaintainVisibleContentPosition(view: ReactNestedScrollView, value: ReadableMap?) {
     if (value != null) {
       view.setMaintainVisibleContentPosition(
           MaintainVisibleScrollPositionHelper.Config.fromReadableMap(value),
@@ -414,23 +414,23 @@ constructor(private val fpsListener: FpsListener? = null) :
   }
 
   @ReactProp(name = ViewProps.POINTER_EVENTS)
-  public fun setPointerEvents(view: ReactNestedScrollView, pointerEventsStr: String?) {
+  fun setPointerEvents(view: ReactNestedScrollView, pointerEventsStr: String?) {
     view.pointerEvents = parsePointerEvents(pointerEventsStr)
   }
 
   @ReactProp(name = "scrollEventThrottle")
-  public fun setScrollEventThrottle(view: ReactNestedScrollView, scrollEventThrottle: Int) {
+  fun setScrollEventThrottle(view: ReactNestedScrollView, scrollEventThrottle: Int) {
     view.scrollEventThrottle = scrollEventThrottle
   }
 
   @ReactProp(name = "horizontal")
   @Suppress("UNUSED_PARAMETER")
-  public fun setHorizontal(view: ReactNestedScrollView?, horizontal: Boolean) {
+  fun setHorizontal(view: ReactNestedScrollView?, horizontal: Boolean) {
     // Do Nothing: Align with static ViewConfigs
   }
 
   @ReactProp(name = "isInvertedVirtualizedList")
-  public fun setIsInvertedVirtualizedList(view: ReactNestedScrollView, applyFix: Boolean) {
+  fun setIsInvertedVirtualizedList(view: ReactNestedScrollView, applyFix: Boolean) {
     // Usually when inverting the scroll view we are using scaleY: -1 on the list
     // and on the parent container. HOWEVER, starting from android API 33 there is
     // a bug that can cause an ANR due to that. Thus we are using different transform
@@ -447,10 +447,10 @@ constructor(private val fpsListener: FpsListener? = null) :
     }
   }
 
-  public companion object {
-    public const val REACT_CLASS: String = "RCTScrollView"
+  companion object {
+    const val REACT_CLASS: String = "RCTScrollView"
 
-    public fun createExportedCustomDirectEventTypeConstants(): Map<String, Any> = mapOf(
+    fun createExportedCustomDirectEventTypeConstants(): Map<String, Any> = mapOf(
         getJSEventName(ScrollEventType.SCROLL) to mapOf("registrationName" to "onScroll"),
         getJSEventName(ScrollEventType.BEGIN_DRAG) to
             mapOf("registrationName" to "onScrollBeginDrag"),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VelocityHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VelocityHelper.kt
@@ -28,7 +28,7 @@ internal class VelocityHelper {
    * Call from a ScrollView in onTouchEvent. Calculating the velocity for END_DRAG movement and send
    * them back to react ScrollResponder.js
    */
-  fun calculateVelocity(ev: MotionEvent): Unit {
+  fun calculateVelocity(ev: MotionEvent) {
     if (velocityTracker == null) {
       velocityTracker = VelocityTracker.obtain()
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
@@ -21,7 +21,7 @@ public interface VirtualView {
   public val virtualViewID: String
   public val containerRelativeRect: Rect
 
-  public fun onModeChange(newMode: VirtualViewMode, thresholdRect: Rect): Unit
+  public fun onModeChange(newMode: VirtualViewMode, thresholdRect: Rect)
 }
 
 /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
@@ -152,7 +152,7 @@ internal class VirtualViewContainerStateExperimental(scrollView: ViewGroup) :
  * overlapping VirtualViews
  */
 private data class Interval(val start: Int, val end: Int, val id: String) {
-  public fun intersects(other: Interval): Boolean {
+  fun intersects(other: Interval): Boolean {
     debugLog(
         "Interval: intersect",
         { "${id}:(${start}, ${end}) vs ${other.id}:(${other.start}, ${other.end})" },

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/generate-nested-scroll-view.js
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/generate-nested-scroll-view.js
@@ -86,6 +86,9 @@ const REACT_SCROLL_VIEW_PATTERN =
 // Regex pattern for matching the original copyright header
 const COPYRIGHT_HEADER_PATTERN = /\/\*\s*\n\s*\* Copyright.*?\*\/\s*\n/s;
 
+const KOTLIN_DECLARATION_PATTERN =
+  /\bpublic\s+(?=(?:\w+\s+)*(?:class|fun|interface|object|val|var)\b)/g;
+
 /**
  * Replace ReactScrollView with ReactNestedScrollView in content.
  */
@@ -98,6 +101,10 @@ function replaceClassNames(content) {
  */
 function replaceCopyrightHeader(content, sourceFile) {
   return content.replace(COPYRIGHT_HEADER_PATTERN, generatedHeader(sourceFile));
+}
+
+function removePublicModifiers(content) {
+  return content.replace(KOTLIN_DECLARATION_PATTERN, '');
 }
 
 /**
@@ -127,6 +134,8 @@ function transformScrollView(content) {
     'internal open class ReactNestedScrollView',
   );
 
+  content = removePublicModifiers(content);
+
   // Remove original copyright header and add generated header
   content = replaceCopyrightHeader(content, 'ReactScrollView.kt');
 
@@ -148,6 +157,8 @@ function transformViewManager(content) {
     'public open class ReactNestedScrollViewManager',
     'internal open class ReactNestedScrollViewManager',
   );
+
+  content = removePublicModifiers(content);
 
   // Remove original copyright header and add generated header
   content = replaceCopyrightHeader(content, 'ReactScrollViewManager.kt');

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -69,7 +69,7 @@ internal open class SwipeRefreshLayoutManager :
   }
 
   // TODO(T46143833): Remove this method once the 'size' prop has been migrated to String in JS.
-  fun setSize(view: ReactSwipeRefreshLayout, value: Int): Unit {
+  fun setSize(view: ReactSwipeRefreshLayout, value: Int) {
     view.setSize(value)
   }
 
@@ -87,7 +87,7 @@ internal open class SwipeRefreshLayoutManager :
   // 0 and 1 are deprecated and will be removed in a future release.
   // See T46143833
   @ReactProp(name = "size")
-  fun setSize(view: ReactSwipeRefreshLayout, size: Dynamic): Unit {
+  fun setSize(view: ReactSwipeRefreshLayout, size: Dynamic) {
     when {
       size.isNull -> view.setSize(SwipeRefreshLayout.DEFAULT)
       size.type == ReadableType.Number -> view.setSize(size.asInt())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
@@ -45,7 +45,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
         RippleDrawable(createRippleDrawableColorStateList(color), ColorDrawable(color), null)
   }
 
-  fun setColor(drawable: Drawable, color: Int?): Unit {
+  fun setColor(drawable: Drawable, color: Int?) {
     if (color == null) {
       drawable.clearColorFilter()
     } else {
@@ -53,11 +53,11 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  fun setTrackColor(color: Int?): Unit {
+  fun setTrackColor(color: Int?) {
     setColor(super.getTrackDrawable(), color)
   }
 
-  fun setThumbColor(color: Int?): Unit {
+  fun setThumbColor(color: Int?) {
     setColor(super.getThumbDrawable(), color)
 
     // Set the ripple color if background is instance of RippleDrawable
@@ -67,7 +67,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  fun setOn(on: Boolean): Unit {
+  fun setOn(on: Boolean) {
     // If the switch has a different value than the value sent by JS, we must change it.
     if (isChecked != on) {
       super.setChecked(on)
@@ -76,7 +76,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     allowChange = true
   }
 
-  fun setTrackColorForTrue(color: Int?): Unit {
+  fun setTrackColorForTrue(color: Int?) {
     if (color == trackColorForTrue) {
       return
     }
@@ -86,7 +86,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  fun setTrackColorForFalse(color: Int?): Unit {
+  fun setTrackColorForFalse(color: Int?) {
     if (color == trackColorForFalse) {
       return
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
@@ -24,7 +24,7 @@ internal class ReactSwitchEvent(surfaceId: Int, viewId: Int, private val isCheck
 
   override fun getEventName(): String = EVENT_NAME
 
-  public override fun getEventData(): WritableMap =
+  override fun getEventData(): WritableMap =
       Arguments.createMap().apply {
         putInt("target", viewTag)
         putBoolean("value", isChecked)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -100,7 +100,7 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     setWillNotDraw(false)
   }
 
-  fun recycleView(): Unit {
+  fun recycleView() {
     BackgroundStyleApplicator.reset(this)
     overflow = Overflow.VISIBLE
     clickableSpans = emptyList()
@@ -404,10 +404,9 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
 
   override fun shouldDelayChildPressedState(): Boolean = false
 
-  public override fun dispatchHoverEvent(event: MotionEvent): Boolean =
-      super.dispatchHoverEvent(event)
+  override fun dispatchHoverEvent(event: MotionEvent): Boolean = super.dispatchHoverEvent(event)
 
-  public override fun onFocusChanged(
+  override fun onFocusChanged(
       gainFocus: Boolean,
       direction: Int,
       previouslyFocusedRect: Rect?,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -69,7 +69,7 @@ internal class PreparedLayoutTextViewManager :
     )
   }
 
-  public override fun createViewInstance(context: ThemedReactContext): PreparedLayoutTextView =
+  override fun createViewInstance(context: ThemedReactContext): PreparedLayoutTextView =
       PreparedLayoutTextView(context)
 
   override fun updateExtraData(view: PreparedLayoutTextView, extraData: Any) {
@@ -109,7 +109,7 @@ internal class PreparedLayoutTextViewManager :
   }
 
   @ReactProp(name = "overflow")
-  fun setOverflow(view: PreparedLayoutTextView, overflow: String?): Unit {
+  fun setOverflow(view: PreparedLayoutTextView, overflow: String?) {
     view.overflow = Overflow.fromString(overflow)
     ImportantForInteractionHelper.setImportantForInteraction(
         view,
@@ -120,19 +120,19 @@ internal class PreparedLayoutTextViewManager :
   }
 
   @ReactProp(name = "accessible")
-  fun setAccessible(view: PreparedLayoutTextView, accessible: Boolean): Unit {
+  fun setAccessible(view: PreparedLayoutTextView, accessible: Boolean) {
     view.isFocusable = accessible
   }
 
   @ReactProp(name = "selectable", defaultBoolean = false)
-  fun setSelectable(view: PreparedLayoutTextView, isSelectable: Boolean): Unit {
+  fun setSelectable(view: PreparedLayoutTextView, isSelectable: Boolean) {
     check(!isSelectable) {
       "selectable Text should use SelectableTextViewManager instead of PreparedLayoutViewManager"
     }
   }
 
   @ReactProp(name = "selectionColor", customType = "Color")
-  fun setSelectionColor(view: PreparedLayoutTextView, color: Int?): Unit {
+  fun setSelectionColor(view: PreparedLayoutTextView, color: Int?) {
     if (color == null) {
       view.selectionColor = DefaultStyleValuesUtil.getDefaultTextColorHighlight(view.context)
     } else {
@@ -151,7 +151,7 @@ internal class PreparedLayoutTextViewManager :
           ],
       defaultFloat = Float.NaN,
   )
-  fun setBorderRadius(view: PreparedLayoutTextView, index: Int, borderRadius: Float): Unit {
+  fun setBorderRadius(view: PreparedLayoutTextView, index: Int, borderRadius: Float) {
     val radius =
         if (borderRadius.isNaN()) null
         else LengthPercentage(borderRadius, LengthPercentageType.POINT)
@@ -159,7 +159,7 @@ internal class PreparedLayoutTextViewManager :
   }
 
   @ReactProp(name = "borderStyle")
-  fun setBorderStyle(view: PreparedLayoutTextView, borderStyle: String?): Unit {
+  fun setBorderStyle(view: PreparedLayoutTextView, borderStyle: String?) {
     val parsedBorderStyle = if (borderStyle == null) null else BorderStyle.fromString(borderStyle)
     BackgroundStyleApplicator.setBorderStyle(view, parsedBorderStyle)
   }
@@ -177,7 +177,7 @@ internal class PreparedLayoutTextViewManager :
           ],
       defaultFloat = Float.NaN,
   )
-  fun setBorderWidth(view: PreparedLayoutTextView, index: Int, width: Float): Unit {
+  fun setBorderWidth(view: PreparedLayoutTextView, index: Int, width: Float) {
     BackgroundStyleApplicator.setBorderWidth(view, LogicalEdge.values()[index], width)
   }
 
@@ -197,12 +197,12 @@ internal class PreparedLayoutTextViewManager :
           ],
       customType = "Color",
   )
-  fun setBorderColor(view: PreparedLayoutTextView, index: Int, color: Int?): Unit {
+  fun setBorderColor(view: PreparedLayoutTextView, index: Int, color: Int?) {
     BackgroundStyleApplicator.setBorderColor(view, LogicalEdge.values()[index], color)
   }
 
   @ReactProp(name = "disabled", defaultBoolean = false)
-  fun setDisabled(view: PreparedLayoutTextView, disabled: Boolean): Unit {
+  fun setDisabled(view: PreparedLayoutTextView, disabled: Boolean) {
     view.isEnabled = !disabled
   }
 
@@ -212,7 +212,7 @@ internal class PreparedLayoutTextViewManager :
       top: Int,
       right: Int,
       bottom: Int,
-  ): Unit {
+  ) {
     view.setPadding(left, top, right, bottom)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.kt
@@ -11,15 +11,15 @@ import android.text.Spanned
 
 /** Class that contains the data needed for a text update. Used by both <Text/> and <TextInput/>. */
 internal class ReactTextUpdate(
-    public val text: Spanned,
-    public val jsEventCounter: Int,
-    public val textAlign: Int,
-    public val textBreakStrategy: Int,
-    public val justificationMode: Int,
+    val text: Spanned,
+    val jsEventCounter: Int,
+    val textAlign: Int,
+    val textBreakStrategy: Int,
+    val justificationMode: Int,
 ) {
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun buildReactTextUpdateFromState(
+    fun buildReactTextUpdateFromState(
         text: Spanned,
         jsEventCounter: Int,
         textAlign: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -185,6 +185,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   }
 
   @Override
+  @SuppressWarnings("try")
   protected void onDraw(Canvas canvas) {
     try (SystraceSection s = new SystraceSection("ReactTextView.onDraw")) {
       Spannable spanned = getSpanned();
@@ -307,6 +308,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   }
 
   @Override
+  @SuppressWarnings("try")
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
     try (SystraceSection s = new SystraceSection("ReactTextView.onMeasure")) {
       super.onMeasure(widthMeasureSpec, heightMeasureSpec);
@@ -321,6 +323,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
   }
 
+  @SuppressWarnings("try")
   public void setText(ReactTextUpdate update) {
     try (SystraceSection s = new SystraceSection("ReactTextView.setText(ReactTextUpdate)")) {
       // Android's TextView crashes when it tries to relayout if LayoutParams are

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -94,7 +94,7 @@ public constructor(
       ReactTextView(context)
 
   override fun updateExtraData(view: ReactTextView, extraData: Any) {
-    SystraceSection("ReactTextViewManager.updateExtraData").use { s ->
+    SystraceSection("ReactTextViewManager.updateExtraData").use { _ ->
       val update = extraData as ReactTextUpdate
       val spanned: Spanned = update.text
       view.setText(update)
@@ -135,7 +135,7 @@ public constructor(
       props: ReactStylesDiffMap,
       stateWrapper: StateWrapper,
   ): Any? {
-    SystraceSection("ReactTextViewManager.updateState").use { s ->
+    SystraceSection("ReactTextViewManager.updateState").use { _ ->
       val refState = (stateWrapper as? ReferenceStateWrapper)?.stateDataReference
       if (refState is PreparedLayout) {
         return getReactTextUpdateFromPreparedLayout(view, refState)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.kt
@@ -132,6 +132,6 @@ public class TextAttributes {
 
   internal companion object {
     // Setting the default to 0 indicates that there is no max.
-    public const val DEFAULT_MAX_FONT_SIZE_MULTIPLIER: Float = 0.0f
+    const val DEFAULT_MAX_FONT_SIZE_MULTIPLIER: Float = 0.0f
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -124,11 +124,11 @@ internal object TextLayoutManager {
     }
   }
 
-  fun setCachedSpannableForTag(reactTag: Int, sp: Spannable): Unit {
+  fun setCachedSpannableForTag(reactTag: Int, sp: Spannable) {
     tagToSpannableCache[reactTag] = sp
   }
 
-  fun deleteCachedSpannableForTag(reactTag: Int): Unit {
+  fun deleteCachedSpannableForTag(reactTag: Int) {
     tagToSpannableCache.remove(reactTag)
   }
 
@@ -147,12 +147,12 @@ internal object TextLayoutManager {
     val fragment = fragments.getMapBuffer(0)
     val textAttributes = fragment.getMapBuffer(FR_KEY_TEXT_ATTRIBUTES)
 
-    if (!textAttributes.contains(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION.toInt())) {
+    if (!textAttributes.contains(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION)) {
       return false
     }
 
     return TextAttributeProps.getLayoutDirection(
-        textAttributes.getString(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION.toInt()),
+        textAttributes.getString(TextAttributeProps.TA_KEY_LAYOUT_DIRECTION),
     ) == LayoutDirection.RTL
   }
 
@@ -168,8 +168,8 @@ internal object TextLayoutManager {
       val fragment = fragments.getMapBuffer(0)
       val textAttributes = fragment.getMapBuffer(FR_KEY_TEXT_ATTRIBUTES)
 
-      if (textAttributes.contains(TextAttributeProps.TA_KEY_ALIGNMENT.toInt())) {
-        return textAttributes.getString(TextAttributeProps.TA_KEY_ALIGNMENT.toInt())
+      if (textAttributes.contains(TextAttributeProps.TA_KEY_ALIGNMENT)) {
+        return textAttributes.getString(TextAttributeProps.TA_KEY_ALIGNMENT)
       }
     }
 
@@ -708,7 +708,7 @@ internal object TextLayoutManager {
       reactTextViewManagerCallback: ReactTextViewManagerCallback?,
       textEffectRegistry: TextEffectRegistry?,
   ): Spannable {
-    var text: Spannable?
+    val text: Spannable?
     if (attributedString.contains(AS_KEY_CACHE_ID)) {
       val cacheId = attributedString.getInt(AS_KEY_CACHE_ID)
       text = checkNotNull(tagToSpannableCache[cacheId])
@@ -1185,7 +1185,7 @@ internal object TextLayoutManager {
       alignment: Layout.Alignment,
       justificationMode: Int,
       paint: TextPaint,
-  ): Unit {
+  ) {
     var boring = isBoring(text, paint)
     var layout: Layout
 
@@ -1197,7 +1197,7 @@ internal object TextLayoutManager {
     var currentFontSize = minimumFontSize
     val spans = text.getSpans(0, text.length, ReactAbsoluteSizeSpan::class.java)
     for (span in spans) {
-      currentFontSize = max(currentFontSize, span.size).toInt()
+      currentFontSize = max(currentFontSize, span.size)
     }
 
     var intervalStart = minimumFontSize

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ContentSizeWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ContentSizeWatcher.kt
@@ -8,5 +8,5 @@
 package com.facebook.react.views.textinput
 
 public interface ContentSizeWatcher {
-  public fun onLayout(): Unit
+  public fun onLayout()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -1323,7 +1323,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
      */
     override fun getInputType() = _inputType
 
-    public fun setInputType(inputType: Int) {
+    fun setInputType(inputType: Int) {
       _inputType = inputType
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -1040,7 +1040,7 @@ public open class ReactTextInputManager public constructor() :
 
     val textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
-            paragraphAttributes.getString(TextLayoutManager.PA_KEY_TEXT_BREAK_STRATEGY.toInt()),
+            paragraphAttributes.getString(TextLayoutManager.PA_KEY_TEXT_BREAK_STRATEGY),
         )
     val currentJustificationMode =
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ScrollWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ScrollWatcher.kt
@@ -8,5 +8,5 @@
 package com.facebook.react.views.textinput
 
 public interface ScrollWatcher {
-  public fun onScrollChanged(horiz: Int, vert: Int, oldHoriz: Int, oldVert: Int): Unit
+  public fun onScrollChanged(horiz: Int, vert: Int, oldHoriz: Int, oldVert: Int)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/SelectionWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/SelectionWatcher.kt
@@ -12,5 +12,5 @@ package com.facebook.react.views.textinput
  * the ReactTextInputManager to forward events from the EditText to JS
  */
 internal interface SelectionWatcher {
-  fun onSelectionChanged(start: Int, end: Int): Unit
+  fun onSelectionChanged(start: Int, end: Int)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
@@ -27,7 +27,7 @@ internal class ReactUnimplementedViewManager :
   private val delegate: ViewManagerDelegate<ReactUnimplementedView> =
       UnimplementedNativeViewManagerDelegate(this)
 
-  public override fun getDelegate(): ViewManagerDelegate<ReactUnimplementedView> = delegate
+  override fun getDelegate(): ViewManagerDelegate<ReactUnimplementedView> = delegate
 
   override fun createViewInstance(reactContext: ThemedReactContext): ReactUnimplementedView =
       ReactUnimplementedView(reactContext)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEmitter.kt
@@ -10,7 +10,7 @@ package com.facebook.react.views.virtual
 import android.graphics.Rect
 
 internal fun interface VirtualViewModeChangeEmitter {
-  public fun emitModeChange(
+  fun emitModeChange(
       mode: VirtualViewMode,
       targetRect: Rect,
       thresholdRect: Rect,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEvent.kt
@@ -29,7 +29,7 @@ internal class VirtualViewModeChangeEvent(
   override fun getEventName(): String = "modeChange"
 
   @VisibleForTesting
-  public override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply {
       putInt("mode", mode.value)
       putMap("targetRect", targetRectAsMap)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
@@ -113,7 +113,7 @@ public class ReactVirtualView(context: Context) :
     recycleView()
   }
 
-  override internal fun recycleView() {
+  override fun recycleView() {
     cleanupLayoutListeners()
     scrollView?.virtualViewContainerState?.remove(this)
     scrollView = null


### PR DESCRIPTION
Summary:

K2 warnings can otherwise accumulate unnoticed across React Native Android targets. Enable `warnings_as_errors_k22` by default for `rn_android_library` and clean up the warnings exposed by the RNTester dependency graph. Generated-source targets opt out where warnings cannot be fixed in checked-in source.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D119096917
