### PR TITLE
Remove `bridgelessEnabled` from `DefaultNewArchitectureEntryPoint` (#58415)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1768,7 +1768,6 @@ public final class com/facebook/react/defaults/DefaultComponentsRegistry {
 
 public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultNewArchitectureEntryPoint;
-	public static final fun getBridgelessEnabled ()Z
 	public static final fun getConcurrentReactEnabled ()Z
 	public static final fun getFabricEnabled ()Z
 	public final fun getReleaseLevel ()Lcom/facebook/react/common/ReleaseLevel;
@@ -1776,10 +1775,8 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load ()V
 	public static final fun load (Z)V
 	public static final fun load (ZZ)V
-	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZILjava/lang/Object;)V
 	public static synthetic fun load$default (ZZILjava/lang/Object;)V
-	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
 	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -40,50 +40,34 @@ public object DefaultNewArchitectureEntryPoint {
    */
   @JvmStatic
   public fun load() {
-    load(turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
+    load(turboModulesEnabled = true, fabricEnabled = true)
   }
 
   @JvmStatic
   @Deprecated(
       message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
+          "Loading the entry point with different flags for Fabric and TurboModule is deprecated." +
+              " Please use load() instead when loading the New Architecture.",
       replaceWith = ReplaceWith("load()"),
   )
   public fun load(
       turboModulesEnabled: Boolean = true,
   ) {
-    load(turboModulesEnabled, fabricEnabled = true, bridgelessEnabled = true)
+    load(turboModulesEnabled, fabricEnabled = true)
   }
 
   @JvmStatic
   @Deprecated(
       message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
-      replaceWith = ReplaceWith("load()"),
-  )
-  public fun load(
-      turboModulesEnabled: Boolean = true,
-      fabricEnabled: Boolean = true,
-  ) {
-    load(turboModulesEnabled, fabricEnabled, bridgelessEnabled = true)
-  }
-
-  @JvmStatic
-  @Deprecated(
-      message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
+          "Loading the entry point with different flags for Fabric and TurboModule is deprecated." +
+              " Please use load() instead when loading the New Architecture.",
       replaceWith = ReplaceWith("load()"),
   )
   public fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
-      bridgelessEnabled: Boolean = true,
   ) {
-    val (isValid, errorMessage) =
-        isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
+    val (isValid, errorMessage) = isConfigurationValid(turboModulesEnabled, fabricEnabled)
     if (!isValid) {
       error(errorMessage)
     }
@@ -103,7 +87,6 @@ public object DefaultNewArchitectureEntryPoint {
     }
 
     privateTurboModulesEnabled = turboModulesEnabled
-    privateBridgelessEnabled = bridgelessEnabled
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }
@@ -113,17 +96,6 @@ public object DefaultNewArchitectureEntryPoint {
     ReactNativeFeatureFlags.override(featureFlags)
 
     privateTurboModulesEnabled = true
-    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
-
-    val (isValid, errorMessage) =
-        isConfigurationValid(
-            privateTurboModulesEnabled,
-            true,
-            privateBridgelessEnabled,
-        )
-    if (!isValid) {
-      error(errorMessage)
-    }
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }
@@ -142,24 +114,17 @@ public object DefaultNewArchitectureEntryPoint {
   public val concurrentReactEnabled: Boolean
     get() = true
 
-  private var privateBridgelessEnabled: Boolean = false
-
-  @JvmStatic
-  public val bridgelessEnabled: Boolean
-    get() = privateBridgelessEnabled
-
   @VisibleForTesting
   public fun isConfigurationValid(
       turboModulesEnabled: Boolean,
       fabricEnabled: Boolean,
-      bridgelessEnabled: Boolean,
   ): Pair<Boolean, String> =
-      if (!turboModulesEnabled || !fabricEnabled || !bridgelessEnabled) {
+      if (!turboModulesEnabled || !fabricEnabled) {
         false to
             "You cannot load React Native with the New Architecture disabled. " +
                 "Please use DefaultNewArchitectureEntryPoint.load() instead of " +
                 "DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=$turboModulesEnabled, " +
-                "fabricEnabled=$fabricEnabled, bridgelessEnabled=$bridgelessEnabled)"
+                "fabricEnabled=$fabricEnabled)"
       } else {
         true to ""
       }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -18,27 +18,11 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false,
             fabricEnabled = false,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=false, bridgelessEnabled=false)",
-        )
-  }
-
-  @Test
-  fun isConfigurationValid_withNewArchOnlyOn_returnsFalse() {
-    val (isValid, errorMessage) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = true,
-            fabricEnabled = true,
-            bridgelessEnabled = false,
-        )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=true, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=false)",
         )
   }
 
@@ -48,24 +32,12 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
             fabricEnabled = false,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false)",
         )
-  }
-
-  @Test
-  fun isConfigurationValid_withBridgelessOn_returnsTrue() {
-    val (isValid, _) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = true,
-            fabricEnabled = true,
-            bridgelessEnabled = true,
-        )
-    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -74,42 +46,21 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false,
             fabricEnabled = true,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true)",
         )
   }
 
   @Test
-  fun isConfigurationValid_withBridgelessWithoutTurboModules_returnsFalse() {
-    val (isValid, errorMessage) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = false,
-            fabricEnabled = true,
-            bridgelessEnabled = true,
-        )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=true)",
-        )
-  }
-
-  @Test
-  fun isConfigurationValid_withBridgelessWithoutFabric_returnsFalse() {
-    val (isValid, errorMessage) =
+  fun isConfigurationValid_withEverythingOn_returnsTrue() {
+    val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
-            fabricEnabled = false,
-            bridgelessEnabled = true,
+            fabricEnabled = true,
         )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=true)",
-        )
+    assertThat(isValid).isTrue()
   }
 }


### PR DESCRIPTION
Summary:

Bridgeless is the only supported mode in the New Architecture, so the
`bridgelessEnabled` flag on `DefaultNewArchitectureEntryPoint` was dead
configuration: every `load(...)` path passed `true`, and `isConfigurationValid`
raised an error when it was `false`. The entry point advertised a toggle that
could only ever hold the one value that is already mandatory.

This removes that surface from `ReactAndroid`:

- Removed the public `bridgelessEnabled` getter and its backing field.
- Removed the deprecated three-argument
  `load(turboModulesEnabled, fabricEnabled, bridgelessEnabled)` overload. Its
  implementation body moved into the two-argument overload, since dropping the
  parameter alone would have collided with the existing
  `load(Boolean, Boolean)` signature.
- Removed the `bridgelessEnabled` parameter from `isConfigurationValid`,
  reducing the guard to `!turboModulesEnabled || !fabricEnabled` and shortening
  the resulting error message.
- `loadWithFeatureFlags` no longer reads `enableBridgelessArchitecture()`.

Behavior note: `loadWithFeatureFlags` previously raised an error when a feature
flags provider returned `enableBridgelessArchitecture() == false`. That check is
gone. It was unreachable in practice because bridgeless is not optional, but it
is a removed validation rather than a pure no-op cleanup.

Bridgeless remains unconditionally enabled. Callers using the no-argument
`load()` are unaffected. The regenerated `ReactAndroid.api` drops exactly
`getBridgelessEnabled ()Z`, `load (ZZZ)V`, and
`load$default (ZZZILjava/lang/Object;)V`.

The equivalent iOS cleanup is intentionally left to a follow-up change.

Changelog:
[Android][Breaking] - Remove `DefaultNewArchitectureEntryPoint.bridgelessEnabled` and the deprecated three-argument `load(turboModulesEnabled, fabricEnabled, bridgelessEnabled)` overload; bridgeless is always enabled in the New Architecture

Reviewed By: rubennorte

Differential Revision: D116317210


