### PR TITLE
Make `react/renderer/components/image` public (#58437)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -173,6 +173,7 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/image/",
                           "react/renderer/components/image/",
                       ),
+                      Pair("../ReactCommon/react/renderer/components/image/React/", "React/"),
                       // rrc_view
                       Pair(
                           "../ReactCommon/react/renderer/components/view/",

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -43,12 +43,18 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files         = podspec_sources("react/renderer/components/image/**/*.{m,mm,cpp,h}", "react/renderer/components/image/**/*.h")
-  s.exclude_files        = "react/renderer/components/image/tests"
+  s.exclude_files        = ["react/renderer/components/image/tests", "react/renderer/components/image/React"]
   s.header_dir           = "react/renderer/components/image"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
                           }
+
+  s.subspec "imageUmbrella" do |ss|
+    ss.source_files        = "react/renderer/components/image/React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "react/renderer/components/image"
+  end
 
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_FabricImage")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB rrc_image_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_image OBJECT ${rrc_image_SRC})
 
 target_include_directories(rrc_image PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(rrc_image INTERFACE ${REACT_COMMON_DIR}/react/renderer/components/image)
 
 target_link_libraries(rrc_image
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/image/ImageShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/imagemanager/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/image/ImageEventEmitter.h>
 #include <react/renderer/components/image/ImageProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/image` module - public
+// entry point.
+//
+//   #include <React/Image.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/image/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/renderer/components/image/ImageComponentDescriptor.h>
+#include <react/renderer/components/image/ImageEventEmitter.h>
+#include <react/renderer/components/image/ImageProps.h>
+#include <react/renderer/components/image/ImageShadowNode.h>
+#include <react/renderer/components/image/ImageState.h>
+#include <react/renderer/components/image/conversions.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <unordered_map>
 

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -455,6 +455,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-FabricImage.podspec': {
+    name: 'React-FabricImage',
+    headerPatterns: ['react/renderer/components/image/**/*.h'],
+    excludePatterns: [
+      'react/renderer/components/image/tests',
+      'react/renderer/components/image/React',
+    ],
+    headerDir: 'react/renderer/components/image',
+    subSpecs: [
+      {
+        name: 'imageUmbrella',
+        headerPatterns: ['react/renderer/components/image/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'ReactCommon/React-Mapbuffer.podspec': {
     name: 'React-Mapbuffer',
     headerPatterns: ['react/renderer/mapbuffer/**/*.h'],


### PR DESCRIPTION
Summary:

Classifies `react/renderer/components/image:image` as a public target under the C++ stable API three-tier visibility model. Replaces the `FrameworksGuard.h` include in the module's 6 exported headers with `<react/cxxstableapi/UmbrellaGuard.h>` and introduces the module umbrella `React/Image.h`, wiring the umbrella into BUCK, CMake, CocoaPods, the iOS prebuild header config and the Android prefab export.

Changelog:
[General][Added] - Added umbrella header for the `react/renderer/components/image` module

Differential Revision: D119477736


