### PR TITLE
Use current PR state in analyze workflow

### DIFF
--- a/.github/workflows/analyze-pr.yml
+++ b/.github/workflows/analyze-pr.yml
@@ -25,7 +25,12 @@ jobs:
         with:
           script: |
             const validatePRBody = require('./.github/workflow-scripts/validatePRBody.js');
-            const {message, status} = validatePRBody(context.payload.pull_request.body);
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const {message, status} = validatePRBody(pullRequest.body);
             core.setOutput('message', message);
             core.setOutput('status', status);
       - name: Check branch target
@@ -34,8 +39,14 @@ jobs:
         with:
           script: |
             const checkBranchTarget = require('./.github/workflow-scripts/checkBranchTarget.js');
-            const baseRef = context.payload.pull_request.base.ref;
-            const {message, status, shouldAddPickLabel} = checkBranchTarget(baseRef);
+            const {data: pullRequest} = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const {message, status, shouldAddPickLabel} = checkBranchTarget(
+              pullRequest.base.ref,
+            );
 
             if (shouldAddPickLabel) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## Summary:

The Analyze Pull Request workflow validates `context.payload.pull_request`, which is the event snapshot saved when a workflow run was created. Rerunning an old run after the PR description or base branch changes therefore validates stale state and can replace a passing check with an incorrect failure.

Fetch the current pull request through `github.rest.pulls.get` before validating its body and base branch so new runs and reruns behave consistently.

## Changelog:

[INTERNAL]

## Test Plan:

- `git diff --check`
- Parsed `.github/workflows/analyze-pr.yml` with Ruby YAML.
- Executed both embedded `github-script` blocks with a mocked valid live PR and stale invalid event payload; both used the live state and passed.
- Executed both blocks with an invalid live PR and valid stale event payload; both used the live state and failed.
- Full repository formatting could not run locally because Yarn package downloads repeatedly failed through the environment proxy with HTTP 503.