### PR TITLE
Fix check-for-reproducer never removing "Needs: Repro" once react-native-bot applied it

### DIFF
--- a/.github/workflow-scripts/__tests__/checkForReproducer-test.js
+++ b/.github/workflow-scripts/__tests__/checkForReproducer-test.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const checkForReproducer = require('../checkForReproducer');
+
+const AUTHOR = 'issue-author';
+const BOT = 'react-native-bot';
+const MAINTAINER = 'some-maintainer';
+
+function labelEvent(event, login, type, name = 'Needs: Repro') {
+  return {event, label: {name}, actor: {login, type}};
+}
+
+function buildGithub({body, comments = [], timeline = []}) {
+  return {
+    rest: {
+      issues: {
+        get: jest.fn().mockResolvedValue({
+          data: {
+            user: {login: AUTHOR},
+            created_at: '2026-01-01T00:00:00Z',
+            body,
+          },
+        }),
+        listComments: jest.fn().mockResolvedValue({data: comments}),
+        listEventsForTimeline: jest.fn().mockResolvedValue({data: timeline}),
+        removeLabel: jest.fn().mockResolvedValue({}),
+        addLabels: jest.fn().mockResolvedValue({}),
+      },
+    },
+  };
+}
+
+const context = {
+  payload: {issue: {number: 1}},
+  repo: {owner: 'react', repo: 'react-native'},
+};
+
+const REPRO_LINK = `Repro: https://github.com/${AUTHOR}/rn-repro`;
+
+describe('checkForReproducer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds "Needs: Repro" and "Needs: Author Feedback" when no reproducer is present', async () => {
+    const github = buildGithub({body: 'It crashes.'});
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.addLabels).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: ['Needs: Repro', 'Needs: Author Feedback'],
+      }),
+    );
+    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+  });
+
+  it('removes "Needs: Repro" when the author links a repository they own', async () => {
+    const github = buildGithub({body: REPRO_LINK});
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Needs: Repro'}),
+    );
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+  });
+
+  it('removes "Needs: Repro" after the author edits in a reproducer, even though react-native-bot applied the label', async () => {
+    const github = buildGithub({
+      body: REPRO_LINK,
+      timeline: [
+        labelEvent('labeled', BOT, 'User', 'Needs: Author Feedback'),
+        labelEvent('labeled', BOT, 'User'),
+        labelEvent(
+          'unlabeled',
+          'github-actions[bot]',
+          'Bot',
+          'Needs: Author Feedback',
+        ),
+      ],
+    });
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Needs: Repro'}),
+    );
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when a maintainer has changed the "Needs: Repro" label', async () => {
+    const github = buildGithub({
+      body: REPRO_LINK,
+      timeline: [
+        labelEvent('labeled', BOT, 'User'),
+        labelEvent('unlabeled', MAINTAINER, 'User'),
+        labelEvent('labeled', MAINTAINER, 'User'),
+      ],
+    });
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.removeLabel).not.toHaveBeenCalled();
+    expect(github.rest.issues.addLabels).not.toHaveBeenCalled();
+  });
+
+  it('ignores label changes on other labels when deciding whether a maintainer intervened', async () => {
+    const github = buildGithub({
+      body: REPRO_LINK,
+      timeline: [
+        labelEvent('labeled', BOT, 'User'),
+        labelEvent('labeled', MAINTAINER, 'User', 'Platform: iOS'),
+      ],
+    });
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Needs: Repro'}),
+    );
+  });
+
+  it('accepts a reproducer link posted in a comment by its own author', async () => {
+    const github = buildGithub({
+      body: 'It crashes.',
+      comments: [
+        {
+          user: {login: AUTHOR},
+          body: `Here you go: https://github.com/${AUTHOR}/rn-repro`,
+        },
+      ],
+      timeline: [labelEvent('labeled', BOT, 'User')],
+    });
+
+    await checkForReproducer(github, context);
+
+    expect(github.rest.issues.removeLabel).toHaveBeenCalledWith(
+      expect.objectContaining({name: 'Needs: Repro'}),
+    );
+  });
+});

--- a/.github/workflow-scripts/checkForReproducer.js
+++ b/.github/workflow-scripts/checkForReproducer.js
@@ -10,6 +10,8 @@
 const NEEDS_REPRO_LABEL = 'Needs: Repro';
 const NEEDS_AUTHOR_FEEDBACK_LABEL = 'Needs: Author Feedback';
 const SKIP_ISSUES_OLDER_THAN = '2023-07-01T00:00:00Z';
+// The account this workflow runs as; a user account, so actor.type is 'User'.
+const REACT_NATIVE_BOT_LOGIN = 'react-native-bot';
 
 module.exports = async (github, context) => {
   const issueData = {
@@ -82,16 +84,22 @@ function containsPattern(body, pattern) {
   return body.search(regexp) !== -1;
 }
 
-// Prevents the bot from responding when maintainer has changed the 'Needs: Repro' label
+// Prevents the bot from responding when a maintainer has changed the
+// 'Needs: Repro' label. Events from GitHub Apps and react-native-bot itself
+// are automation, not maintainer decisions.
 async function hasMaintainerChangedLabel(github, issueData, author) {
   const timeline = await github.rest.issues.listEventsForTimeline(issueData);
 
   const labeledEvents = timeline.data.filter(
     event => event.event === 'labeled' || event.event === 'unlabeled',
   );
-  const userEvents = labeledEvents.filter(event => event.actor.type !== 'Bot');
+  const maintainerEvents = labeledEvents.filter(
+    event =>
+      event.actor.type !== 'Bot' &&
+      event.actor.login !== REACT_NATIVE_BOT_LOGIN,
+  );
 
-  return userEvents.some(
+  return maintainerEvents.some(
     event =>
       event.actor.login !== author && event.label.name === NEEDS_REPRO_LABEL,
   );


### PR DESCRIPTION
## Summary:

`check-for-reproducer.yml` runs `checkForReproducer.js` on every issue edit so that, once an author adds a reproducer, the `Needs: Repro` label is removed. In practice the label is never removed, because the guard that is meant to defer to maintainers locks the bot out of its own label.

`hasMaintainerChangedLabel` treats every `labeled`/`unlabeled` event on `Needs: Repro` as a maintainer decision unless `actor.type === 'Bot'`. That only excludes GitHub Apps (e.g. `github-actions[bot]`). `react-native-bot` — the account this workflow runs as via `REACT_NATIVE_BOT_GITHUB_TOKEN` — is a regular user account, so its timeline events have `actor.type === 'User'`. The bot's own initial "labeled Needs: Repro" event therefore satisfies `actor.login !== author && label.name === 'Needs: Repro'`, the function returns `true`, and every subsequent run exits before looking for a reproducer.

Concrete example, https://github.com/react/react-native/issues/58427 (timeline via the REST API):

```
2026-09-09T17:07:59Z labeled   Needs: Repro           by react-native-bot    type=User
2026-09-09T17:12:17Z unlabeled Needs: Author Feedback by github-actions[bot] type=Bot
2026-09-09T17:12:18Z labeled   Needs: Attention       by github-actions[bot] type=Bot
```

The author edited a same-account GitHub repository link (created from `react-native-community/reproducer-react-native`) into the body; `check-for-reproducer` ran on each edit (runs 34381378212 and 34381697572, both green) and the label stayed. A sample of the 8 most recently updated open issues carrying `Needs: Repro` shows the same shape on all of them: the only `Needs: Repro` event is the bot's own `labeled`, with no removal ever recorded, and none of 12 recently closed `Needs: Repro` issues had the label removed by the bot either.

This PR makes `hasMaintainerChangedLabel` ignore events produced by `react-native-bot` in addition to GitHub Apps, so that only human label changes count as maintainer intervention. It adds a unit test for the script (there was none), covering: no reproducer → labels added; author repo link → label removed; bot-applied label + author edit → label removed (the regression); maintainer changed the label → no-op; unrelated label changes ignored; reproducer in a comment by its author.

## Changelog:

[INTERNAL] [FIXED] - Let `check-for-reproducer` remove `Needs: Repro` after the author adds a reproducer (the bot's own label no longer counts as a maintainer decision)

## Test Plan:

```
$ npx jest@29.7.0 --config '{"rootDir":".github/workflow-scripts","testRegex":"__tests__/checkForReproducer-test\\.js$","transform":{}}'
PASS .github/workflow-scripts/__tests__/checkForReproducer-test.js
  checkForReproducer
    ✓ adds "Needs: Repro" and "Needs: Author Feedback" when no reproducer is present
    ✓ removes "Needs: Repro" when the author links a repository they own
    ✓ removes "Needs: Repro" after the author edits in a reproducer, even though react-native-bot applied the label
    ✓ does nothing when a maintainer has changed the "Needs: Repro" label
    ✓ ignores label changes on other labels when deciding whether a maintainer intervened
    ✓ accepts a reproducer link posted in a comment by its own author

Tests:       6 passed, 6 total
```

With the script reverted to `main`, the three tests whose timeline contains the bot's own `labeled Needs: Repro` event fail (3 failed, 3 passed) because `hasMaintainerChangedLabel` returns `true`, confirming the test captures the regression. `prettier --check` (3.9.4, repo config) passes on both files.
