### PR TITLE
Run RCTAccessibilityManager methods on the main queue

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -40,6 +40,11 @@ RCT_EXPORT_MODULE()
   return YES;
 }
 
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
 - (instancetype)init
 {
   if (self = [super init]) {


### PR DESCRIPTION
Summary:
RCTAccessibilityManager mirrors UIKit accessibility state into ivars from nine
NSNotificationCenter handlers, which are delivered on the main thread. The module
declared no methodQueue, so its exported methods ran on the JS thread instead, and
none of its properties are atomic.

That leaves the content size multipliers open to a data race. The `multipliers`
getter lazily assigns `_multipliers` on read and is reached from the main thread via
the content size category notification, while `setAccessibilityContentSizeMultipliers:`
reaches `setMultipliers:` from the JS thread and releases the previous dictionary.
Concurrent access can over-release that dictionary and leave a dangling pointer
behind, which then faults on the next message to it.

Declare methodQueue as the main queue so the exported methods and the notification
handlers serialize on one thread. The module already requires main queue setup and
every method reads UIKit-derived state, so this matches how it is used.

Changelog:
[iOS][Fixed] - Fix data race on accessibility content size multipliers in `RCTAccessibilityManager`

Differential Revision: D119565016


