### PR TITLE
fix(normalize-color): require full-string match for rgb/hsl/hwb

### DIFF
--- a/packages/normalize-color/__tests__/normalizeColor-test.js
+++ b/packages/normalize-color/__tests__/normalizeColor-test.js
@@ -37,6 +37,13 @@ it('refuses non-spec compliant colors', () => {
   expect(normalizeColor('#00gg00')).toBe(null);
   expect(normalizeColor('rgb(1, 2, 3,)')).toBe(null);
   expect(normalizeColor('rgb(1, 2, 3')).toBe(null);
+  // Functional forms must match the whole string (hex already did).
+  expect(normalizeColor('xxrgb(1, 2, 3)yy')).toBe(null);
+  expect(normalizeColor('rgb(1, 2, 3)yy')).toBe(null);
+  expect(normalizeColor('xxrgb(1, 2, 3)')).toBe(null);
+  expect(normalizeColor('rgba(1,2,3,0.5)extra')).toBe(null);
+  expect(normalizeColor('prefixhsl(0, 0%, 0%)')).toBe(null);
+  expect(normalizeColor('hwb(0 0% 0%)suffix')).toBe(null);
 
   // Used to be accepted by normalizeColor
   expect(normalizeColor('abc')).toBe(null);

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -276,23 +276,25 @@ function getMatchers() {
       '|' +
       callWithSlashSeparator(NUMBER, NUMBER, NUMBER, NUMBER);
 
+    // Anchor functional forms the same way as hex* so leading/trailing
+    // junk (e.g. "xxrgb(1, 2, 3)yy") cannot partially match.
     cachedMatchers = {
-      rgb: new RegExp('rgb(' + rgbRegexPattern + ')'),
-      rgba: new RegExp('rgba(' + rgbRegexPattern + ')'),
-      hsl: new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
+      rgb: new RegExp('^rgb(' + rgbRegexPattern + ')$'),
+      rgba: new RegExp('^rgba(' + rgbRegexPattern + ')$'),
+      hsl: new RegExp('^hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE) + '$'),
       hsla: new RegExp(
-        'hsla(' +
+        '^hsla(' +
           commaSeparatedCall(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER) +
           '|' +
           callWithSlashSeparator(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER) +
-          ')',
+          ')$',
       ),
       hwb: new RegExp(
-        'hwb(' +
+        '^hwb(' +
           callModern(NUMBER, PERCENTAGE, PERCENTAGE) +
           '|' +
           callWithSlashSeparator(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER) +
-          ')',
+          ')$',
       ),
       hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
       hex4: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,


### PR DESCRIPTION
## Summary

`@react-native/normalize-colors` anchors hex color forms with `^`/`$`, but `rgb`/`rgba`/`hsl`/`hsla`/`hwb` matchers did not. Because `RegExp.prototype.exec` finds a substring match, strings like `xxrgb(1, 2, 3)yy` or `rgba(1,2,3,0.5)extra` were accepted and normalized.

That is inconsistent with hex handling (` #fff ` / `#fff ` already return `null`) and with treating the whole input as a single color token.

Fixes #58495

## Changelog

[GENERAL] [FIXED] - Reject functional color strings that only partially match rgb/hsl/hwb

## Test Plan

```sh
yarn test packages/normalize-color/__tests__/normalizeColor-test.js
```

All 14 tests pass. Added cases for leading/trailing junk around `rgb`/`rgba`/`hsl`/`hwb`.

Minimal repro (before fix):

```js
const normalizeColor = require('@react-native/normalize-colors');
normalizeColor('xxrgb(1, 2, 3)yy'); // was 0x010203ff, now null
```


Made with [Cursor](https://cursor.com)