### PR TITLE
Classify react/nativemodule/defaults as for-frameworks

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.h
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <react/cxxstableapi/PrivateGuard.h>
+#pragma once
+
+#include <react/cxxstableapi/FrameworksGuard.h>
 
 #include <ReactCommon/TurboModule.h>
 


### PR DESCRIPTION
Summary:
Reclassify `DefaultTurboModules.h` from the private C++ Stable API tier to the
"for frameworks" tier, and add the `#pragma once` the header was missing.

`DefaultTurboModules::getTurboModule` is the entry point out-of-tree platforms and
custom C++ hosts use to obtain React Native's core turbo modules. Its exported surface
is a single static function over `std::string`, `CallInvoker` and the `TurboModule` base
class, so it exposes no private type. The concrete `react/nativemodule/*`
implementations it delegates to all remain private.


Changelog: [Internal]

Differential Revision: D119326878


