### PR TITLE
Classify iosswitch headers as private

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/AppleSwitchComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/AppleSwitchComponentDescriptor.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include "AppleSwitchShadowNode.h"
 
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/AppleSwitchShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/AppleSwitchShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <react/cxxstableapi/PrivateGuard.h>
+
 #include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
 #include <react/renderer/components/FBReactNativeSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>


### PR DESCRIPTION
Summary:
Classify the Apple Fabric Switch C++ headers as private API. Strict API consumers now receive a hard error when including these implementation headers, while React Native builds continue to use them under RN_BUILDING.

Propagate the cxxstableapi dependency from the iosswitch Buck target so its exported guarded headers resolve PrivateGuard.h.

Changelog: [Internal]

Differential Revision: D119171908


