### PR TITLE
Exclude Yoga tests from iOS build

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -70,6 +70,7 @@ let rctDeprecation = RNTarget(
 let yoga = RNTarget(
   name: .yoga,
   path: "ReactCommon/yoga",
+  excludedPaths: ["test"],
   publicHeadersPath: "yoga"
 )
 


### PR DESCRIPTION
Summary:
Fixes OSS CI breakage by excluding the `test` directory from the Yoga SwiftPM target. The new `test/BaselineTest.cpp` requires gtest which is unavailable in the iOS build environment, causing compilation failures. CocoaPods and CMake builds were already unaffected.

## Changelog:
[Internal] - 

---
Agent Home session: https://www.internalfb.com/agent-home?session_id=dmh_fileadiff_diffcomment_D119293889_iDlbpMcSAiXb

Differential Revision: D119478374


