### PR TITLE
Remove `bridgelessEnabled` from `RCTRootViewFactoryConfiguration` (#58416)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -116,11 +116,6 @@
   return YES;
 }
 
-- (BOOL)bridgelessEnabled
-{
-  return YES;
-}
-
 - (BOOL)fabricEnabled
 {
   return YES;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -289,10 +289,7 @@ static NSDictionary *RCTConvertConnectionOptionsToLaunchOptions(UISceneConnectio
   };
 
   RCTRootViewFactoryConfiguration *configuration =
-      [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock
-                                                       newArchEnabled:YES
-                                                   turboModuleEnabled:YES
-                                                    bridgelessEnabled:YES];
+      [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock newArchEnabled:YES];
 
   configuration.customizeRootView = ^(UIView *_Nonnull rootView) {
     [weakSelf.delegate customizeRootView:(RCTRootView *)rootView];

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -46,9 +46,6 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
 /// This property controls whether the App will use the Fabric renderer of the New Architecture or not.
 @property (nonatomic, assign, readonly) BOOL fabricEnabled;
 
-/// This property controls whether React Native's new initialization layer is enabled.
-@property (nonatomic, assign, readonly) BOOL bridgelessEnabled;
-
 /// This method controls whether the `turboModules` feature of the New Architecture is turned on or off
 @property (nonatomic, assign, readonly) BOOL turboModuleEnabled;
 
@@ -64,16 +61,6 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * pointing to a path inside the app resources, e.g. `file://.../main.jsbundle`.
  *
  */
-- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
-                        newArchEnabled:(BOOL)newArchEnabled
-                    turboModuleEnabled:(BOOL)turboModuleEnabled
-                     bridgelessEnabled:(BOOL)bridgelessEnabled __deprecated;
-
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL
-                   newArchEnabled:(BOOL)newArchEnabled
-               turboModuleEnabled:(BOOL)turboModuleEnabled
-                bridgelessEnabled:(BOOL)bridgelessEnabled __deprecated;
-
 - (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
                         newArchEnabled:(BOOL)newArchEnabled NS_DESIGNATED_INITIALIZER;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -42,37 +42,12 @@
   return [self initWithBundleURLBlock:bundleURLBlock];
 }
 
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL
-                   newArchEnabled:(BOOL)newArchEnabled
-               turboModuleEnabled:(BOOL)turboModuleEnabled
-                bridgelessEnabled:(BOOL)bridgelessEnabled
-{
-  return [self initWithBundleURLBlock:^{
-    return bundleURL;
-  }];
-}
-
-- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
-                        newArchEnabled:(BOOL)newArchEnabled
-                    turboModuleEnabled:(BOOL)turboModuleEnabled
-                     bridgelessEnabled:(BOOL)bridgelessEnabled
-{
-  if (self = [super init]) {
-    _bundleURLBlock = bundleURLBlock;
-    _fabricEnabled = YES;
-    _turboModuleEnabled = YES;
-    _bridgelessEnabled = YES;
-  }
-  return self;
-}
-
 - (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
 {
   if (self = [super init]) {
     _bundleURLBlock = bundleURLBlock;
     _fabricEnabled = YES;
     _turboModuleEnabled = YES;
-    _bridgelessEnabled = YES;
   }
   return self;
 }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1768,7 +1768,6 @@ public final class com/facebook/react/defaults/DefaultComponentsRegistry {
 
 public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultNewArchitectureEntryPoint;
-	public static final fun getBridgelessEnabled ()Z
 	public static final fun getConcurrentReactEnabled ()Z
 	public static final fun getFabricEnabled ()Z
 	public final fun getReleaseLevel ()Lcom/facebook/react/common/ReleaseLevel;
@@ -1776,10 +1775,8 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load ()V
 	public static final fun load (Z)V
 	public static final fun load (ZZ)V
-	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZILjava/lang/Object;)V
 	public static synthetic fun load$default (ZZILjava/lang/Object;)V
-	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
 	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -40,50 +40,34 @@ public object DefaultNewArchitectureEntryPoint {
    */
   @JvmStatic
   public fun load() {
-    load(turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
+    load(turboModulesEnabled = true, fabricEnabled = true)
   }
 
   @JvmStatic
   @Deprecated(
       message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
+          "Loading the entry point with different flags for Fabric and TurboModule is deprecated." +
+              " Please use load() instead when loading the New Architecture.",
       replaceWith = ReplaceWith("load()"),
   )
   public fun load(
       turboModulesEnabled: Boolean = true,
   ) {
-    load(turboModulesEnabled, fabricEnabled = true, bridgelessEnabled = true)
+    load(turboModulesEnabled, fabricEnabled = true)
   }
 
   @JvmStatic
   @Deprecated(
       message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
-      replaceWith = ReplaceWith("load()"),
-  )
-  public fun load(
-      turboModulesEnabled: Boolean = true,
-      fabricEnabled: Boolean = true,
-  ) {
-    load(turboModulesEnabled, fabricEnabled, bridgelessEnabled = true)
-  }
-
-  @JvmStatic
-  @Deprecated(
-      message =
-          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
-              "Please use load() instead when loading the New Architecture.",
+          "Loading the entry point with different flags for Fabric and TurboModule is deprecated." +
+              " Please use load() instead when loading the New Architecture.",
       replaceWith = ReplaceWith("load()"),
   )
   public fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,
-      bridgelessEnabled: Boolean = true,
   ) {
-    val (isValid, errorMessage) =
-        isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
+    val (isValid, errorMessage) = isConfigurationValid(turboModulesEnabled, fabricEnabled)
     if (!isValid) {
       error(errorMessage)
     }
@@ -103,7 +87,6 @@ public object DefaultNewArchitectureEntryPoint {
     }
 
     privateTurboModulesEnabled = turboModulesEnabled
-    privateBridgelessEnabled = bridgelessEnabled
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }
@@ -113,17 +96,6 @@ public object DefaultNewArchitectureEntryPoint {
     ReactNativeFeatureFlags.override(featureFlags)
 
     privateTurboModulesEnabled = true
-    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
-
-    val (isValid, errorMessage) =
-        isConfigurationValid(
-            privateTurboModulesEnabled,
-            true,
-            privateBridgelessEnabled,
-        )
-    if (!isValid) {
-      error(errorMessage)
-    }
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }
@@ -142,24 +114,17 @@ public object DefaultNewArchitectureEntryPoint {
   public val concurrentReactEnabled: Boolean
     get() = true
 
-  private var privateBridgelessEnabled: Boolean = false
-
-  @JvmStatic
-  public val bridgelessEnabled: Boolean
-    get() = privateBridgelessEnabled
-
   @VisibleForTesting
   public fun isConfigurationValid(
       turboModulesEnabled: Boolean,
       fabricEnabled: Boolean,
-      bridgelessEnabled: Boolean,
   ): Pair<Boolean, String> =
-      if (!turboModulesEnabled || !fabricEnabled || !bridgelessEnabled) {
+      if (!turboModulesEnabled || !fabricEnabled) {
         false to
             "You cannot load React Native with the New Architecture disabled. " +
                 "Please use DefaultNewArchitectureEntryPoint.load() instead of " +
                 "DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=$turboModulesEnabled, " +
-                "fabricEnabled=$fabricEnabled, bridgelessEnabled=$bridgelessEnabled)"
+                "fabricEnabled=$fabricEnabled)"
       } else {
         true to ""
       }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -18,27 +18,11 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false,
             fabricEnabled = false,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=false, bridgelessEnabled=false)",
-        )
-  }
-
-  @Test
-  fun isConfigurationValid_withNewArchOnlyOn_returnsFalse() {
-    val (isValid, errorMessage) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = true,
-            fabricEnabled = true,
-            bridgelessEnabled = false,
-        )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=true, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=false)",
         )
   }
 
@@ -48,24 +32,12 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
             fabricEnabled = false,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false)",
         )
-  }
-
-  @Test
-  fun isConfigurationValid_withBridgelessOn_returnsTrue() {
-    val (isValid, _) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = true,
-            fabricEnabled = true,
-            bridgelessEnabled = true,
-        )
-    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -74,42 +46,21 @@ class DefaultNewArchitectureEntryPointTest {
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false,
             fabricEnabled = true,
-            bridgelessEnabled = false,
         )
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=false)",
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true)",
         )
   }
 
   @Test
-  fun isConfigurationValid_withBridgelessWithoutTurboModules_returnsFalse() {
-    val (isValid, errorMessage) =
-        DefaultNewArchitectureEntryPoint.isConfigurationValid(
-            turboModulesEnabled = false,
-            fabricEnabled = true,
-            bridgelessEnabled = true,
-        )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=true)",
-        )
-  }
-
-  @Test
-  fun isConfigurationValid_withBridgelessWithoutFabric_returnsFalse() {
-    val (isValid, errorMessage) =
+  fun isConfigurationValid_withEverythingOn_returnsTrue() {
+    val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
-            fabricEnabled = false,
-            bridgelessEnabled = true,
+            fabricEnabled = true,
         )
-    assertThat(isValid).isFalse()
-    assertThat(errorMessage)
-        .isEqualTo(
-            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=true)",
-        )
+    assertThat(isValid).isTrue()
   }
 }

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1697,14 +1697,11 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL bridgelessEnabled;
   public @property (assign, readonly) BOOL fabricEnabled;
   public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURL:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(NSURL* bundleURL, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1696,14 +1696,11 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL bridgelessEnabled;
   public @property (assign, readonly) BOOL fabricEnabled;
   public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURL:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(NSURL* bundleURL, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1697,14 +1697,11 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL bridgelessEnabled;
   public @property (assign, readonly) BOOL fabricEnabled;
   public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURL:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(NSURL* bundleURL, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:turboModuleEnabled:bridgelessEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled, BOOL turboModuleEnabled, BOOL bridgelessEnabled);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {


### PR DESCRIPTION
Summary:

Follow-up to the Android change in the previous diff, applying the same cleanup
to iOS.

Bridgeless is the only supported mode, so the `bridgelessEnabled` surface on
`RCTRootViewFactoryConfiguration` was already deprecated and hardcoded: the
property was assigned `YES` in every initializer, the two deprecated
initializers ignored the argument entirely, and
`RCTDefaultReactNativeFactoryDelegate` returned `YES` unconditionally. Nothing
read the value.

Changes:

- Removed the `bridgelessEnabled` property from
  `RCTRootViewFactoryConfiguration`.
- Removed the two deprecated initializers
  `initWithBundleURLBlock:newArchEnabled:turboModuleEnabled:bridgelessEnabled:`
  and `initWithBundleURL:newArchEnabled:turboModuleEnabled:bridgelessEnabled:`.
  Both were marked `__deprecated` and discarded all arguments except the bundle
  URL, delegating to the designated initializer.
- Removed the `bridgelessEnabled` method from
  `RCTDefaultReactNativeFactoryDelegate`. It was not declared in any header or
  protocol.
- Updated the one caller in `RCTReactNativeFactory` to use
  `initWithBundleURLBlock:newArchEnabled:`.

Behavior is unchanged: bridgeless remains unconditionally enabled. Callers of
the designated `initWithBundleURLBlock:newArchEnabled:` and
`initWithBundleURL:newArchEnabled:` initializers are unaffected.

Changelog:
[iOS][Breaking] - Remove the deprecated `bridgelessEnabled` property and the deprecated `initWithBundleURLBlock:newArchEnabled:turboModuleEnabled:bridgelessEnabled:` / `initWithBundleURL:newArchEnabled:turboModuleEnabled:bridgelessEnabled:` initializers from `RCTRootViewFactoryConfiguration`; bridgeless is always enabled

Reviewed By: rubennorte

Differential Revision: D116318829


