### PR TITLE
Do not fail superseded Maestro Cloud runs

### DIFF
--- a/.github/workflows/maestro-cloud-rntester.yml
+++ b/.github/workflows/maestro-cloud-rntester.yml
@@ -62,6 +62,8 @@ jobs:
           test -n "$MAESTRO_CLOUD_PROJECT_ID"
           test -z "$(find packages/rn-tester/.maestro -type l -print -quit)"
       - name: Run flows on Maestro Cloud
+        id: maestro-cloud
+        continue-on-error: true
         uses: mobile-dev-inc/action-maestro-cloud@5759506b4ec7ee0a1ece4b7e6574bba2b282f241 # v3.0.1
         with:
           api-key: ${{ secrets.MAESTRO_CLOUD_API_KEY }}
@@ -75,3 +77,15 @@ jobs:
             APP_ID=${{ inputs.app-id }}
           maestro-cli-version: 2.6.1
           timeout: 60
+      - name: Check Maestro Cloud result
+        if: always()
+        env:
+          MAESTRO_CLOUD_OUTCOME: ${{ steps.maestro-cloud.outcome }}
+          MAESTRO_CLOUD_UPLOAD_STATUS: ${{ steps.maestro-cloud.outputs.MAESTRO_CLOUD_UPLOAD_STATUS }}
+        run: |
+          if [[ "$MAESTRO_CLOUD_UPLOAD_STATUS" == "STOPPED" ]]; then
+            echo "::notice::Maestro Cloud run was superseded by a newer upload"
+          elif [[ "$MAESTRO_CLOUD_OUTCOME" == "failure" ]]; then
+            echo "::error::Maestro Cloud failed with status ${MAESTRO_CLOUD_UPLOAD_STATUS:-UNKNOWN}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary:

Treat Maestro Cloud uploads stopped by a newer upload as successfully superseded instead of failing the GitHub Actions job. The action still fails the job for test failures, timeouts, and errors, including failures where no upload status is available.

This allows the Maestro Cloud “Stop Previous Flows” setting to be re-enabled without creating failure tasks for intentionally superseded runs. Re-enabling that project setting remains a separate dashboard operation.

## Changelog:

[INTERNAL] [FIXED] - Do not fail CI when a Maestro Cloud run is superseded

## Test Plan:

- `git diff --check` — passed
- `./node_modules/.bin/prettier --check .github/workflows/maestro-cloud-rntester.yml` — passed
- Exercised the result gate for STOPPED, ERROR, missing-status failure, and SUCCESS outcomes — passed