### PR TITLE
Fix `minimumFontScale` with `adjustsFontSizeToFit` in the New Architecture

### DIFF
--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -122,8 +122,6 @@ export type TextPropsAndroid = {
   /**
    * Smallest possible font scale when `adjustsFontSizeToFit` is enabled
    * (values 0.01-1.0).
-   *
-   * @platform ios
    */
   minimumFontScale?: ?number,
 };

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6044,7 +6044,7 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	public fun setIncludeFontPadding (Z)V
 	public fun setLetterSpacing (F)V
 	public fun setLinkifyMask (I)V
-	public fun setMinimumFontSize (F)V
+	public fun setMinimumFontScale (F)V
 	public fun setNumberOfLines (I)V
 	public fun setOverflow (Ljava/lang/String;)V
 	public fun setSpanned (Landroid/text/Spannable;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -71,7 +71,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   private @Nullable TextUtils.TruncateAt mEllipsizeLocation;
   private boolean mAdjustsFontSizeToFit;
   private float mFontSize;
-  private float mMinimumFontSize;
+  private float mMinimumFontScale;
   private float mLetterSpacing;
   private int mLinkifyMaskType;
   private boolean mTextIsSelectable;
@@ -132,7 +132,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mShouldAdjustSpannableFontSize = false;
     mEllipsizeLocation = TextUtils.TruncateAt.END;
     mFontSize = Float.NaN;
-    mMinimumFontSize = Float.NaN;
+    mMinimumFontScale = Float.NaN;
     mLetterSpacing = 0.f;
     mOverflow = Overflow.VISIBLE;
     mSpanned = null;
@@ -238,7 +238,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             YogaMeasureMode.EXACTLY,
             getHeight(),
             YogaMeasureMode.EXACTLY,
-            mMinimumFontSize,
+            mMinimumFontScale,
             mNumberOfLines,
             getIncludeFontPadding(),
             getBreakStrategy(),
@@ -540,8 +540,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     applyTextAttributes();
   }
 
-  public void setMinimumFontSize(float minimumFontSize) {
-    mMinimumFontSize = minimumFontSize;
+  public void setMinimumFontScale(float minimumFontScale) {
+    mMinimumFontScale = minimumFontScale;
     mShouldAdjustSpannableFontSize = true;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -585,9 +585,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
   public void updateView() {
     @Nullable
     TextUtils.TruncateAt ellipsizeLocation =
-        mNumberOfLines == ViewDefaults.NUMBER_OF_LINES || mAdjustsFontSizeToFit
-            ? null
-            : mEllipsizeLocation;
+        mNumberOfLines == ViewDefaults.NUMBER_OF_LINES ? null : mEllipsizeLocation;
     setEllipsize(ellipsizeLocation);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -168,9 +168,9 @@ public constructor(
         )
     view.setSpanned(spanned)
 
-    val minimumFontSize: Float =
-        paragraphAttributes.getDouble(TextLayoutManager.PA_KEY_MINIMUM_FONT_SIZE).toFloat()
-    view.setMinimumFontSize(minimumFontSize)
+    val minimumFontScale: Float =
+        paragraphAttributes.getDouble(TextLayoutManager.PA_KEY_MINIMUM_FONT_SCALE).toFloat()
+    view.setMinimumFontScale(minimumFontScale)
 
     // Clear any stale PreparedLayout from a previous update
     view.setPreparedLayout(null)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -93,8 +93,7 @@ internal object TextLayoutManager {
   const val PA_KEY_ADJUST_FONT_SIZE_TO_FIT: Int = 3
   const val PA_KEY_INCLUDE_FONT_PADDING: Int = 4
   const val PA_KEY_HYPHENATION_FREQUENCY: Int = 5
-  const val PA_KEY_MINIMUM_FONT_SIZE: Int = 6
-  const val PA_KEY_MAXIMUM_FONT_SIZE: Int = 7
+  const val PA_KEY_MINIMUM_FONT_SCALE: Int = 6
   const val PA_KEY_TEXT_ALIGN_VERTICAL: Int = 8
   const val PA_KEY_TEXT_WIDTH_MODE: Int = 9
 
@@ -1046,9 +1045,9 @@ internal object TextLayoutManager {
     val justificationMode = getTextJustificationMode(alignmentAttr)
 
     if (adjustFontSizeToFit) {
-      val minimumFontSize =
-          if (paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SIZE))
-              paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SIZE).toFloat()
+      val minimumFontScale =
+          if (paragraphAttributes.contains(PA_KEY_MINIMUM_FONT_SCALE))
+              paragraphAttributes.getDouble(PA_KEY_MINIMUM_FONT_SCALE).toFloat()
           else Float.NaN
 
       adjustSpannableFontToFit(
@@ -1057,7 +1056,7 @@ internal object TextLayoutManager {
           YogaMeasureMode.EXACTLY,
           height,
           heightYogaMeasureMode,
-          minimumFontSize,
+          minimumFontScale,
           maximumNumberOfLines,
           includeFontPadding,
           textBreakStrategy,
@@ -1209,7 +1208,7 @@ internal object TextLayoutManager {
       widthYogaMeasureMode: YogaMeasureMode,
       height: Float,
       heightYogaMeasureMode: YogaMeasureMode,
-      minimumFontSizeAttr: Float,
+      minimumFontScale: Float,
       maximumNumberOfLines: Int,
       includeFontPadding: Boolean,
       textBreakStrategy: Int,
@@ -1221,16 +1220,20 @@ internal object TextLayoutManager {
     var boring = isBoring(text, paint)
     var layout: Layout
 
-    // Minimum font size is 4pts to match the iOS implementation.
-    val minimumFontSize =
-        (if (minimumFontSizeAttr.isNaN()) 4.dpToPx() else minimumFontSizeAttr).toInt()
-
     // Find the largest font size used in the spannable to use as a starting point.
-    var currentFontSize = minimumFontSize
+    var currentFontSize = 0
     val spans = text.getSpans(0, text.length, ReactAbsoluteSizeSpan::class.java)
     for (span in spans) {
       currentFontSize = max(currentFontSize, span.size)
     }
+
+    // The smallest font size is the largest font size scaled by minimumFontScale, floored at 4dp
+    // to match the iOS implementation.
+    val absoluteMinimumFontSize = 4.dpToPx().toInt()
+    val minimumFontSize =
+        if (minimumFontScale.isNaN() || minimumFontScale <= 0f) absoluteMinimumFontSize
+        else max((minimumFontScale * currentFontSize).toInt(), absoluteMinimumFontSize)
+    currentFontSize = max(currentFontSize, minimumFontSize)
 
     var intervalStart = minimumFontSize
     var intervalEnd = currentFontSize

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
@@ -21,8 +21,11 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.get
+import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.views.text.internal.span.ReactAbsoluteSizeSpan
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -31,6 +34,16 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 class ReactTextViewTest {
+
+  @Before
+  fun setUp() {
+    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(RuntimeEnvironment.getApplication())
+  }
+
+  @After
+  fun tearDown() {
+    DisplayMetricsHolder.setScreenDisplayMetrics(null)
+  }
 
   @Test
   fun drawsGlyphInkOutsideLineHeightWhenOverflowIsVisible() {
@@ -70,7 +83,7 @@ class ReactTextViewTest {
             ViewGroup.LayoutParams.WRAP_CONTENT,
         )
     view.setTextColor(Color.BLACK)
-    view.setMinimumFontSize(4f)
+    view.setMinimumFontScale(0.1f)
     view.setNumberOfLines(0)
     view.setAdjustFontSizeToFit(true)
     view.setSpanned(text)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/ReactTextViewTest.kt
@@ -14,6 +14,7 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.TextUtils
 import android.text.style.ReplacementSpan
 import android.util.TypedValue
 import android.view.Gravity
@@ -120,6 +121,18 @@ class ReactTextViewTest {
     view.recycleView()
 
     assertThat(view.useBoundsForWidth).isFalse()
+  }
+
+  @Test
+  fun adjustsFontSizeToFitKeepsEllipsizeLocation() {
+    val view = TestReactTextView(RuntimeEnvironment.getApplication())
+    view.setNumberOfLines(1)
+    view.setEllipsizeLocation(TextUtils.TruncateAt.END)
+    view.setAdjustFontSizeToFit(true)
+
+    view.updateView()
+
+    assertThat(view.ellipsize).isEqualTo(TextUtils.TruncateAt.END)
   }
 
   private fun layoutAndDraw(view: TestReactTextView, width: Int, height: Int) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerMinimumFontScaleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextLayoutManagerMinimumFontScaleTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import android.text.Layout
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.TextPaint
+import com.facebook.react.common.ReactConstants
+import com.facebook.react.uimanager.DisplayMetricsHolder
+import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.views.text.internal.span.ReactAbsoluteSizeSpan
+import com.facebook.yoga.YogaMeasureMode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class TextLayoutManagerMinimumFontScaleTest {
+
+  @Before
+  fun setUp() {
+    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(RuntimeEnvironment.getApplication())
+  }
+
+  @After
+  fun tearDown() {
+    DisplayMetricsHolder.setScreenDisplayMetrics(null)
+  }
+
+  @Test
+  fun `minimumFontScale limits how far the font shrinks relative to the largest font size`() {
+    val text = spannableWithFontSize(LARGE_FONT_SIZE)
+
+    adjustToUnsatisfiableHeight(text, minimumFontScale = 0.5f)
+
+    assertThat(largestFontSize(text)).isEqualTo((LARGE_FONT_SIZE * 0.5f).toInt())
+  }
+
+  @Test
+  fun `minimumFontScale is applied to the largest font size in the spannable`() {
+    val text = SpannableString("Small text and LARGE TEXT")
+    text.setSpan(ReactAbsoluteSizeSpan(SMALL_FONT_SIZE), 0, 14, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    text.setSpan(
+        ReactAbsoluteSizeSpan(LARGE_FONT_SIZE),
+        15,
+        text.length,
+        Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+    )
+
+    adjustToUnsatisfiableHeight(text, minimumFontScale = 0.5f)
+
+    assertThat(largestFontSize(text)).isEqualTo((LARGE_FONT_SIZE * 0.5f).toInt())
+  }
+
+  @Test
+  fun `missing minimumFontScale shrinks down to the 4dp floor`() {
+    val text = spannableWithFontSize(LARGE_FONT_SIZE)
+
+    adjustToUnsatisfiableHeight(text, minimumFontScale = Float.NaN)
+
+    assertThat(largestFontSize(text)).isEqualTo(4.dpToPx().toInt())
+  }
+
+  @Test
+  fun `zero minimumFontScale shrinks down to the 4dp floor`() {
+    val text = spannableWithFontSize(LARGE_FONT_SIZE)
+
+    adjustToUnsatisfiableHeight(text, minimumFontScale = 0f)
+
+    assertThat(largestFontSize(text)).isEqualTo(4.dpToPx().toInt())
+  }
+
+  @Test
+  fun `minimumFontScale never shrinks below the 4dp floor`() {
+    val text = spannableWithFontSize(LARGE_FONT_SIZE)
+
+    adjustToUnsatisfiableHeight(text, minimumFontScale = 0.01f)
+
+    assertThat(largestFontSize(text)).isEqualTo(4.dpToPx().toInt())
+  }
+
+  @Test
+  fun `text that already fits is not shrunk`() {
+    val text = spannableWithFontSize(LARGE_FONT_SIZE)
+
+    TextLayoutManager.adjustSpannableFontToFit(
+        text,
+        10_000f,
+        YogaMeasureMode.EXACTLY,
+        10_000f,
+        YogaMeasureMode.EXACTLY,
+        0.5f,
+        ReactConstants.UNSET,
+        true,
+        Layout.BREAK_STRATEGY_SIMPLE,
+        Layout.HYPHENATION_FREQUENCY_NONE,
+        Layout.Alignment.ALIGN_NORMAL,
+        0,
+        newPaint(),
+    )
+
+    assertThat(largestFontSize(text)).isEqualTo(LARGE_FONT_SIZE)
+  }
+
+  // Uses a height no font size can satisfy so the text is shrunk all the way to the minimum.
+  private fun adjustToUnsatisfiableHeight(text: SpannableString, minimumFontScale: Float) {
+    TextLayoutManager.adjustSpannableFontToFit(
+        text,
+        10_000f,
+        YogaMeasureMode.EXACTLY,
+        1f,
+        YogaMeasureMode.EXACTLY,
+        minimumFontScale,
+        ReactConstants.UNSET,
+        true,
+        Layout.BREAK_STRATEGY_SIMPLE,
+        Layout.HYPHENATION_FREQUENCY_NONE,
+        Layout.Alignment.ALIGN_NORMAL,
+        0,
+        newPaint(),
+    )
+  }
+
+  private fun spannableWithFontSize(fontSize: Int): SpannableString {
+    val text = SpannableString("Hello")
+    text.setSpan(ReactAbsoluteSizeSpan(fontSize), 0, text.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    return text
+  }
+
+  private fun newPaint(): TextPaint =
+      TextPaint(TextPaint.ANTI_ALIAS_FLAG).apply { textSize = LARGE_FONT_SIZE.toFloat() }
+
+  private fun largestFontSize(text: Spanned): Int =
+      text.getSpans(0, text.length, ReactAbsoluteSizeSpan::class.java).maxOfOrNull { it.size } ?: 0
+
+  private companion object {
+    const val SMALL_FONT_SIZE = 10
+    const val LARGE_FONT_SIZE = 40
+  }
+}

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -33,8 +33,6 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              rhs.includeFontPadding,
              rhs.android_hyphenationFrequency,
              rhs.textAlignVertical) &&
-      floatEquality(minimumFontSize, rhs.minimumFontSize) &&
-      floatEquality(maximumFontSize, rhs.maximumFontSize) &&
       floatEquality(minimumFontScale, rhs.minimumFontScale);
 }
 
@@ -61,13 +59,9 @@ SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
           adjustsFontSizeToFit,
           paragraphAttributes.adjustsFontSizeToFit),
       debugStringConvertibleItem(
-          "minimumFontSize",
-          minimumFontSize,
-          paragraphAttributes.minimumFontSize),
-      debugStringConvertibleItem(
-          "maximumFontSize",
-          maximumFontSize,
-          paragraphAttributes.maximumFontSize),
+          "minimumFontScale",
+          minimumFontScale,
+          paragraphAttributes.minimumFontScale),
       debugStringConvertibleItem(
           "includeFontPadding",
           includeFontPadding,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -68,17 +68,10 @@ class ParagraphAttributes : public DebugStringConvertible {
   HyphenationFrequency android_hyphenationFrequency{};
 
   /*
-   * In case of font size adjustment enabled, defines minimum and maximum
-   * font sizes.
-   */
-  Float minimumFontSize{std::numeric_limits<Float>::quiet_NaN()};
-  Float maximumFontSize{std::numeric_limits<Float>::quiet_NaN()};
-
-  /*
    * Specifies the smallest possible scale a font can reach when
    * adjustsFontSizeToFit is enabled. (values 0.01-1.0).
    */
-  Float minimumFontScale{std::numeric_limits<Float>::quiet_NaN()};
+  Float minimumFontScale{0.0};
 
   /*
    * The vertical alignment of the text, causing the glyphs to be vertically
@@ -109,8 +102,6 @@ struct hash<facebook::react::ParagraphAttributes> {
         attributes.textBreakStrategy,
         attributes.textWidthMode,
         attributes.adjustsFontSizeToFit,
-        attributes.minimumFontSize,
-        attributes.maximumFontSize,
         attributes.includeFontPadding,
         attributes.android_hyphenationFrequency,
         attributes.minimumFontScale,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -1085,18 +1085,6 @@ inline ParagraphAttributes convertRawProp(
       "minimumFontScale",
       sourceParagraphAttributes.minimumFontScale,
       defaultParagraphAttributes.minimumFontScale);
-  paragraphAttributes.minimumFontSize = convertRawProp(
-      context,
-      rawProps,
-      "minimumFontSize",
-      sourceParagraphAttributes.minimumFontSize,
-      defaultParagraphAttributes.minimumFontSize);
-  paragraphAttributes.maximumFontSize = convertRawProp(
-      context,
-      rawProps,
-      "maximumFontSize",
-      sourceParagraphAttributes.maximumFontSize,
-      defaultParagraphAttributes.maximumFontSize);
   paragraphAttributes.includeFontPadding = convertRawProp(
       context,
       rawProps,
@@ -1199,8 +1187,7 @@ constexpr static MapBuffer::Key PA_KEY_TEXT_BREAK_STRATEGY = 2;
 constexpr static MapBuffer::Key PA_KEY_ADJUST_FONT_SIZE_TO_FIT = 3;
 constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
-constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
-constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
+constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SCALE = 6;
 constexpr static MapBuffer::Key PA_KEY_TEXT_ALIGN_VERTICAL = 8;
 constexpr static MapBuffer::Key PA_KEY_TEXT_WIDTH_MODE = 9;
 
@@ -1217,8 +1204,7 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes &paragraphAttributes)
   if (paragraphAttributes.textAlignVertical.has_value()) {
     builder.putString(PA_KEY_TEXT_ALIGN_VERTICAL, toString(*paragraphAttributes.textAlignVertical));
   }
-  builder.putDouble(PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
-  builder.putDouble(PA_KEY_MAXIMUM_FONT_SIZE, paragraphAttributes.maximumFontSize);
+  builder.putDouble(PA_KEY_MINIMUM_FONT_SCALE, paragraphAttributes.minimumFontScale);
 
   return builder.build();
 }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/ParagraphAttributesTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/ParagraphAttributesTest.cpp
@@ -9,11 +9,11 @@
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/attributedstring/conversions.h>
 
+#include <limits>
+
 namespace facebook::react {
 
-// The three Float fields default to NaN, and NaN != NaN under IEEE-754.
-// operator== must special-case NaN via floatEquality so two freshly
-// default-constructed ParagraphAttributes compare equal.
+// Two freshly default-constructed ParagraphAttributes must compare equal.
 TEST(
     ParagraphAttributesTest,
     testOperatorEqualsDefaultConstructedInstancesAreEqual) {
@@ -23,38 +23,36 @@ TEST(
   EXPECT_TRUE(a == b);
 }
 
-// operator== compares Float fields with an epsilon tolerance (0.005) rather
-// than an exact ==. Differences below the epsilon must still compare equal;
-// differences well above the epsilon must compare unequal.
+// operator== compares minimumFontScale with an epsilon tolerance (0.005)
+// rather than an exact ==. Differences below the epsilon must still compare
+// equal; differences well above the epsilon must compare unequal.
 TEST(
     ParagraphAttributesTest,
     testOperatorEqualsFloatFieldsUseEpsilonComparison) {
   ParagraphAttributes a{};
-  a.minimumFontSize = 12.0f;
-  a.maximumFontSize = 48.0f;
   a.minimumFontScale = 0.5f;
   auto b = a;
 
-  b.minimumFontSize = a.minimumFontSize + 0.001f;
-  b.maximumFontSize = a.maximumFontSize + 0.001f;
   b.minimumFontScale = a.minimumFontScale + 0.001f;
   EXPECT_TRUE(a == b);
 
   b = a;
-  b.minimumFontSize = a.minimumFontSize + 1.0f;
+  b.minimumFontScale = a.minimumFontScale + 0.1f;
   EXPECT_FALSE(a == b);
 }
 
 // floatEquality returns true only when *both* operands are NaN or when
-// *neither* is. A NaN-vs-finite mismatch in any of the three float fields
-// must therefore make the instances unequal, even though both operands are
-// "invalid" font sizes.
-TEST(
-    ParagraphAttributesTest,
-    testOperatorEqualsNaNVsFiniteFloatComparesUnequal) {
+// *neither* is. Two NaN minimumFontScale values must compare equal, and a
+// NaN-vs-finite mismatch must compare unequal.
+TEST(ParagraphAttributesTest, testOperatorEqualsHandlesNaNMinimumFontScale) {
   ParagraphAttributes withNaN{};
+  withNaN.minimumFontScale = std::numeric_limits<Float>::quiet_NaN();
+  auto otherWithNaN = withNaN;
+
+  EXPECT_TRUE(withNaN == otherWithNaN);
+
   ParagraphAttributes withFinite{};
-  withFinite.minimumFontSize = 12.0f;
+  withFinite.minimumFontScale = 0.5f;
 
   EXPECT_FALSE(withNaN == withFinite);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
@@ -102,18 +102,6 @@ void BaseParagraphProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
         includeFontPadding,
         "includeFontPadding");
     REBUILD_FIELD_SWITCH_CASE(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
@@ -122,18 +122,6 @@ folly::dynamic HostPlatformParagraphProps::getDiffProps(
     result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
   }
 
-  if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
-  }
-
   if (paragraphAttributes.includeFontPadding !=
       oldProps->paragraphAttributes.includeFontPadding) {
     result["includeFontPadding"] = paragraphAttributes.includeFontPadding;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -177,14 +177,8 @@ void BaseTextInputProps::setProp(
         paDefaults,
         value,
         paragraphAttributes,
-        minimumFontSize,
-        "minimumFontSize");
-    REBUILD_FIELD_SWITCH_CASE(
-        paDefaults,
-        value,
-        paragraphAttributes,
-        maximumFontSize,
-        "maximumFontSize");
+        minimumFontScale,
+        "minimumFontScale");
     REBUILD_FIELD_SWITCH_CASE(
         paDefaults,
         value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -390,15 +390,9 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
+          paragraphAttributes.minimumFontScale,
+          oldProps->paragraphAttributes.minimumFontScale)) {
+    result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
   }
 
   if (paragraphAttributes.includeFontPadding !=

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -415,6 +415,22 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   return paragraphLines;
 }
 
+- (CGFloat)_maximumFontSizeInAttributedString:(NSAttributedString *)attributedString
+{
+  __block CGFloat maximumFontSize = 0.0;
+  [attributedString enumerateAttribute:NSFontAttributeName
+                               inRange:NSMakeRange(0, attributedString.length)
+                               options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
+                            usingBlock:^(id _Nullable value, NSRange range, BOOL *_Nonnull stop) {
+                              CGFloat fontSize = ((UIFont *)value).pointSize;
+                              if (fontSize > maximumFontSize) {
+                                maximumFontSize = fontSize;
+                              }
+                            }];
+
+  return maximumFontSize;
+}
+
 - (NSTextStorage *)_textStorageAndLayoutManagerWithAttributesString:(NSAttributedString *)attributedString
                                                 paragraphAttributes:(ParagraphAttributes)paragraphAttributes
                                                                size:(CGSize)size
@@ -438,8 +454,8 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   [textStorage addLayoutManager:layoutManager];
 
   if (paragraphAttributes.adjustsFontSizeToFit) {
-    CGFloat minimumFontSize = !isnan(paragraphAttributes.minimumFontSize) ? paragraphAttributes.minimumFontSize : 4.0;
-    CGFloat maximumFontSize = !isnan(paragraphAttributes.maximumFontSize) ? paragraphAttributes.maximumFontSize : 96.0;
+    CGFloat maximumFontSize = [self _maximumFontSizeInAttributedString:attributedString];
+    CGFloat minimumFontSize = MAX(paragraphAttributes.minimumFontScale * maximumFontSize, 4.0);
     [textStorage scaleFontSizeToFitSize:size minimumFontSize:minimumFontSize maximumFontSize:maximumFontSize];
   }
 

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -155,6 +155,14 @@ class AdjustingFontSize extends React.Component<
         </RNTesterText>
 
         <RNTesterText
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.5}
+          style={{fontSize: 40, marginVertical: 6}}>
+          Can limit how small the text becomes with minimumFontScale
+        </RNTesterText>
+
+        <RNTesterText
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{fontSize: 30, marginVertical: 6}}>

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -213,6 +213,14 @@ class AdjustingFontSize extends React.Component<
         </Text>
 
         <Text
+          numberOfLines={1}
+          adjustsFontSizeToFit={true}
+          minimumFontScale={0.5}
+          style={{fontSize: 40, marginVertical: 6}}>
+          Can limit how small the text becomes with minimumFontScale
+        </Text>
+
+        <Text
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{fontSize: 30, marginVertical: 6}}>


### PR DESCRIPTION
## Summary:

`minimumFontScale` has no effect when used with `adjustsFontSizeToFit` under the New Architecture on either platform (#50248). Text shrinks all the way down to the hard-coded floor regardless of the requested scale.

The root cause is the same on both platforms. Fabric's `ParagraphAttributes` carries `minimumFontSize`, but no `<Text>` or `<TextInput>` prop ever sets it, so it is always `NaN`:

- **iOS**: `RCTTextLayoutManager` falls back to a 4pt minimum whenever `minimumFontSize` is `NaN`, so the floor is always 4pt.
- **Android**: the C++ side serializes `minimumFontSize` into MapBuffer key 6, and `TextLayoutManager.adjustSpannableFontToFit()` treats that value as an absolute minimum font size, falling back to 4dp when it is `NaN`. Same result: the floor is always 4dp.

This PR serializes `minimumFontScale` (the field already existed) into a new MapBuffer key (10). Each platform then derives the minimum font size from that scale. `minimumFontSize` and MapBuffer key 6 are left as they are and deprecated in favor of `minimumFontScale`; an explicit `minimumFontSize` still takes precedence over the scale on both platforms, so existing callers keep working unchanged. The legacy renderers based the scale on the outermost text's font size; using the largest font size in the attributed string follows the approach from #43543.

- **iOS**: `RCTTextLayoutManager` finds the largest font size in the attributed string and computes the minimum as `MAX(minimumFontScale * largestFontSize, 4.0)`.
- **Android**: `adjustSpannableFontToFit()` finds the largest `ReactAbsoluteSizeSpan` first and uses `max(minimumFontScale * largestFontSize, 4dp)`. This uses the same scale-based calculation as the original Android implementation in #26389, although the legacy renderer based it on the outer text's effective font size rather than the largest span. A `NaN` or non-positive scale keeps the bare 4dp floor. Both the measurement path (`createLayout()`) and the view path (`ReactTextViewManager` -> `ReactTextView.onDraw()`) go through this one function, so only its interpretation of the value changes. `PA_KEY_MINIMUM_FONT_SCALE` is added as key 10, `ReactTextView.setMinimumFontSize()` is kept and marked `@Deprecated`, and `setMinimumFontScale()` is added alongside it (the `ReactAndroid.api` dump was also updated).
- **Android**: `ReactTextView.updateView()` no longer clears the ellipsize location when `adjustsFontSizeToFit` is set. With the floor effectively pinned at 4dp that branch was dead, since text always fit. Now that a floor can stop the text from shrinking, text that still overflows at the floor gets the requested `ellipsizeMode` instead of being clipped, matching iOS.


The 4pt/4dp floor is kept on both platforms. `minimumFontScale` still has an `@platform ios` annotation in `TextProps.js`, so that annotation is removed since it's supported on Android as well.

Builds on #58529, which removed the unused `maximumFontSize` attribute and introduced the largest-font-size helper this PR reuses on iOS.

This supersedes #54072 (iOS only) and #43543.

Fixes #50248.

## Changelog:

[GENERAL] [FIXED] - Fix `minimumFontScale` with `adjustsFontSizeToFit` in the New Architecture

## Test Plan:

**Unit tests**

- Updated `ParagraphAttributesTest.cpp` to cover `minimumFontScale`.
- Added `TextLayoutManagerMinimumFontScaleTest.kt` covering the scale calculation, the 4dp floor, the precedence of an explicit `minimumFontSize` over the scale, and text that already fits.
- Added a `ReactTextViewTest.kt` case verifying that `adjustsFontSizeToFit` preserves the ellipsize location.
- Regenerated the C++ API snapshots (`yarn cxx-api-build`) for the new MapBuffer key.

```sh
./gradlew :packages:react-native:ReactAndroid:testDebugUnitTest --tests 'com.facebook.react.views.text.*'
```

All 47 `com.facebook.react.views.text` tests pass.

**RNTester**


Added a `minimumFontScale={0.5}` line to the `adjustsFontSizeToFit` section of the Text example on both platforms ("Can limit how small the text becomes with minimumFontScale"). Before this change the line shrinks past the requested floor; after it stops at 50% of the original font size and is ellipsized.


Each screenshot below was captured on the same machine, on an iPhone 17 simulator and an Android API 35 emulator. "Before" is this branch's base commit with only the new RNTester example applied.


| | Before | After |
| - | - | - |
| iOS | <img width="465" height="446" alt="iPhone 17 2026-09-11 at 2 12 45 PM" src="https://github.com/user-attachments/assets/88a99587-de23-4751-b449-34f9ecfffedd" /> |  <img width="464" height="465" alt="iPhone 17 2026-09-11 at 1 54 28 PM" src="https://github.com/user-attachments/assets/40251f9f-73c9-4b87-89fc-b836bd5c7c6b" />  |
| Android |  <img width="453" height="505" alt="Android Emulator - Pixel_8_API_355554 2026-09-11 at 2 12 26 PM" src="https://github.com/user-attachments/assets/2e7a466a-149b-4f4f-a1be-275d7032ed27" /> |  <img width="454" height="517" alt="Android Emulator - Pixel_8_API_355554 2026-09-11 at 1 56 34 PM" src="https://github.com/user-attachments/assets/d25562d9-5096-43b6-ad30-90b8b5288c3a" />  |

