### PR TITLE
fix: use ES import for Platform instead of require

### DIFF
--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -11,6 +11,7 @@
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 
+import Platform from '../../Utilities/Platform';
 import AndroidSwipeRefreshLayoutNativeComponent, {
   Commands as AndroidSwipeRefreshLayoutCommands,
 } from './AndroidSwipeRefreshLayoutNativeComponent';
@@ -18,8 +19,6 @@ import PullToRefreshViewNativeComponent, {
   Commands as PullToRefreshCommands,
 } from './PullToRefreshViewNativeComponent';
 import * as React from 'react';
-
-const Platform = require('../../Utilities/Platform').default;
 
 export type RefreshControlPropsIOS = Readonly<{
   /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -16,9 +16,9 @@ import type {HostInstance} from '../../../src/private/types/HostInstance';
 
 import {Commands as AndroidTextInputCommands} from '../../Components/TextInput/AndroidTextInputNativeComponent';
 import {Commands as iOSTextInputCommands} from '../../Components/TextInput/RCTSingelineTextInputNativeComponent';
+import Platform from '../../Utilities/Platform';
 
 const {findNodeHandle} = require('../../ReactNative/RendererProxy');
-const Platform = require('../../Utilities/Platform').default;
 
 let currentlyFocusedInputRef: ?HostInstance = null;
 const inputs = new Set<HostInstance>();

--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -15,8 +15,9 @@ import type {
   PackagerAsset,
 } from '../../src/private/assets/AssetRegistry';
 
+import Platform from '../Utilities/Platform';
+
 const PixelRatio = require('../Utilities/PixelRatio').default;
-const Platform = require('../Utilities/Platform').default;
 const {pickScale} = require('./AssetUtils');
 const {
   getAndroidResourceFolderName,

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -21,13 +21,13 @@ import type {
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import {type ScrollResponderType} from '../Components/ScrollView/ScrollView';
 import View from '../Components/View/View';
+import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import memoizeOne from 'memoize-one';
 import * as React from 'react';
 
 const StyleSheet = require('../StyleSheet/StyleSheet').default;
 const deepDiffer = require('../Utilities/differ/deepDiffer').default;
-const Platform = require('../Utilities/Platform').default;
 const invariant = require('invariant');
 
 const VirtualizedList = VirtualizedLists.VirtualizedList;

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -14,6 +14,7 @@ import type {RootTag} from '../ReactNative/RootTag';
 import type {DirectEventHandler} from '../Types/CodegenTypes';
 
 import {type ColorValue} from '../StyleSheet/StyleSheet';
+import Platform from '../Utilities/Platform';
 import RCTModalHostView from './RCTModalHostViewNativeComponent';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import * as React from 'react';
@@ -24,7 +25,6 @@ const AppContainer = require('../ReactNative/AppContainer').default;
 const I18nManager = require('../ReactNative/I18nManager').default;
 const {RootTagContext} = require('../ReactNative/RootTag');
 const StyleSheet = require('../StyleSheet/StyleSheet').default;
-const Platform = require('../Utilities/Platform').default;
 
 const VirtualizedListContextResetter =
   VirtualizedLists.VirtualizedListContextResetter;

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -11,10 +11,9 @@
 import type {DialogOptions} from '../../src/private/specs_DEPRECATED/modules/NativeDialogManagerAndroid';
 
 import NativeDialogManagerAndroid from '../NativeModules/specs/NativeDialogManagerAndroid';
+import Platform from '../Utilities/Platform';
 import NativePermissionsAndroid from './NativePermissionsAndroid';
 import invariant from 'invariant';
-
-const Platform = require('../Utilities/Platform').default;
 
 export type Rationale = {
   title: string,

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -11,13 +11,13 @@
 import type {RootTag} from '../Types/RootTagTypes';
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
+import Platform from '../Utilities/Platform';
 import NativeUIManager from './NativeUIManager';
 import nullthrows from 'nullthrows';
 
 const NativeModules = require('../BatchedBridge/NativeModules').default;
 const defineLazyObjectProperty =
   require('../Utilities/defineLazyObjectProperty').default;
-const Platform = require('../Utilities/Platform').default;
 const UIManagerProperties = require('./UIManagerProperties').default;
 
 const viewManagerConfigs: {[string]: any | null} = {};

--- a/packages/react-native/Libraries/Share/Share.js
+++ b/packages/react-native/Libraries/Share/Share.js
@@ -11,10 +11,10 @@
 import type {ColorValue} from '../StyleSheet/StyleSheet';
 
 import NativeActionSheetManager from '../ActionSheetIOS/NativeActionSheetManager';
+import Platform from '../Utilities/Platform';
 import NativeShareModule from './NativeShareModule';
 
 const processColor = require('../StyleSheet/processColor').default;
-const Platform = require('../Utilities/Platform').default;
 const invariant = require('invariant');
 
 export type ShareContent =

--- a/packages/react-native/Libraries/StyleSheet/processColor.js
+++ b/packages/react-native/Libraries/StyleSheet/processColor.js
@@ -12,7 +12,8 @@
 
 import type {ColorValue, NativeColorValue} from './StyleSheet';
 
-const Platform = require('../Utilities/Platform').default;
+import Platform from '../Utilities/Platform';
+
 const normalizeColor = require('./normalizeColor').default;
 
 export type ProcessedColorValue = number | NativeColorValue;

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -13,9 +13,9 @@ import type {ExtendedError} from '../Core/ExtendedError';
 import getDevServer from '../Core/Devtools/getDevServer';
 import LogBox from '../LogBox/LogBox';
 import NativeRedBox from '../NativeModules/specs/NativeRedBox';
+import Platform from './Platform';
 
 const DevSettings = require('./DevSettings').default;
-const Platform = require('./Platform').default;
 const invariant = require('invariant');
 const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const prettyFormat = require('pretty-format');

--- a/packages/react-native/Libraries/Vibration/Vibration.js
+++ b/packages/react-native/Libraries/Vibration/Vibration.js
@@ -8,9 +8,8 @@
  * @format
  */
 
+import Platform from '../Utilities/Platform';
 import NativeVibration from './NativeVibration';
-
-const Platform = require('../Utilities/Platform').default;
 
 let _vibrating: boolean = false;
 let _id: number = 0; // _id is necessary to prevent race condition.


### PR DESCRIPTION
## Summary:

Previously, the Metro inline plugin for `Platform` didn't work inside React Native files that used ES imports for `Platform` (making `require()` the only way for the inline plugin to do its job). 

Read more: https://github.com/react/metro/pull/1521#issuecomment-4281839470

Since the inline plugin was moved from `metro` to `react-native-babel-preset` (PR: https://github.com/react/react-native/pull/57848), this issue has been resolved, so using `require()` is no longer necessary.

## Changelog:

[INTERNAL] [CHANGED] - Use ES module imports for Platform API

## Test Plan:


...