### PR TITLE
Make `react/renderer/imagemanager` public (#58438)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -173,6 +173,7 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/image/",
                           "react/renderer/components/image/",
                       ),
+                      Pair("../ReactCommon/react/renderer/components/image/React/", "React/"),
                       // rrc_view
                       Pair(
                           "../ReactCommon/react/renderer/components/view/",

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -157,7 +157,8 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/imagemanager/",
                           "react/renderer/imagemanager/",
                       ),
-                      Pair("../ReactCommon/react/renderer/imagemanager/platform/cxx/", ""),
+                      Pair("../ReactCommon/react/renderer/imagemanager/React/", "React/"),
+                      Pair("../ReactCommon/react/renderer/imagemanager/platform/android/", ""),
                       // react_renderer_mounting
                       Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
                       // react_renderer_scheduler

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -182,6 +182,12 @@ Pod::Spec.new do |s|
     ss.header_dir           = "react/renderer/imagemanager"
   end
 
+  s.subspec "imagemanagerUmbrella" do |ss|
+    ss.source_files         = "react/renderer/imagemanager/React/*.h"
+    ss.header_dir           = ""
+    ss.header_mappings_dir  = "react/renderer/imagemanager"
+  end
+
   s.subspec "mounting" do |ss|
     ss.dependency             "React-jsinspectortracing"
     ss.source_files         = podspec_sources("react/renderer/mounting/**/*.{m,mm,cpp,h}", "react/renderer/mounting/**/*.h")

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -43,12 +43,18 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files         = podspec_sources("react/renderer/components/image/**/*.{m,mm,cpp,h}", "react/renderer/components/image/**/*.h")
-  s.exclude_files        = "react/renderer/components/image/tests"
+  s.exclude_files        = ["react/renderer/components/image/tests", "react/renderer/components/image/React"]
   s.header_dir           = "react/renderer/components/image"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
                           }
+
+  s.subspec "imageUmbrella" do |ss|
+    ss.source_files        = "react/renderer/components/image/React/*.h"
+    ss.header_dir          = ""
+    ss.header_mappings_dir = "react/renderer/components/image"
+  end
 
   resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_FabricImage")
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -12,6 +12,7 @@ file(GLOB rrc_image_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_image OBJECT ${rrc_image_SRC})
 
 target_include_directories(rrc_image PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(rrc_image INTERFACE ${REACT_COMMON_DIR}/react/renderer/components/image)
 
 target_link_libraries(rrc_image
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageComponentDescriptor.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/image/ImageShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/imagemanager/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/components/image/ImageEventEmitter.h>
 #include <react/renderer/components/image/ImageProps.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/React/Image.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/components/image` module - public
+// entry point.
+//
+//   #include <React/Image.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/components/image/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/renderer/components/image/ImageComponentDescriptor.h>
+#include <react/renderer/components/image/ImageEventEmitter.h>
+#include <react/renderer/components/image/ImageProps.h>
+#include <react/renderer/components/image/ImageShadowNode.h>
+#include <react/renderer/components/image/ImageState.h>
+#include <react/renderer/components/image/conversions.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <unordered_map>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(react_renderer_imagemanager
         PRIVATE
           ${CMAKE_CURRENT_SOURCE_DIR}
         )
+target_include_directories(react_renderer_imagemanager INTERFACE ${REACT_COMMON_DIR}/react/renderer/imagemanager)
 
 react_native_android_selector(mapbufferjni mapbufferjni "")
 react_native_android_selector(reactnativejni reactnativejni "")

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/imagemanager/ImageResponse.h>
 #include <react/renderer/imagemanager/ImageResponseObserver.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <memory>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserver.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/imagemanager/ImageResponse.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/imagemanager/ImageResponse.h>
 #include <react/renderer/imagemanager/ImageResponseObserver.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageTelemetry.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/utils/Telemetry.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/React/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/React/ImageManager.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// =============================================================================
+// Umbrella header for the `react/renderer/imagemanager` module - public entry
+// point.
+//
+//   #include <React/ImageManager.h>
+//
+// Re-exports the module's public interface headers. React Native's own code
+// should keep using the fine-grained `<react/renderer/imagemanager/...>`
+// includes; only outside consumers use this umbrella.
+// =============================================================================
+
+// Marks that the following headers are pulled in through the umbrella, so their
+// shared guard (<react/cxxstableapi/UmbrellaGuard.h>) accepts them. The marker
+// is saved and restored rather than defined and undefined: the scope ends at
+// this block, so later *direct* includes in the same TU are still caught, and
+// it nests inside an enclosing umbrella rather than disarming it.
+#pragma push_macro("RN_UMBRELLA_CONTEXT")
+#undef RN_UMBRELLA_CONTEXT
+#define RN_UMBRELLA_CONTEXT 1
+
+#include <react/renderer/imagemanager/ImageManager.h>
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/ImageRequestParams.h>
+#include <react/renderer/imagemanager/ImageResponse.h>
+#include <react/renderer/imagemanager/ImageResponseObserver.h>
+#include <react/renderer/imagemanager/ImageResponseObserverCoordinator.h>
+#include <react/renderer/imagemanager/ImageTelemetry.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+#undef RN_UMBRELLA_CONTEXT
+#pragma pop_macro("RN_UMBRELLA_CONTEXT")

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/PrivateGuard.h>
 
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <utility>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/PrivateGuard.h>
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/graphicsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageRequestParams.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <react/renderer/graphics/Float.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <react/cxxstableapi/FrameworksGuard.h>
-
 #import <UIKit/UIKit.h>
 
 #import "RCTImageManagerProtocol.h"

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManagerProtocol.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManagerProtocol.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <react/cxxstableapi/FrameworksGuard.h>
-
 #import <Foundation/Foundation.h>
 #import <react/renderer/core/ReactPrimitives.h>
 #import <react/renderer/imagemanager/ImageRequest.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <react/cxxstableapi/FrameworksGuard.h>
-
 #import <UIKit/UIKit.h>
 
 #import <React/RCTConvert.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <react/cxxstableapi/FrameworksGuard.h>
-
 #import <UIKit/UIKit.h>
 
 #import "RCTImageManagerProtocol.h"

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <react/cxxstableapi/FrameworksGuard.h>
+#include <react/cxxstableapi/UmbrellaGuard.h>
 
 #include <string>
 #include <vector>

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -455,6 +455,22 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
     ],
   },
+  'ReactCommon/React-FabricImage.podspec': {
+    name: 'React-FabricImage',
+    headerPatterns: ['react/renderer/components/image/**/*.h'],
+    excludePatterns: [
+      'react/renderer/components/image/tests',
+      'react/renderer/components/image/React',
+    ],
+    headerDir: 'react/renderer/components/image',
+    subSpecs: [
+      {
+        name: 'imageUmbrella',
+        headerPatterns: ['react/renderer/components/image/React/*.h'],
+        headerDir: 'React',
+      },
+    ],
+  },
   'ReactCommon/React-Mapbuffer.podspec': {
     name: 'React-Mapbuffer',
     headerPatterns: ['react/renderer/mapbuffer/**/*.h'],

--- a/packages/react-native/scripts/ios-prebuild/headers-config.js
+++ b/packages/react-native/scripts/ios-prebuild/headers-config.js
@@ -162,6 +162,12 @@ const PodspecExceptions /*: {[key: string]: PodSpecConfiguration} */ = {
       },
 
       {
+        name: 'imagemanagerUmbrella',
+        headerPatterns: ['react/renderer/imagemanager/React/*.h'],
+        headerDir: 'React',
+      },
+
+      {
         name: 'mounting',
         headerPatterns: ['react/renderer/mounting/**/*.h'],
         excludePatterns: ['react/renderer/mounting/tests'],


### PR DESCRIPTION
Summary:

Classifies `react/renderer/imagemanager:imagemanager` as a public target under the C++ stable API three-tier visibility model. Replaces the `FrameworksGuard.h` include in the module's 7 exported headers with `<react/cxxstableapi/UmbrellaGuard.h>` and introduces the module umbrella `React/ImageManager.h`, wiring the umbrella into BUCK, CMake, CocoaPods, the iOS prebuild header config and the Android prefab export.

Changelog:
[General][Added] - Added umbrella header for the `react/renderer/imagemanager` module

Reviewed By: cortinico

Differential Revision: D119477737
