### PR TITLE
Downgrade HMR client console.warn to console.log

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -167,7 +167,7 @@ const HMRClient: HMRClientNativeInterface = {
     // there's nothing to hot-reload — registering with the server would just log
     // spurious "Unable to resolve module" errors.
     if (!getDevServer().bundleLoadedFromServer) {
-      console.warn(
+      console.log(
         'Not enabling Hot Module Reloading: the JS bundle was loaded from a local ' +
           'file, not from Metro. To use HMR, load the bundle from the packager.',
       );


### PR DESCRIPTION
Summary:
Downgrade a `console.warn` to `console.log` in HMRClient when the bundle is not loaded from Metro. This message is informational rather than a warning condition.

Changelog: [Internal]

Differential Revision: D119640117


