### PR TITLE
Skip HMR client setup when bundle is not from Metro

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -162,6 +162,18 @@ const HMRClient: HMRClientNativeInterface = {
     invariant(host, 'Missing required parameter `host`');
     invariant(!hmrClient, 'Cannot initialize hmrClient twice');
 
+    // HMR requires a Metro-served bundle so the server can map source edits back
+    // to the running module set. When the bundle was loaded from a local file
+    // there's nothing to hot-reload — registering with the server would just log
+    // spurious "Unable to resolve module" errors.
+    if (!getDevServer().bundleLoadedFromServer) {
+      console.warn(
+        'Not enabling Hot Module Reloading: the JS bundle was loaded from a local ' +
+          'file, not from Metro. To use HMR, load the bundle from the packager.',
+      );
+      return;
+    }
+
     // Moving to top gives errors due to NativeModules not being initialized
     const DevLoadingView = require('./DevLoadingView').default;
 


### PR DESCRIPTION
Summary:
When the JS bundle is loaded from a local file (bundled with the app or restored from disk), `HMRClient.setup()` still runs during startup and registers an entry-point with the packager over the fallback `/hot?bundleEntry=...` URL. There is no coherent module map to hot-reload against, so the packager side logs an "Unable to resolve module" error.

Gate `setup()` on `getDevServer().bundleLoadedFromServer` and early-return with a `console.warn` when the bundle did not come from Metro. The user still sees why HMR is unavailable in this session, but the noisy resolver error goes away.

Changelog:
[General][Fixed] - Skip HMR client setup when the JS bundle was not loaded from Metro

Differential Revision: D110603320


