### PR TITLE
Resolve umbrella headers in CMake builds (#58483)

### DIFF
--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -13,6 +13,7 @@ file(GLOB react_debug_redbox_SRC CONFIGURE_DEPENDS redbox/*.cpp)
 add_library(react_debug OBJECT ${react_debug_SRC} ${react_debug_redbox_SRC})
 
 target_include_directories(react_debug PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_debug INTERFACE ${REACT_COMMON_DIR}/react/debug)
 
 target_link_libraries(react_debug folly_runtime react_cxxstableapi)
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -23,6 +23,7 @@ react_native_android_selector(platform_DIR
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
         ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
 target_include_directories(rrc_view PUBLIC ${REACT_COMMON_DIR} ${platform_DIR})
+target_include_directories(rrc_view INTERFACE ${REACT_COMMON_DIR}/react/renderer/components/view)
 
 target_link_libraries(rrc_view
         folly_runtime

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -11,6 +11,7 @@ file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
 target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_mapbuffer INTERFACE ${REACT_COMMON_DIR}/react/renderer/mapbuffer)
 target_link_libraries(react_renderer_mapbuffer glog glog_init react_cxxstableapi react_debug)
 target_compile_reactnative_options(react_renderer_mapbuffer PRIVATE)
 target_compile_options(react_renderer_mapbuffer PRIVATE -Wpedantic)


### PR DESCRIPTION
Summary:

The `React/*.h` umbrella headers for `react/renderer/components/view`, `react/debug` and `react/renderer/mapbuffer` are exported by every build system except CMake, so `#include <React/View.h>`, `<React/Debug.h>` and `<React/MapBuffer.h>` fail to resolve there.

Add the missing `target_include_directories(<target> INTERFACE ...)` entry to each module, matching what the other umbrella-exporting modules already do.

Changelog:
[Android][Fixed] - Make the `React/View.h`, `React/Debug.h` and `React/MapBuffer.h` umbrella headers resolvable in CMake builds

Reviewed By: cortinico

Differential Revision: D119662087


