### PR TITLE
fix(codegen): read react-native.config.cjs so ESM projects are not silently skipped

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -21,6 +21,7 @@ const {
 const {
   cleanupEmptyFilesAndFolders,
   extractLibrariesFromJSON,
+  readReactNativeConfig,
 } = require('../generate-artifacts-executor/utils');
 const fs = require('node:fs');
 const os = require('node:os');
@@ -138,6 +139,58 @@ const packageJson = JSON.stringify({
         libraryPath: myDependencyPath,
         name: 'my-module',
       });
+    });
+  });
+});
+
+describe('readReactNativeConfig', () => {
+  const CONFIG_JS = "module.exports = {dependencies: {'from-js': {root: '/js'}}};";
+  const CONFIG_CJS = "module.exports = {dependencies: {'from-cjs': {root: '/cjs'}}};";
+
+  function withProjectRoot(files, assertion) {
+    const projectRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'react-native-codegen-config-'),
+    );
+    try {
+      for (const [name, contents] of Object.entries(files)) {
+        fs.writeFileSync(path.join(projectRoot, name), contents);
+      }
+      // baseOutputPath is a directory with no generated autolinking output, so
+      // resolution falls through to the react-native.config file.
+      assertion(readReactNativeConfig(projectRoot, projectRoot));
+    } finally {
+      fs.rmSync(projectRoot, {recursive: true, force: true});
+    }
+  }
+
+  it('reads react-native.config.js', () => {
+    withProjectRoot({'react-native.config.js': CONFIG_JS}, config => {
+      expect(config.dependencies).toHaveProperty('from-js');
+    });
+  });
+
+  it('reads react-native.config.cjs when there is no .js config', () => {
+    withProjectRoot({'react-native.config.cjs': CONFIG_CJS}, config => {
+      expect(config.dependencies).toHaveProperty('from-cjs');
+    });
+  });
+
+  it('prefers react-native.config.js when both exist', () => {
+    withProjectRoot(
+      {
+        'react-native.config.js': CONFIG_JS,
+        'react-native.config.cjs': CONFIG_CJS,
+      },
+      config => {
+        expect(config.dependencies).toHaveProperty('from-js');
+        expect(config.dependencies).not.toHaveProperty('from-cjs');
+      },
+    );
+  });
+
+  it('returns an empty config when neither exists', () => {
+    withProjectRoot({}, config => {
+      expect(config).toEqual({});
     });
   });
 });

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -126,14 +126,16 @@ function readReactNativeConfig(
     projectRoot,
     baseOutputPath,
   );
-  const rnConfigFilePath = path.resolve(projectRoot, 'react-native.config.js');
+  const rnConfigFilePath = ['react-native.config.js', 'react-native.config.cjs']
+    .map(fileName => path.resolve(projectRoot, fileName))
+    .find(candidatePath => fs.existsSync(candidatePath));
   if (autolinkingOutput) {
     return autolinkingOutput;
-  } else if (fs.existsSync(rnConfigFilePath)) {
+  } else if (rnConfigFilePath != null) {
     // $FlowFixMe[unsupported-syntax]
     return require(rnConfigFilePath);
   } else {
-    codegenLog(`Could not find React Native config at: ${rnConfigFilePath}`);
+    codegenLog(`Could not find React Native config in: ${projectRoot}`);
     return {};
   }
 }


### PR DESCRIPTION
## Summary

`readReactNativeConfig` resolves the config with a single hardcoded extension:

```js
const rnConfigFilePath = path.resolve(projectRoot, 'react-native.config.js');
```

A project whose `package.json` declares `"type": "module"` cannot use that filename. Node parses `.js` as ESM there, and the `require()` two lines below either throws or returns the wrong shape:

| Config file | `require()` result |
| --- | --- |
| `react-native.config.js`, CommonJS body | throws `ReferenceError: module is not defined in ES module scope` — uncaught here, so codegen dies |
| `react-native.config.js`, ESM body | returns `{__esModule, default}`, so `rnConfig.dependencies` is `undefined` |
| `react-native.config.cjs` | returns the config correctly |

`.cjs` is the only extension that is both `require()`-able and legal in an ESM package — and `@react-native-community/cli` already treats it as first-class:

```js
// @react-native-community/cli-config/build/readConfigFromDisk.js
const searchPlacesForCJS = ['react-native.config.js', 'react-native.config.cjs', 'react-native.config.ts'];
```

added for react-native-community/cli#2167. Codegen has its own resolver, does not use cosmiconfig, and was never brought in line. This PR closes that gap.

### Why it matters

Autolinking and codegen disagree about the same file, so the failure is silent and deferred. Autolinking reads the `.cjs` config and installs the pod; codegen doesn't, so it generates nothing for that library; the pod then compiles and its Fabric component includes a header that was never generated:

```
.../react/renderer/components/RNCSlider/RNCSliderShadowNode.h:5:10:
fatal error: 'react/renderer/components/RNCSlider/Props.h' file not found
```

Nothing in that error points at the config. `findLibrariesFromReactNativeConfig` bails via `if (!rnConfig.dependencies) return [];` without logging.

The other two config sources do not cover it:

- `build/generated/autolinking/autolinking.json` is written by `use_native_modules!` during `pod install`, so it is absent whenever codegen runs first (pipelines that codegen before installing pods, or `generate-codegen-artifacts.js` invoked directly).
- The `package.json` dependency scan only sees **direct** dependencies. A library reached through `dependencies[...].root` — the whole reason to write a config file — is by definition not one.

## Changelog:

[General] [Fixed] - Codegen now also reads `react-native.config.cjs`, so libraries declared in it are no longer skipped in ESM projects

## Test Plan

Four cases added to `packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js`, following the existing `mkdtempSync` fixture pattern:

```
yarn jest packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js

  readReactNativeConfig
    ✓ reads react-native.config.js
    ✓ reads react-native.config.cjs when there is no .js config
    ✓ prefers react-native.config.js when both exist
    ✓ returns an empty config when neither exists

Test Suites: 1 passed, 1 total
Tests:       48 passed, 48 total
Snapshots:   24 passed, 24 total
```

All 48 tests in the file pass, including the 24 existing snapshots — the change is additive for projects that have a `.js` config.

**Negative control:** with the `utils.js` change reverted and the tests left in place, the `.cjs` case fails as expected:

```
  ✕ reads react-native.config.cjs when there is no .js config
Tests: 1 failed, 47 skipped, 48 total
```

## Notes

The log line in the `else` branch now names the directory searched rather than a single path, since there are two candidates:

```diff
-    codegenLog(`Could not find React Native config at: ${rnConfigFilePath}`);
+    codegenLog(`Could not find React Native config in: ${projectRoot}`);
```

Happy to extend this to `.mjs` / `.ts` to fully match the CLI's `searchPlaces`, but neither is a drop-in — `.mjs` cannot be `require()`d for the right default-export shape, and `.ts` needs a loader — so this PR keeps to the one case that is.
