### PR TITLE
fix(ios): keep a zoomed ScrollView usable when its content size changes

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -495,10 +495,19 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   }
 
   _contentSize = contentSize;
-  _containerView.frame = CGRect{RCTCGPointFromPoint(data.contentBoundingRect.origin), contentSize};
+
+  // `_containerView` is the scroll view's zooming view (see `viewForZoomingInScrollView:`), so while the user is
+  // pinch-zoomed in it carries a scale transform. Setting `frame` on a view whose `transform` is not the identity is
+  // undefined behavior, so lay it out through `bounds` and `center` instead. The scroll view must get the *zoomed*
+  // size, which is what UIScrollView itself keeps `contentSize` at while zooming.
+  CGPoint contentOrigin = RCTCGPointFromPoint(data.contentBoundingRect.origin);
+  _containerView.bounds = CGRect{CGPointZero, contentSize};
+  CGSize zoomedContentSize = _containerView.frame.size;
+  _containerView.center =
+      CGPoint{contentOrigin.x + zoomedContentSize.width / 2, contentOrigin.y + zoomedContentSize.height / 2};
 
   [self _preserveContentOffsetIfNeededWithBlock:^{
-    self->_scrollView.contentSize = contentSize;
+    self->_scrollView.contentSize = zoomedContentSize;
   }];
 }
 


### PR DESCRIPTION
## Summary:

`RCTScrollViewComponentView`'s `_containerView` is also the view UIScrollView zooms (`viewForZoomingInScrollView:`), so while the user is pinch-zoomed in it carries a scale transform. On every content size change `updateState:oldState:` assigned `_containerView.frame`, which is undefined behavior for a view with a non-identity transform (in practice UIKit shrinks the view's bounds by the zoom scale), and it also handed the unzoomed size to the UIScrollView as `contentSize`.

Visible result: pinch-zoom into a ScrollView, then change its size (rotate the device, or change the layout around it). The scrolled position jumps, and the content can no longer be zoomed all the way out; it stays stuck in a corner until the user zooms out and resizes again.

This lays the container out through `bounds` and `center` instead, and gives the scroll view the zoomed content size, which is what UIScrollView itself keeps `contentSize` at while zooming. With `zoomScale == 1` the result is identical to before. In RTL, where the container carries a flip transform, `bounds`/`center` produce the same frame the old assignment did.

## Changelog:

[IOS] [FIXED] - Pinch-zoomed ScrollView no longer breaks (position jump, cannot zoom back out) when its size changes

## Test Plan:

1. Run the reproducer at https://github.com/mifi/reproducer-react-native (a zoomable ScrollView whose height changes on a button press, or rotate the device).
2. Zoom in, pan, resize. Before: position jumps and the content can no longer be zoomed out fully. After: zoom scale is kept and the content can be zoomed back out to fill the ScrollView.
3. Unzoomed ScrollViews (RNTester ScrollView examples, including RTL) behave as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFQpictoKhRhhEupaMy4xv)_