### PR TITLE
Use a variable for the Maestro Cloud project ID

### DIFF
--- a/.github/workflows/maestro-cloud-rntester.yml
+++ b/.github/workflows/maestro-cloud-rntester.yml
@@ -33,8 +33,6 @@ on:
     secrets:
       MAESTRO_CLOUD_API_KEY:
         required: true
-      MAESTRO_CLOUD_PROJECT_ID:
-        required: true
 
 jobs:
   test:
@@ -55,7 +53,7 @@ jobs:
         env:
           MAESTRO_APP_FILE: ${{ inputs.app-file }}
           MAESTRO_CLOUD_API_KEY: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-          MAESTRO_CLOUD_PROJECT_ID: ${{ secrets.MAESTRO_CLOUD_PROJECT_ID }}
+          MAESTRO_CLOUD_PROJECT_ID: ${{ vars.MAESTRO_CLOUD_PROJECT_ID }}
         run: |
           test -e "$MAESTRO_APP_FILE"
           test -n "$MAESTRO_CLOUD_API_KEY"
@@ -65,7 +63,7 @@ jobs:
         uses: mobile-dev-inc/action-maestro-cloud@5759506b4ec7ee0a1ece4b7e6574bba2b282f241 # v3.0.1
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
-          project-id: ${{ secrets.MAESTRO_CLOUD_PROJECT_ID }}
+          project-id: ${{ vars.MAESTRO_CLOUD_PROJECT_ID }}
           app-file: ${{ inputs.app-file }}
           workspace: packages/rn-tester/.maestro
           branch: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Summary:

Read the Maestro Cloud project ID from a GitHub Actions variable instead of a secret. Project IDs are identifiers rather than credentials, and secret masking currently redacts the project ID inside Maestro Cloud console URLs, making those links invalid. The API key remains a secret.

The `MAESTRO_CLOUD_PROJECT_ID` repository variable has already been configured.

## Changelog:

[INTERNAL] [FIXED] - Preserve Maestro Cloud console URLs in GitHub Actions logs

## Test Plan:

- `git diff --check` — passed
- `./node_modules/.bin/prettier --check .github/workflows/maestro-cloud-rntester.yml` — passed
- Verified `MAESTRO_CLOUD_PROJECT_ID` is available as a repository Actions variable