### PR TITLE
Remove newArchEnabled from root view factory initializers (#58488)

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -47,8 +47,6 @@ NS_ASSUME_NONNULL_BEGIN
  *   - (UIViewController *)createRootViewController;
  *   - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController;
  * New Architecture:
- *   - (BOOL)turboModuleEnabled;
- *   - (BOOL)fabricEnabled;
  *   - (NSDictionary *)prepareInitialProps
  *   - (Class)getModuleClassFromName:(const char *)name
  *   - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -116,16 +116,6 @@
   return YES;
 }
 
-- (BOOL)fabricEnabled
-{
-  return YES;
-}
-
-- (BOOL)turboModuleEnabled
-{
-  return YES;
-}
-
 - (Class)getModuleClassFromName:(const char *)name
 {
   return nullptr;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -289,7 +289,7 @@ static NSDictionary *RCTConvertConnectionOptionsToLaunchOptions(UISceneConnectio
   };
 
   RCTRootViewFactoryConfiguration *configuration =
-      [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock newArchEnabled:YES];
+      [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock];
 
   configuration.customizeRootView = ^(UIView *_Nonnull rootView) {
     [weakSelf.delegate customizeRootView:(RCTRootView *)rootView];

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -55,10 +55,9 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * pointing to a path inside the app resources, e.g. `file://.../main.jsbundle`.
  *
  */
-- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
-                        newArchEnabled:(BOOL)newArchEnabled NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL newArchEnabled:(BOOL)newArchEnabled;
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL;
 
 /**
  * Block that allows to override logic of creating root view instance.

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -43,12 +43,6 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
 #pragma mark - RCTRootViewFactory Configuration
 @interface RCTRootViewFactoryConfiguration : NSObject
 
-/// This property controls whether the App will use the Fabric renderer of the New Architecture or not.
-@property (nonatomic, assign, readonly) BOOL fabricEnabled;
-
-/// This method controls whether the `turboModules` feature of the New Architecture is turned on or off
-@property (nonatomic, assign, readonly) BOOL turboModuleEnabled;
-
 /// Return the bundle URL for the main bundle.
 @property (nonatomic, nonnull) RCTBundleURLBlock bundleURLBlock;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -46,8 +46,6 @@
 {
   if (self = [super init]) {
     _bundleURLBlock = bundleURLBlock;
-    _fabricEnabled = YES;
-    _turboModuleEnabled = YES;
   }
   return self;
 }

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -32,16 +32,6 @@
 
 @implementation RCTRootViewFactoryConfiguration
 
-- (instancetype)initWithBundleURL:(NSURL *)bundleURL newArchEnabled:(BOOL)newArchEnabled
-{
-  return [self initWithBundleURL:bundleURL];
-}
-
-- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock newArchEnabled:(BOOL)newArchEnabled
-{
-  return [self initWithBundleURLBlock:bundleURLBlock];
-}
-
 - (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
 {
   if (self = [super init]) {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1694,8 +1694,8 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
-  public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
+  public virtual instancetype initWithBundleURL:(NSURL* bundleURL);
+  public virtual instancetype initWithBundleURLBlock:(RCTBundleURLBlock bundleURLBlock);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -1693,8 +1693,6 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL fabricEnabled;
-  public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1693,8 +1693,8 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
-  public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
+  public virtual instancetype initWithBundleURL:(NSURL* bundleURL);
+  public virtual instancetype initWithBundleURLBlock:(RCTBundleURLBlock bundleURLBlock);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -1692,8 +1692,6 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL fabricEnabled;
-  public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1694,8 +1694,8 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
-  public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
-  public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);
+  public virtual instancetype initWithBundleURL:(NSURL* bundleURL);
+  public virtual instancetype initWithBundleURLBlock:(RCTBundleURLBlock bundleURLBlock);
 }
 
 interface RCTSafeAreaViewComponentView : public RCTViewComponentView {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -1693,8 +1693,6 @@ interface RCTRootViewFactoryConfiguration : public NSObject {
   public @property (assign) RCTLoadSourceForBridgeBlock loadSourceForBridge;
   public @property (assign) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
   public @property (assign) RCTSourceURLForBridgeBlock sourceURLForBridge;
-  public @property (assign, readonly) BOOL fabricEnabled;
-  public @property (assign, readonly) BOOL turboModuleEnabled;
   public @property (weak) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
   public virtual instancetype initWithBundleURL:newArchEnabled:(NSURL* bundleURL, BOOL newArchEnabled);
   public virtual instancetype initWithBundleURLBlock:newArchEnabled:(RCTBundleURLBlock bundleURLBlock, BOOL newArchEnabled);


### PR DESCRIPTION
Summary:

Remove the unused `newArchEnabled` parameter from `RCTRootViewFactoryConfiguration` initializers and update callers.

Changelog:
[iOS][Breaking] - Remove `newArchEnabled` from `RCTRootViewFactoryConfiguration` initializers; use `initWithBundleURL:` or `initWithBundleURLBlock:` instead

Differential Revision: D119673104


