### PR TITLE
Fix "Cannot read property 'canonical' of undefined" in Fabric getListener when event target is not a live fiber

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -996,7 +996,7 @@ __DEV__ &&
     }
     function getListener$1(inst, registrationName) {
       inst = inst.stateNode;
-      if (null === inst) return null;
+      if (null == inst) return null;
       inst = getFiberCurrentPropsFromNode$1(inst);
       if (null === inst) return null;
       if ((inst = inst[registrationName]) && "function" !== typeof inst)
@@ -1136,7 +1136,7 @@ __DEV__ &&
     }
     function getListener(inst, registrationName) {
       inst = inst.stateNode;
-      if (null === inst) return null;
+      if (null == inst) return null;
       inst = getFiberCurrentPropsFromNode$1(inst);
       if (null === inst) return null;
       if ((inst = inst[registrationName]) && "function" !== typeof inst)

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -672,7 +672,7 @@ function traverseTwoPhase$1(inst, fn, arg) {
 }
 function getListener$1(inst, registrationName) {
   inst = inst.stateNode;
-  if (null === inst) return null;
+  if (null == inst) return null;
   inst = getFiberCurrentPropsFromNode$1(inst);
   if (null === inst) return null;
   if ((inst = inst[registrationName]) && "function" !== typeof inst)
@@ -1086,7 +1086,7 @@ var plugins = [],
   registrationNameModules = {};
 function getListener(inst, registrationName) {
   inst = inst.stateNode;
-  if (null === inst) return null;
+  if (null == inst) return null;
   inst = getFiberCurrentPropsFromNode$1(inst);
   if (null === inst) return null;
   if ((inst = inst[registrationName]) && "function" !== typeof inst)

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -737,7 +737,7 @@ function traverseTwoPhase$1(inst, fn, arg) {
 }
 function getListener$1(inst, registrationName) {
   inst = inst.stateNode;
-  if (null === inst) return null;
+  if (null == inst) return null;
   inst = getFiberCurrentPropsFromNode$1(inst);
   if (null === inst) return null;
   if ((inst = inst[registrationName]) && "function" !== typeof inst)
@@ -1151,7 +1151,7 @@ var plugins = [],
   registrationNameModules = {};
 function getListener(inst, registrationName) {
   inst = inst.stateNode;
-  if (null === inst) return null;
+  if (null == inst) return null;
   inst = getFiberCurrentPropsFromNode$1(inst);
   if (null === inst) return null;
   if ((inst = inst[registrationName]) && "function" !== typeof inst)


### PR DESCRIPTION
## Summary:

Fixes a production crash in the Fabric legacy event system:

```
    TypeError: Cannot read property 'canonical' of undefined
      at getListener (ReactFabric-dev.js:997)
```

`getListener` guards the fiber's `stateNode` with a strict null check:

```js
inst = inst.stateNode;
if (null === inst) return null;
inst = getFiberCurrentPropsFromNode(inst); // → instance.canonical.currentProps
```

Inside the reconciler this is sufficient — `stateNode` is initialized to `null` in the
`FiberNode` constructor, reset to `null` in `detachFiberAfterEffects` (including the
alternate), and only ever assigned instance objects in `completeWork` — so `undefined`
cannot be produced by React itself.

However, the responder event path receives its target from **native dispatch across the
JSI boundary**. The instance handle is stored natively as a weak reference
(`EventTarget`/`InstanceHandle`, where a dead `jsi::WeakObject::lock()` yields
`undefined` rather than `null`), so when a touch is delivered for a view that unmounted
mid-gesture (screen transition on press, sheet dismissal, list cell recycling), the
target reaching the plugins is no longer guaranteed to be a live host fiber. Reading
`.stateNode` on such a target yields `undefined`, which passes the strict `=== null`
check and crashes one line later in `getFiberCurrentPropsFromNode` with the error above.

This change loosens the check to `null == inst`, matching the guards already used at the
other entry points of the same pipeline (`null != target` in `dispatchEvent`,
`null == targetInst` in `ReactNativeBridgeEventPlugin.extractEvents`). With the guard,
the event for a dead target is dropped instead of throwing.

We are seeing this crash in production (React Native 0.84.0, Hermes, new architecture)
reported to Sentry as an unhandled error, correlated with touches during unmount.

Note: `ReactFabric-{dev,prod,profiling}.js` are generated bundles synced from
facebook/react — the source counterpart of this fix is
`packages/react-native-renderer/src/ReactNativeGetListener.js` (and its inlined copy in
`ResponderEventPlugin`). Happy to redirect this patch there if that is the preferred
route; filing here first since the crash manifests in React Native releases.

## Changelog:

[GENERAL] [FIXED] - Fix "Cannot read property 'canonical' of undefined" crash in Fabric event dispatch when a touch is delivered to a view unmounted mid-gesture

## Test Plan:

- Verified via code inspection that `undefined` cannot originate from the reconciler
  itself (`FiberNode` constructor, `detachFiberAfterEffects`, and every `stateNode`
  assignment in `completeWork` only ever produce an object or `null`), so the loosened
  check only affects out-of-contract targets coming from native dispatch — for which
  every sibling guard in this pipeline already uses loose null checks.
- The change is limited to the `stateNode` guard in the two inlined copies of
  `getListener` (responder plugin + plugin registry) in each of the three generated
  bundles; the subsequent props guard is untouched. `yarn jest react-native` passes.
- Reproduction scenario: start a touch on a pressable row and unmount it before the
  event is processed (e.g. navigation triggered by the same interaction, or a recycled
  list removing the row). Before this change the dispatch throws the TypeError above;
  after it, the stale touch is ignored.
