### PR TITLE
Only claim the TextInput responder while a touch is active

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -161,7 +161,10 @@ type LastNativeSelection = {
   mostRecentEventCount: number,
 };
 
-const emptyFunctionThatReturnsTrue = () => true;
+// Claiming the responder on a selection change with no active touch leaves the
+// input holding it with no matching touch event to release it.
+const hasActiveTouch = (event: GestureResponderEvent) =>
+  event.touchHistory.numberActiveTouches > 0;
 
 /**
  * This hook handles the synchronization between the state of the text input
@@ -604,7 +607,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
         onFocus={_onFocus}
         onScroll={_onScroll}
         onSelectionChange={_onSelectionChange}
-        onSelectionChangeShouldSetResponder={emptyFunctionThatReturnsTrue}
+        onSelectionChangeShouldSetResponder={hasActiveTouch}
         selection={selection}
         selectionColor={selectionColor}
         style={StyleSheet.compose(


### PR DESCRIPTION
## Summary:

`TextInput` passes `onSelectionChangeShouldSetResponder={emptyFunctionThatReturnsTrue}`, so it takes the JS responder on any selection change the responder system walks. That walk is gated on `trackedTouchCount > 0`, and the counter counts events rather than touches: press two fingers down separately, lift them together, and it never comes back down, since two starts arrive as two events and the lift arrives as one. From then on every keystroke-driven selection change hands the responder to the focused input with no touch behind it, and the next tap elsewhere is dropped, because negotiation dispatches from the lowest common ancestor of the responder and the new target and so never reaches the new target's own `onStartShouldSetResponder`.

Claim it only while `touchHistory.numberActiveTouches > 0`, which is read from `touches.length` on every start and end and does track the real state. Drag selection keeps working, since a finger is down for the whole gesture.

Fixes #58445. RNTester reproducer in #58449.

## Changelog:

[IOS] [FIXED] - TextInput no longer takes the touch responder on a selection change with no active touch

## Test Plan:

- `yarn lint` and `yarn flow-check` clean, `yarn test packages/react-native/Libraries/Components` passes
- Not verified on a device, and no test added: the Fantom responder tests are skipped in OSS, so there is nothing here CI would run. #58449 has the manual steps, which need a physical device (the Simulator lands both fingers in one event and does not reproduce it)
