### PR TITLE
test(rn-tester): playground repro for normalize-color partial match (#58495)

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -12,14 +12,59 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {processColor, StyleSheet, View} from 'react-native';
+
+// Reproducer for https://github.com/facebook/react-native/issues/58495
+// On main, functional color strings with surrounding junk still normalize
+// (same as a valid rgb()), so processColor returns a non-null value and the
+// swatch paints. Expected: junk inputs should be null / no fill.
+const CASES: $ReadOnlyArray<{label: string, color: string, expectNull: boolean}> =
+  [
+    {label: 'valid rgb', color: 'rgb(1, 2, 3)', expectNull: false},
+    {label: 'junk around rgb', color: 'xxrgb(1, 2, 3)yy', expectNull: true},
+    {label: 'rgb with suffix', color: 'rgb(1, 2, 3)yy', expectNull: true},
+    {
+      label: 'rgba with suffix',
+      color: 'rgba(1,2,3,0.5)extra',
+      expectNull: true,
+    },
+    {label: 'hex rejects spaces', color: ' #fff ', expectNull: true},
+  ];
 
 function Playground() {
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
+      <RNTesterText style={styles.title}>
+        Issue #58495 — normalize-color partial match
       </RNTesterText>
+      <RNTesterText>
+        Junk functional strings should process to null (like spaced hex). On
+        main they currently resolve and paint.
+      </RNTesterText>
+      {CASES.map(testCase => {
+        const processed = processColor(testCase.color);
+        const isNull = processed == null;
+        const unexpected = isNull !== testCase.expectNull;
+        return (
+          <View key={testCase.label} style={styles.row}>
+            <View
+              style={[
+                styles.swatch,
+                processed != null ? {backgroundColor: testCase.color} : null,
+              ]}
+            />
+            <View style={styles.meta}>
+              <RNTesterText>
+                {testCase.label}: {JSON.stringify(testCase.color)}
+              </RNTesterText>
+              <RNTesterText>
+                processColor → {processed == null ? 'null' : String(processed)}
+                {unexpected ? '  ← unexpected on main' : ''}
+              </RNTesterText>
+            </View>
+          </View>
+        );
+      })}
     </View>
   );
 }
@@ -27,6 +72,24 @@ function Playground() {
 const styles = StyleSheet.create({
   container: {
     padding: 10,
+    gap: 12,
+  },
+  title: {
+    fontWeight: '700',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  swatch: {
+    width: 36,
+    height: 36,
+    borderWidth: 1,
+    borderColor: '#999',
+  },
+  meta: {
+    flex: 1,
   },
 });
 


### PR DESCRIPTION
## Summary

RNTester Playground reproducer for https://github.com/facebook/react-native/issues/58495.

On `main`, `processColor('xxrgb(1, 2, 3)yy')` (and similar junk around `rgb`/`rgba`) returns a non-null processed color and paints a swatch, while hex with spaces correctly stays `null`.

Fix PR (separate): https://github.com/facebook/react-native/pull/58496

## Changelog

[INTERNAL] [CHANGED] - Add RNTester Playground repro for normalize-color partial matching

## Test Plan

1. Build and run RNTester.
2. Open the **Playground** example.
3. Confirm junk functional color rows show non-null `processColor` values and filled swatches (bug on main).


Made with [Cursor](https://cursor.com)