### PR TITLE
Add Switch screenshot coverage for props reconciliation (#58470)

### DIFF
--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -267,6 +267,15 @@ class ContainerBackgroundColorStyleExample extends React.Component<
   }
 }
 
+function TransparentExample() {
+  return (
+    <View>
+      <Switch value thumbColor="transparent" />
+      <Switch value thumbColor="#FF000000" />
+    </View>
+  );
+}
+
 exports.title = 'Switch';
 exports.documentationURL = 'https://reactnative.dev/docs/switch';
 exports.category = 'UI';
@@ -318,6 +327,13 @@ exports.examples = [
     title: "The container's background color can be set",
     render(): React.MixedElement {
       return <ContainerBackgroundColorStyleExample />;
+    },
+  },
+  {
+    title: 'The switch thumb renders transparent',
+    name: 'transparent-thumb-color',
+    render(): React.MixedElement {
+      return <TransparentExample />;
     },
   },
 ] as Array<RNTesterModuleExample>;


### PR DESCRIPTION
Summary:

Add Jest E2E screenshot coverage for transparent Android `Switch` thumbs under the baseline and props update reconciliation configurations. Register reconciliation as an explicit opt-in config and apply its flags through the pre-startup feature flag provider.

Changelog: [Internal]

Differential Revision: D117232722


