### PR TITLE
Exclude regenerator-runtime from production bundles

### DIFF
--- a/packages/react-native/Libraries/Core/setUpRegeneratorRuntime.js
+++ b/packages/react-native/Libraries/Core/setUpRegeneratorRuntime.js
@@ -18,29 +18,33 @@ const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
  * You can use this module directly, or just require InitializeCore.
  */
 
-let hasNativeGenerator;
-try {
-  // If this function was lowered by regenerator-transform, it will try to
-  // access `global.regeneratorRuntime` which doesn't exist yet and will throw.
-  hasNativeGenerator = hasNativeConstructor(
-    function* () {},
-    'GeneratorFunction',
-  );
-} catch {
-  // In this case, we know generators are not provided natively.
-  hasNativeGenerator = false;
-}
+// The preset only lowers generators in development builds, so the runtime is
+// only needed there. Gating on __DEV__ keeps it out of production bundles.
+if (__DEV__) {
+  let hasNativeGenerator;
+  try {
+    // If this function was lowered by regenerator-transform, it will try to
+    // access `global.regeneratorRuntime` which doesn't exist yet and will throw.
+    hasNativeGenerator = hasNativeConstructor(
+      function* () {},
+      'GeneratorFunction',
+    );
+  } catch {
+    // In this case, we know generators are not provided natively.
+    hasNativeGenerator = false;
+  }
 
-// If generators are provided natively, which suggests that there was no
-// regenerator-transform, then there is no need to set up the runtime.
-if (!hasNativeGenerator) {
-  polyfillGlobal('regeneratorRuntime', () => {
-    // The require just sets up the global, so make sure when we first
-    // invoke it the global does not exist
-    delete global.regeneratorRuntime;
+  // If generators are provided natively, which suggests that there was no
+  // regenerator-transform, then there is no need to set up the runtime.
+  if (!hasNativeGenerator) {
+    polyfillGlobal('regeneratorRuntime', () => {
+      // The require just sets up the global, so make sure when we first
+      // invoke it the global does not exist
+      delete global.regeneratorRuntime;
 
-    // regenerator-runtime/runtime exports the regeneratorRuntime object, so we
-    // can return it safely.
-    return require('regenerator-runtime/runtime'); // flowlint-line untyped-import:off
-  });
+      // regenerator-runtime/runtime exports the regeneratorRuntime object, so we
+      // can return it safely.
+      return require('regenerator-runtime/runtime'); // flowlint-line untyped-import:off
+    });
+  }
 }


### PR DESCRIPTION
## Summary:

`setUpRegeneratorRuntime` probes whether generators are native and only installs `regeneratorRuntime` when they are not. That decision happens at runtime, but the `require('regenerator-runtime/runtime')` inside it is resolved statically, so Metro follows the edge and the runtime ships in every release bundle. The branch is dead there: `@react-native/babel-preset` only enables `regenerator-transform` when `isHermesProfile && dev`, and Hermes and JSC provide native generators, so the probe always returns `true` in release and the polyfill is never installed.

This wraps the probe and the polyfill in `if (__DEV__)`. `__DEV__` is inlined to `false` and the block is constant-folded away before dependency collection, so the module leaves the production graph. Development builds are unchanged. The same pattern is already used for `setUpReactDevTools` in the same setup sequence.

```diff
 setUpRegeneratorRuntime.js
+if (__DEV__) {
   let hasNativeGenerator = hasNativeConstructor(function* () {}, ...)
   if (!hasNativeGenerator) {
     polyfillGlobal('regeneratorRuntime', () => require('regenerator-runtime/runtime'))
   }
+}
```

Release bundle of `private/helloworld` (`dev=false`, `minify=true`). The `regenerator-runtime/runtime` module accounts for 6,657 B of minified output on each platform, attributed from the source map.

| bundle | main | this change | delta |
| --- | ---: | ---: | ---: |
| iOS, minified | 857.86 KB | 850.83 KB | -7.03 KB |
| iOS, minified + gzip | 206.76 KB | 204.40 KB | -2.36 KB |
| Android, minified | 861.64 KB | 854.61 KB | -7.03 KB |
| Android, minified + gzip | 208.11 KB | 205.75 KB | -2.36 KB |

The gate is inside the module rather than at its call site in `setUpDefaultReactNativeEnvironment`, so requiring `setUpRegeneratorRuntime` directly in a release build is now a no-op. A build whose own Babel configuration lowers generators in release relied on that path and will need to require `regenerator-runtime/runtime` itself; the React Native preset never lowers generators in release.

## Changelog:

[GENERAL] [CHANGED] - Exclude `regenerator-runtime` from production bundles.

## Test Plan:

- `yarn test packages/react-native/Libraries/Core` — 3 suites, 93 tests passed.
- `yarn flow-check` — 0 errors.
- `yarn eslint packages/react-native/Libraries/Core/setUpRegeneratorRuntime.js`, `prettier --check` on the file, and `git diff --check` — clean.
- Release bundles for `ios` and `android`, before and after: table above. A `dev: true` bundle still contains `regenerator-runtime/runtime`.
- Fantom: CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
