### PR TITLE
Declare RNTester test pod dependencies for dynamic frameworks

### DIFF
--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -38,8 +38,10 @@ Pod::Spec.new do |s|
   s.dependency "React-Core", version
   s.dependency "React-CoreModules", version
   s.dependency "ReactCommon/turbomodule/core", version
+  s.dependency "React-NativeModulesApple", version
   s.dependency "React-jsi", version
 
+  depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 end


### PR DESCRIPTION
## Summary

**Native stacked review:** [Review this layer](https://github.com/kunal26das/react-native/pull/2) in the registered [six-PR fork stack](https://github.com/kunal26das/react-native/pull/6). This PR remains the upstream submission to `react/react-native`.

RNTester's test pod uses `ObjCTurboModule` and the selected JavaScript engine but does not declare their providing pods as direct dependencies. When building RNTester from source with dynamic frameworks, `React-RCTTest` fails to link those symbols.

Declare `React-NativeModulesApple` and use the existing `depend_on_js_engine` helper so CocoaPods links the selected engine. This is independent of the proposed Kotlin Multiplatform experiment; the dependency omission also reproduces in the generated source-build graph with KMP disabled.

## Changelog:

[INTERNAL] [FIXED] - Declare RNTester test pod dependencies for dynamic framework source builds.

## Test Plan

- Compared CocoaPods graphs from the unchanged base and corrected podspec: the dynamic base graph omits the symbol providers; the corrected graph includes them.
- Checked the engine helper with its default/Hermes settings and JSC selection.
- Compared static-library and static-framework graphs: all 12 aggregate configurations and 30 embedded-file entries remain unchanged.
- Executed the existing RNTester test plan with the exact corrected podspec in the KMP integration checkout: 151 passed, 16 upstream skips, zero failures with dynamic frameworks. The static-library and static-framework runs also each passed 151 tests.
- The native test execution above includes the KMP experiment. The independent KMP-disabled comparison checks project generation, not a second native test run. Device and Intel simulator execution were not performed.

The change is two dependency declarations; it changes no production implementation.
