### PR TITLE
Add RN_BUILDING to fantom

### DIFF
--- a/private/react-native-fantom/tester/CMakeLists.txt
+++ b/private/react-native-fantom/tester/CMakeLists.txt
@@ -38,6 +38,10 @@ add_fantom_third_party_subdir(folly)
 add_fantom_third_party_subdir(gflags)
 add_fantom_third_party_subdir(nlohmann_json)
 
+# Marks everything added below as React Native's own build, to enable private
+# includes in Fantom.
+add_compile_definitions(RN_BUILDING)
+
 add_subdirectory(${FANTOM_CODEGEN_DIR} codegen)
 
 add_library(glog_init INTERFACE)


### PR DESCRIPTION
Summary:
Update Fantom build config to compile with `RN_BUILDING` defined, allowing all includes within Fantom.

Changelog: [Internal]

Differential Revision: D117860963
