### PR TITLE
Cover cxxreact:bridge with Stable API guards (#58404)

### DIFF
--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -66,6 +66,7 @@ Pod::Spec.new do |s|
   s.dependency "RCTSwiftUIWrapper"
 
   add_dependency(s, "React-FabricImage")
+  add_dependency(s, "React-cxxreact")
   add_dependency(s, "React-Fabric", :additional_framework_paths => [
     "react/renderer/components/scrollview/platform/cxx",
     "react/renderer/components/scrollview/platform/ios",

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -165,6 +165,8 @@ val preparePrefab by
                       Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
                       // react_utils
                       Pair("../ReactCommon/react/utils/", "react/utils/"),
+                      Pair("../ReactCommon/react/utils/platform/android/", ""),
+                      Pair("../ReactCommon/react/utils/React/", "React/"),
                       // rrc_image
                       Pair(
                           "../ReactCommon/react/renderer/components/image/",

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -113,6 +113,7 @@ val preparePrefab by
                       // reactnativejni
                       Pair("src/main/jni/react/jni", "react/jni/"),
                       Pair("../ReactCommon/cxxreact/", "cxxreact/"),
+                      Pair("../ReactCommon/cxxreact/React/", "React/"),
                       // react_featureflags
                       Pair("../ReactCommon/react/featureflags/", "react/featureflags/"),
                       Pair("../ReactCommon/react/featureflags/React/", "React/"),

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
 
     ss.subspec "core" do |sss|
       sss.source_files = podspec_sources("react/nativemodule/core/ReactCommon/**/*.{cpp,h}", "react/nativemodule/core/ReactCommon/**/*.h")
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_featureflags.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"" }
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_featureflags.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-cxxreact/React_cxxreact.framework/Headers\"" }
       sss.dependency "React-bridging"
       sss.dependency "React-cxxreact", version
       sss.dependency "React-debug", version

--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB react_cxxreact_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_cxxreact OBJECT ${react_cxxreact_SRC})
 
 target_include_directories(react_cxxreact PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_cxxreact INTERFACE ${REACT_COMMON_DIR}/cxxreact)
 
 target_link_libraries(react_cxxreact
         boost
@@ -22,6 +23,7 @@ target_link_libraries(react_cxxreact
         jsi
         jsinspector
         logger
+        react_cxxstableapi
         reactperflogger
         runtimeexecutor
         react_debug)

--- a/packages/react-native/ReactCommon/cxxreact/CxxModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/CxxModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <functional>
 #include <map>
 #include <tuple>

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <cxxreact/CxxModule.h>

--- a/packages/react-native/ReactCommon/cxxreact/Instance.h
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <condition_variable>

--- a/packages/react-native/ReactCommon/cxxreact/JSBigString.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSBigString.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <string>
 

--- a/packages/react-native/ReactCommon/cxxreact/JSBundleType.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSBundleType.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <folly/Portability.h>
 #include <cstdint>
 #include <cstring>

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <memory>
 #include <string>
 

--- a/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <cstdint>

--- a/packages/react-native/ReactCommon/cxxreact/JsArgumentHelpers-inl.h
+++ b/packages/react-native/ReactCommon/cxxreact/JsArgumentHelpers-inl.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <folly/dynamic.h>
 
 namespace facebook {

--- a/packages/react-native/ReactCommon/cxxreact/JsArgumentHelpers.h
+++ b/packages/react-native/ReactCommon/cxxreact/JsArgumentHelpers.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <exception>
 #include <string>
 

--- a/packages/react-native/ReactCommon/cxxreact/MessageQueueThread.h
+++ b/packages/react-native/ReactCommon/cxxreact/MessageQueueThread.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <functional>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/cxxreact/MethodCall.h
+++ b/packages/react-native/ReactCommon/cxxreact/MethodCall.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <map>

--- a/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <memory>

--- a/packages/react-native/ReactCommon/cxxreact/NativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <string>
 #include <vector>
 

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <atomic>

--- a/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #ifndef RCT_REMOVE_LEGACY_ARCH
 
 #include <cstdint>

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -34,6 +34,8 @@ Pod::Spec.new do |s|
   }
   s.header_dir             = "cxxreact"
 
+  resolve_use_frameworks(s, header_mappings_dir: "..", module_name: "React_cxxreact")
+
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
@@ -45,6 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger", version
   s.dependency "React-debug", version
   s.dependency "React-timing", version
+  s.dependency "React-cxxstableapi"
   add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
 
   s.resource_bundles = {'React-cxxreact_privacy' => 'PrivacyInfo.xcprivacy'}
@@ -55,6 +58,12 @@ Pod::Spec.new do |s|
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+
+  s.subspec "cxxreactUmbrella" do |ss|
+    ss.source_files        = "React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "."
+  end
 
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/cxxreact/React/JSBigString.h
+++ b/packages/react-native/ReactCommon/cxxreact/React/JSBigString.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `cxxreact` module - public entry point.
+//
+//   #include <React/JSBigString.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<cxxreact/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <cxxreact/JSBigString.h>
+#include <cxxreact/JSBundleType.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include <cmath>
 #include <functional>
 #include <mutex>

--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <cstdint>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/cxxreact/RecoverableError.h
+++ b/packages/react-native/ReactCommon/cxxreact/RecoverableError.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <exception>
 #include <functional>
 #include <string>

--- a/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #include "TraceSection.h"
 
 // NOTE: This is here for a backwards compatibility and should be removed once

--- a/packages/react-native/ReactCommon/cxxreact/TraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/TraceSection.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/FrameworksGuard.h>
+
 #ifdef WITH_FBSYSTRACE
 #include <fbsystrace.h>
 #endif

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
     s.dependency "React-bridging"
     s.dependency "React-callinvoker"
     s.dependency "React-Core"
-    s.dependency "React-cxxreact"
+    add_dependency(s, "React-cxxreact")
     s.dependency "React-jsi"
     s.dependency "React-featureflags"
     add_dependency(s, "React-debug")

--- a/packages/react-native/ReactCommon/react/utils/Base64.h
+++ b/packages/react-native/ReactCommon/react/utils/Base64.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <string>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -26,11 +26,13 @@ target_include_directories(react_utils
           ${REACT_COMMON_DIR}
           ${platform_DIR}
 )
+target_include_directories(react_utils INTERFACE ${REACT_COMMON_DIR}/react/utils)
 
 target_link_libraries(react_utils
         glog
         glog_init
         jsi
+        react_cxxstableapi
         react_debug)
 target_compile_reactnative_options(react_utils PRIVATE)
 target_compile_options(react_utils PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/utils/FloatComparison.h
+++ b/packages/react-native/ReactCommon/react/utils/FloatComparison.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cmath>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
+++ b/packages/react-native/ReactCommon/react/utils/ManagedObjectWrapper.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/debug/react_native_assert.h>
 
 #if defined(__APPLE__)

--- a/packages/react-native/ReactCommon/react/utils/MoveWrapper.h
+++ b/packages/react-native/ReactCommon/react/utils/MoveWrapper.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <memory>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/utils/OnScopeExit.h
+++ b/packages/react-native/ReactCommon/react/utils/OnScopeExit.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <utility>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/utils/PackTraits.h
+++ b/packages/react-native/ReactCommon/react/utils/PackTraits.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <type_traits>
 
 namespace facebook::react::traits {

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = podspec_sources(source_files, ["*.h", "platform/ios/**/*.h"])
   s.header_dir             = "react/utils"
-  s.exclude_files          = "tests"
+  s.exclude_files          = ["tests", "React"]
 
   if ENV['USE_FRAMEWORKS']
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
@@ -46,6 +46,7 @@ Pod::Spec.new do |s|
                                "DEFINES_MODULE" => "YES" }
 
   s.dependency "React-jsi", version
+  s.dependency "React-cxxstableapi"
 
   if use_hermes()
     s.dependency "hermes-engine"
@@ -54,6 +55,12 @@ Pod::Spec.new do |s|
   add_rncore_dependency(s)
 
   add_dependency(s, "React-debug")
+
+  s.subspec "utilsUmbrella" do |ss|
+    ss.source_files        = "React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "."
+  end
 
   mark_as_react_native_build(s)
 end

--- a/packages/react-native/ReactCommon/react/utils/React/Utils.h
+++ b/packages/react-native/ReactCommon/react/utils/React/Utils.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/utils` module - public entry point.
+//
+//   #include <React/Utils.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/utils/...>` includes; only outside
+// consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/utils/Base64.h>
+#include <react/utils/ContextContainer.h>
+#include <react/utils/FloatComparison.h>
+#include <react/utils/LowPriorityExecutor.h>
+#include <react/utils/ManagedObjectWrapper.h>
+#include <react/utils/MoveWrapper.h>
+#include <react/utils/OnScopeExit.h>
+#include <react/utils/PackTraits.h>
+#include <react/utils/RunLoopObserver.h>
+#include <react/utils/SharedFunction.h>
+#include <react/utils/SimpleThreadSafeCache.h>
+#include <react/utils/Telemetry.h>
+#include <react/utils/TemplateStringLiteral.h>
+#include <react/utils/Uuid.h>
+#include <react/utils/fnv1a.h>
+#include <react/utils/hash_combine.h>
+#include <react/utils/iequals.h>
+#include <react/utils/jsi-utils.h>
+#include <react/utils/toLower.h>
+#include <react/utils/to_underlying.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <atomic>
 #include <functional>
 #include <memory>

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
+++ b/packages/react-native/ReactCommon/react/utils/SimpleThreadSafeCache.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <concepts>
 #include <list>
 #include <mutex>

--- a/packages/react-native/ReactCommon/react/utils/Telemetry.h
+++ b/packages/react-native/ReactCommon/react/utils/Telemetry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <chrono>
 #include <type_traits>
 

--- a/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
+++ b/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <algorithm>
 #include <array>
 #include <string_view>

--- a/packages/react-native/ReactCommon/react/utils/Uuid.h
+++ b/packages/react-native/ReactCommon/react/utils/Uuid.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <string>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/utils/fnv1a.h
+++ b/packages/react-native/ReactCommon/react/utils/fnv1a.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cstdint>
 #include <functional>
 #include <string_view>

--- a/packages/react-native/ReactCommon/react/utils/hash_combine.h
+++ b/packages/react-native/ReactCommon/react/utils/hash_combine.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <cstdint>
 #include <functional>
 #include <optional>

--- a/packages/react-native/ReactCommon/react/utils/iequals.h
+++ b/packages/react-native/ReactCommon/react/utils/iequals.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <react/utils/toLower.h>
 #include <string_view>
 

--- a/packages/react-native/ReactCommon/react/utils/jsi-utils.h
+++ b/packages/react-native/ReactCommon/react/utils/jsi-utils.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <jsi/jsi.h>
 #include <string>
 

--- a/packages/react-native/ReactCommon/react/utils/platform/android/react/utils/LowPriorityExecutor.h
+++ b/packages/react-native/ReactCommon/react/utils/platform/android/react/utils/LowPriorityExecutor.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
+#include <functional>
+
 namespace facebook::react::LowPriorityExecutor {
 
 void execute(std::function<void()> &&workItem);

--- a/packages/react-native/ReactCommon/react/utils/platform/cxx/react/utils/LowPriorityExecutor.h
+++ b/packages/react-native/ReactCommon/react/utils/platform/cxx/react/utils/LowPriorityExecutor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 
 namespace facebook::react::LowPriorityExecutor {

--- a/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/LowPriorityExecutor.h
+++ b/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/LowPriorityExecutor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <functional>
 
 namespace facebook::react::LowPriorityExecutor {

--- a/packages/react-native/ReactCommon/react/utils/toLower.h
+++ b/packages/react-native/ReactCommon/react/utils/toLower.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 namespace facebook::react {
 
 /**

--- a/packages/react-native/ReactCommon/react/utils/to_underlying.h
+++ b/packages/react-native/ReactCommon/react/utils/to_underlying.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/UmbrellaGuard.h>
+
 #include <type_traits>
 
 namespace facebook::react {

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -100,6 +100,7 @@ class NewArchitectureHelper
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-rendererdebug", "React_rendererdebug", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-renderercss", "React_renderercss", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-cxxstableapi", "React_cxxstableapi", []))
+                .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-cxxreact", "React_cxxreact", []))
                 .each { |search_path|
                     header_search_paths << "\"#{search_path}\""
                 }

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -93,7 +93,7 @@ class NewArchitectureHelper
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-runtimeexecutor", "React_runtimeexecutor", ["platform/ios"]))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-NativeModulesApple", "React_NativeModulesApple", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-RCTFabric", "RCTFabric", []))
-                .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-utils", "React_utils", []))
+                .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-utils", "React_utils", ["react/utils/platform/ios"]))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-featureflags", "React_featureflags", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-debug", "React_debug", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-ImageManager", "React_ImageManager", []))

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -602,6 +602,24 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/react/utils/React-utils.podspec': {
+    name: 'React-utils',
+    headerPatterns: [],
+    headerDir: '',
+    subSpecs: [
+      {
+        name: 'utils',
+        headerPatterns: ['*.h', 'platform/ios/**/*.h'],
+        excludePatterns: ['tests', 'React'],
+        headerDir: 'react/utils',
+      },
+      {
+        name: 'utilsUmbrella',
+        headerPatterns: ['React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
 };
 
 module.exports = {PodspecExceptions};

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -620,6 +620,23 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/cxxreact/React-cxxreact.podspec': {
+    name: 'React-cxxreact',
+    headerPatterns: [],
+    headerDir: '',
+    subSpecs: [
+      {
+        name: 'cxxreact',
+        headerPatterns: ['*.h'],
+        headerDir: 'cxxreact',
+      },
+      {
+        name: 'cxxreactUmbrella',
+        headerPatterns: ['React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
 };
 
 module.exports = {PodspecExceptions};

--- a/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
@@ -129,6 +129,8 @@ exports[`updateReactNativeArtifacts should set nightly version: packages/react-n
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <cstdint>
 #include <string_view>
 
@@ -285,6 +287,8 @@ exports[`updateReactNativeArtifacts should set release version: packages/react-n
  */
 
 #pragma once
+
+#include <react/cxxstableapi/PrivateGuard.h>
 
 #include <cstdint>
 #include <string_view>

--- a/scripts/releases/templates/ReactNativeVersion.h-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.h-template.js
@@ -23,6 +23,8 @@ module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <cstdint>
 #include <string_view>
 


### PR DESCRIPTION
Summary:

Classifies `cxxreact:bridge` as a private target under the three-tier C++ stable API visibility model. Consumers that opt into `RN_STRICT_API` now get an error if they include its headers directly; without that flag the guards are inert, so no existing build changes behaviour. `ReactNativeVersion.h` is a generated file, so its guard also goes into `scripts/releases/templates/ReactNativeVersion.h-template.js`; without that the next version stamp would rewrite the header and silently drop the guard from every release and nightly artifact.

Changelog: [Internal]

Differential Revision: D119163927
