### PR TITLE
Correct three entries in the v0.88.0-rc.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,9 @@
 
 ### Breaking
 
-- **Touchable**: The `Touchable` root export (undocumented) is removed. If you are extending `Touchable` as a type, please use `ViewProps` instead. ([0015d1e4f9](https://github.com/react/react-native/commit/0015d1e4f9f812f775b9eb78e6da63beea7dc34c) by [@huntie](https://github.com/huntie))
-
 #### iOS specific
 
-- **TurboModules**: Add `RCTArrayBuffer`, the ObjC representation of a JS `ArrayBuffer` for TurboModules, with an explicit byte-ownership contract ([11f9a7f449](https://github.com/react/react-native/commit/11f9a7f4491eb1b01955298851d5a87a3bb311cc) by Kamil Paradowski)
+- **TurboModules**: Codegen now emits `RCTArrayBuffer *` for TurboModule methods taking or returning an `ArrayBuffer`, replacing `NSMutableData *`. Modules that adopted ObjC `ArrayBuffer` support in 0.87 stop compiling until they update ([11f9a7f449](https://github.com/react/react-native/commit/11f9a7f4491eb1b01955298851d5a87a3bb311cc) by Kamil Paradowski)
 
 ### Added
 
@@ -39,6 +37,7 @@
 - **TextInput**: Add `fontVariationSettings` support for `TextInput` ([a688608090](https://github.com/react/react-native/commit/a68860809024511ed7dae963aadba8eba4b0e73b) by [@evankatz14](https://github.com/evankatz14))
 - **TurboModules**: Add `ArrayBuffer`, the Java representation of a JS `ArrayBuffer` for TurboModules, with an explicit byte-ownership contract ([5bb9639594](https://github.com/react/react-native/commit/5bb9639594952de0893c22130eb0654b5c4594b5) by Kamil Paradowski)
 - **TurboModules**: Add ArrayBuffer support to Java TurboModules ([5fb3ebce1a](https://github.com/react/react-native/commit/5fb3ebce1ac4125e55f270a18dbc4f873b0eb09f) by Kamil Paradowski)
+- **TurboModules**: Borrowed `ArrayBuffer` bytes are scoped to the synchronous call that received them. `ArrayBuffer.bytes` and `ArrayBuffer.size` throw `IllegalStateException` afterwards, and a `ByteBuffer` already obtained from `bytes` is unchecked and reads freed memory, so copy with `ArrayBuffer.arrayBufferWithCopiedBytes` to keep them ([d84c13d511](https://github.com/react/react-native/commit/d84c13d5111eef037a196e8e9d5393cfb0d17982) by [@christophpurrer](https://github.com/christophpurrer))
 
 #### iOS specific
 
@@ -152,7 +151,6 @@
 - **Text**: Keep inline views inside Text from shrinking with Android system font scale ([551d12a787](https://github.com/react/react-native/commit/551d12a787f925aa0b9c7d7fa9a5703b28a64cbc) by [@TorinAsakura](https://github.com/TorinAsakura))
 - **TextInput**: Ellipsize long single-line TextInput placeholders to match iOS ([7f18ad0f84](https://github.com/react/react-native/commit/7f18ad0f8486bf90cc77c38ee1097250218f7f8e) by [@kosmydel](https://github.com/kosmydel))
 - **TextInput**: Show the soft keyboard when a long-press starts text selection in TextInput ([9195e52706](https://github.com/react/react-native/commit/9195e5270605e77d979d6e6bcdcb5a9d987545f1) by [@idoyana](https://github.com/idoyana))
-- **TurboModules**: TurboModule methods taking or returning an `ArrayBuffer` ([d84c13d511](https://github.com/react/react-native/commit/d84c13d5111eef037a196e8e9d5393cfb0d17982) by [@christophpurrer](https://github.com/christophpurrer))
 - **View**: Resetting border widths no longer clips children in rounded overflow-hidden views. ([146aaac7ee](https://github.com/react/react-native/commit/146aaac7eed016eb89e750cd2144f47806ee5863) by [@RealBhupesh](https://github.com/RealBhupesh))
 - **ViewManagers**: Fix `Double` prop defaults being rounded to float precision in generated `ViewManager` delegates ([2c4278d83b](https://github.com/react/react-native/commit/2c4278d83b2cf2de31d8d5a4d9f259e5cf0134f6) by [@dennytosp](https://github.com/dennytosp))
 - **ViewManagers**: Fix `RuntimeException: Unrecognized type: class com.facebook.yoga.YogaValue` when a `ViewManager` implements a `DimensionValue` prop with `ReactProp` ([091ac613ce](https://github.com/react/react-native/commit/091ac613cebafde540d9c1e56284d782029d3d35) by [@dennytosp](https://github.com/dennytosp))


### PR DESCRIPTION
Summary:
Three corrections to the `v0.88.0-rc.0` section of `CHANGELOG.md`.

1. Remove the `Touchable` root export entry. That removal already shipped in `v0.87.0` under a cherry-picked commit, so it is not new in 0.88 and its entry is a duplicate.

2. Reword the iOS `RCTArrayBuffer` entry. It sits under Breaking but read as a plain addition, which hid the part that actually breaks. Codegen now emits `RCTArrayBuffer *` for TurboModule methods taking or returning an `ArrayBuffer`, where 0.87 shipped `NSMutableData *` for both arguments and returns, so modules that adopted ObjC `ArrayBuffer` support in 0.87 stop compiling until they update. `RCTArrayBuffer` derives from `NSObject` rather than `NSData`, so there is no implicit conversion to soften the change.

3. Move the Android `ArrayBuffer` entry from Fixed to Added, and rewrite it. Its source commit carries two `Changelog:` blocks and the generator took the category from the first and the text from the second, leaving a sentence fragment with no verb. Java `ArrayBuffer` support is itself new in this release, so the use-after-free the commit hardens against never reached a published version and a Fixed entry would describe a bug no user experienced. The borrow contract is API semantics for a new type, so the entry now sits with the other two Java `ArrayBuffer` entries under Added.

Both rewritten entries are also tightened from three sentences to two. At 429 and 324 characters they were the two longest entries in the file; the longest is now 321, against a p90 of 149 for the section and a 406-character precedent in v0.87.0.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D119308634


