### PR TITLE
Exclude local screenshot baselines from iOS Maestro Cloud

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -184,7 +184,7 @@ jobs:
       download-path: /tmp/RNTesterBuild/RNTester.app
       app-file: /tmp/RNTesterBuild/RNTester.app
       app-id: com.meta.RNTester.localDevelopment
-      exclude-tags: android-only
+      exclude-tags: android-only,local-screenshot-baseline
     secrets: inherit
 
   test_e2e_ios_rntester:


### PR DESCRIPTION
## Summary:

Exclude Maestro flows tagged `local-screenshot-baseline` from iOS Cloud runs, matching the Android Cloud configuration. Maestro Cloud uses a different iOS device viewport from the local simulator used to capture these baselines. This currently makes `text-width-mode` fail before image comparison because the expected crop is 960x489 while the Cloud crop is 664x328.

## Changelog:

[INTERNAL] [FIXED] - Exclude local screenshot baselines from iOS Maestro Cloud

## Test Plan:

- `git diff --check` — passed
- `./node_modules/.bin/prettier --check .github/workflows/test-all.yml` — passed
- Confirmed the iOS Cloud exclusion now matches the existing Android Cloud exclusion for `local-screenshot-baseline`
- Failure evidence: https://github.com/react/react-native/actions/runs/34423810927/job/102712935698