### PR TITLE
Export the native Fabric UI manager for React (#58398)

### DIFF
--- a/packages/react-native/src/react-private-interface.js
+++ b/packages/react-native/src/react-private-interface.js
@@ -29,6 +29,7 @@ import typeof ExceptionsManager from '../Libraries/Core/ExceptionsManager';
 import typeof RawEventEmitter from '../Libraries/Core/RawEventEmitter';
 import typeof ReactFiberErrorDialog from '../Libraries/Core/ReactFiberErrorDialog';
 import typeof RCTEventEmitter from '../Libraries/EventEmitter/RCTEventEmitter';
+import type {Spec as FabricUIManager} from '../Libraries/ReactNative/FabricUIManager';
 import typeof {
   createPublicInstance,
   createPublicRootInstance,
@@ -81,6 +82,9 @@ module.exports = {
   },
   get UIManager(): UIManager {
     return require('../Libraries/ReactNative/UIManager').default;
+  },
+  get fabricUIManager(): ?FabricUIManager {
+    return require('../Libraries/ReactNative/FabricUIManager').getFabricUIManager();
   },
   // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
   get deepDiffer(): deepDiffer {

--- a/packages/react-native/src/react-private-interface.js.flow
+++ b/packages/react-native/src/react-private-interface.js.flow
@@ -14,6 +14,7 @@
 // IMPORTANT: Keep this file in sync with react-private-interface.js.
 // ----------------------------------------------------------------------------
 
+import type {Spec as FabricUIManager} from '../Libraries/ReactNative/FabricUIManager';
 import typeof {createPublicTextInstance as createPublicTextInstanceT} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
 
 export type {PublicRootInstance} from '../Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
@@ -27,6 +28,7 @@ export * as ReactNativeFeatureFlags from './private/featureflags/ReactNativeFeat
 export * as ReactNativeViewConfigRegistry from '../Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
 export {default as TextInputState} from '../Libraries/Components/TextInput/TextInputState';
 export {default as UIManager} from '../Libraries/ReactNative/UIManager';
+declare export const fabricUIManager: ?FabricUIManager;
 export {default as deepDiffer} from '../Libraries/Utilities/differ/deepDiffer';
 export {default as deepFreezeAndThrowOnMutationInDev} from '../Libraries/Utilities/deepFreezeAndThrowOnMutationInDev';
 export {default as flattenStyle} from '../Libraries/StyleSheet/flattenStyle';


### PR DESCRIPTION
Summary:

Expose the native Fabric UI manager through `react-native/react-private-interface` so the React renderer can consume it without reading the global directly.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D119165837


