### PR TITLE
Require `BatchedBridge` lazily in `NativeModules`

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -11,9 +11,18 @@
 'use strict';
 
 import type {ExtendedError} from '../Core/ExtendedError';
+import typeof BatchedBridgeT from './BatchedBridge';
 
-const BatchedBridge = require('./BatchedBridge').default;
 const invariant = require('invariant');
+
+// Lazy-require to avoid loading the legacy bridge in bridgeless mode.
+let BatchedBridge: ?BatchedBridgeT = null;
+function getBatchedBridge(): BatchedBridgeT {
+  if (BatchedBridge == null) {
+    BatchedBridge = require('./BatchedBridge').default;
+  }
+  return BatchedBridge;
+}
 
 export type ModuleConfig = [
   string /* name */,
@@ -77,7 +86,7 @@ function genModule(
   }
 
   if (__DEV__) {
-    BatchedBridge.createDebugLookup(moduleID, moduleName, methods);
+    getBatchedBridge().createDebugLookup(moduleID, moduleName, methods);
   }
 
   return {name: moduleName, module};
@@ -106,7 +115,7 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
       // $FlowFixMe[incompatible-type]
       const enqueueingFrameError: ExtendedError = new Error();
       return new Promise((resolve, reject) => {
-        BatchedBridge.enqueueNativeCall(
+        getBatchedBridge().enqueueNativeCall(
           moduleID,
           methodID,
           args,
@@ -142,7 +151,7 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
       const callbackCount = hasSuccessCallback + hasErrorCallback;
       const newArgs = args.slice(0, args.length - callbackCount);
       if (type === 'sync') {
-        return BatchedBridge.callNativeSyncHook(
+        return getBatchedBridge().callNativeSyncHook(
           moduleID,
           methodID,
           newArgs,
@@ -150,7 +159,7 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
           onSuccess,
         );
       } else {
-        BatchedBridge.enqueueNativeCall(
+        getBatchedBridge().enqueueNativeCall(
           moduleID,
           methodID,
           newArgs,


### PR DESCRIPTION
## Summary:

`NativeModules` requires `BatchedBridge` at module scope, which constructs a `MessageQueue` and defines `global.__fbBatchedBridge`. In bridgeless mode the module resolves to `global.nativeModuleProxy` and the bridge is never read again: its only users are `genModule` and `genMethod`, which run from the `__fbBatchedBridgeConfig` branch or via `__fbGenNativeModule` from the legacy executor.

Bundles built with `inlineRequires` (the default in `@react-native/metro-config`) already defer this require. Bundles built without it, such as those from `@expo/metro-config`, evaluate `BatchedBridge` and `MessageQueue` at startup with no consumer. This moves the require into a cached getter, matching the `RN$Bridgeless` guards in `registerCallableModule` and `JSTimers`. Bridge mode is unchanged, and bundle size is unchanged since Metro still follows the require.

## Changelog:

[GENERAL] [CHANGED] - Require `BatchedBridge` lazily from `NativeModules` so bridgeless startup no longer instantiates `MessageQueue`.

## Test Plan:

- `yarn test packages/react-native/Libraries/BatchedBridge packages/react-native/Libraries/TurboModule packages/react-native/Libraries/Core packages/react-native/Libraries/ReactNative` — 6 suites, 102 tests passed.
- `yarn flow-check` — 0 errors. ESLint and Prettier clean on the file.
- `private/helloworld` dev bundle with `inlineRequires: false`, evaluated in a Node VM with bridgeless globals stubbed: 191 → 189 modules; `BatchedBridge.js` and `MessageQueue.js` no longer evaluate, nothing added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
