### PR TITLE
Keep multipart header separators inside completed parts

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.kt
@@ -156,7 +156,7 @@ internal class MultipartStreamReader(
     val marker: ByteString = ByteString.encodeUtf8(CRLF + CRLF)
     val indexOfMarker = content.indexOf(marker, 0)
 
-    if (indexOfMarker == -1L || indexOfMarker >= chunkLength) {
+    if (indexOfMarker == -1L || indexOfMarker > chunkLength - marker.size()) {
       // No headers marker found inside the chunk. Treat the entire chunk as body.
       val bodyLength = chunkLength
       val body = Okio.buffer(FixedLengthSource(content, bodyLength))

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -10,6 +10,8 @@ package com.facebook.react.devsupport
 import okio.Buffer
 import okio.BufferedSource
 import okio.ByteString
+import okio.ForwardingSource
+import okio.Okio
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -210,6 +212,42 @@ class MultipartStreamReaderTest {
 
     assertThat(success).isTrue()
     assertThat(callback.callCount).isEqualTo(1)
+  }
+
+  @Test
+  fun testDelimitersAcrossEveryReadBoundary() {
+    // The trailing CRLF must not become a header separator spanning the next boundary.
+    val body = "binary\u0000\r\n--samplX\r\n--sample-\r\n"
+    val response = "preamble\r\n--sample\r\n${body}\r\n--sample\r\nsecond\r\n--sample--\r\nepilogue"
+    for (readSize in 1..response.length) {
+      val upstream = Buffer().writeUtf8(response)
+      val source =
+          Okio.buffer(
+              object : ForwardingSource(upstream) {
+                override fun read(sink: Buffer, byteCount: Long): Long =
+                    super.read(sink, minOf(byteCount, readSize.toLong()))
+              }
+          )
+      val parts = mutableListOf<String>()
+      val last = mutableListOf<Boolean>()
+      val success =
+          MultipartStreamReader(source, "sample")
+              .readAllParts(
+                  object : CallCountTrackingChunkCallback() {
+                    override fun onChunkComplete(
+                        headers: Map<String, String>,
+                        body: BufferedSource,
+                        isLastChunk: Boolean,
+                    ) {
+                      parts.add(body.readUtf8())
+                      last.add(isLastChunk)
+                    }
+                  }
+              )
+      assertThat(success).describedAs("read size %s", readSize).isTrue()
+      assertThat(parts).containsExactly(body, "second")
+      assertThat(last).containsExactly(false, true)
+    }
   }
 
   internal open class CallCountTrackingChunkCallback : MultipartStreamReader.ChunkListener {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -215,6 +215,7 @@ class MultipartStreamReaderTest {
   }
 
   @Test
+  @Suppress("DEPRECATION_ERROR") // Match the reader's compatibility with legacy Okio.
   fun testDelimitersAcrossEveryReadBoundary() {
     // The trailing CRLF must not become a header separator spanning the next boundary.
     val body = "binary\u0000\r\n--samplX\r\n--sample-\r\n"


### PR DESCRIPTION
## Summary

**Native stacked review:** [Review this layer](https://github.com/kunal26das/react-native/pull/4) in the registered [six-PR fork stack](https://github.com/kunal26das/react-native/pull/6). This PR remains the upstream submission to `react/react-native`.

A multipart body ending in CRLF can produce a CRLFCRLF match that starts in the body and ends in the following boundary. `MultipartStreamReader` currently checks only the start of the match, then treats it as a header separator inside the completed part. This can create a negative body length and fail a development bundle download.

Require the entire header separator to lie inside the part. Add a regression that reads the response at every possible chunk size, including binary content and boundary-like body bytes.

This is an existing native Android defect found while evaluating shared multipart parsing. The fix and regression are independent of Kotlin Multiplatform.

## Changelog:

[ANDROID] [FIXED] - Keep multipart header separators inside their completed part.

## Test Plan

- Executed the real `MultipartStreamReaderTest` JUnit class with the original parser plus the new regression: the regression fails with negative body length.
- Executed it with this one-line bounds fix: all seven tests pass, including every read size in the regression.
- Repeated the isolated check with the exact final PR parser and seven-test file, the repository's Okio 2.9.0, Kotlin standard library 2.2.0, JUnit 4.13.2 and AssertJ 3.21.0: seven tests passed. The exact unchanged upstream parser with the same test file fails only the new regression. The fixture has no shared KMP JAR dependency. This does not claim Android device execution.

The assembled follow-up stack also passed the full ReactAndroid suite: 623 tests across 94 suites, zero failures/errors/skips. That run includes this bounds fix and regression, the shared multipart adapter, and other stack changes; it is not an isolated run of this PR. The regression suppresses a compile-time deprecation error to retain the reader's existing Okio 2.9 API usage.

The repository test entry point is `:packages:react-native:ReactAndroid:testDebugUnitTest --tests com.facebook.react.devsupport.MultipartStreamReaderTest`.
